### PR TITLE
Optionally provide mint keypair for pumpfun

### DIFF
--- a/src/tools/launch_pumpfun_token.ts
+++ b/src/tools/launch_pumpfun_token.ts
@@ -152,6 +152,7 @@ async function signAndSendTransaction(
  * @param description - Description of the token
  * @param imageUrl - URL of the token image
  * @param options - Optional token options (twitter, telegram, website, initialLiquiditySOL, slippageBps, priorityFee)
+ * @param providedMintKeypair - Optional pre-generated mint keypair (useful for grinded pump addresses)
  * @returns - Signature of the transaction, mint address and metadata URI, if successful, else error
  */
 export async function launchPumpFunToken(
@@ -161,9 +162,10 @@ export async function launchPumpFunToken(
   description: string,
   imageUrl: string,
   options?: PumpFunTokenOptions,
+  providedMintKeypair?: Keypair,
 ): Promise<PumpfunLaunchResponse> {
   try {
-    const mintKeypair = Keypair.generate();
+    const mintKeypair = providedMintKeypair ?? Keypair.generate();
     const metadataResponse = await uploadMetadata(
       tokenName,
       tokenTicker,


### PR DESCRIPTION
Allow the mint keypair to be grinded so that it ends with `pump`

# Pull Request Description

## Changes Made
This PR adds the following changes:
<!-- List the key changes made in this PR -->
- Added optional `providedMintKeypair` parameter to `launchPumpFunToken`
  
## Implementation Details
<!-- Provide technical details about the implementation -->
- Parameter is optional and shouldn't cause any issue with existing usage

## Checklist
- [ ] I have tested these changes locally
- [ ] I have updated the documentation
- [ ] I have added a transaction link
- [ ] I have added the prompt used to test it 
