### PR TITLE
Add support for querying other wallet balance

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -6,6 +6,7 @@ import {
   deploy_collection,
   deploy_token,
   get_balance,
+  get_balance_other,
   getTPS,
   resolveSolDomain,
   getPrimaryDomain,
@@ -60,12 +61,12 @@ export class SolanaAgentKit {
   public connection: Connection;
   public wallet: Keypair;
   public wallet_address: PublicKey;
-  public openai_api_key: string;
+  public openai_api_key: string | null;
 
   constructor(
     private_key: string,
     rpc_url = "https://api.mainnet-beta.solana.com",
-    openai_api_key: string,
+    openai_api_key: string | null = null,
   ) {
     this.connection = new Connection(rpc_url);
     this.wallet = Keypair.fromSecretKey(bs58.decode(private_key));
@@ -96,6 +97,13 @@ export class SolanaAgentKit {
 
   async getBalance(token_address?: PublicKey): Promise<number> {
     return get_balance(this, token_address);
+  }
+
+  async getBalanceOther(
+    walletAddress: PublicKey,
+    tokenAddress?: PublicKey,
+  ): Promise<number> {
+    return get_balance_other(this, walletAddress, tokenAddress);
   }
 
   async mintNFT(

--- a/src/langchain/index.ts
+++ b/src/langchain/index.ts
@@ -32,8 +32,51 @@ export class SolanaBalanceTool extends Tool {
 
       return JSON.stringify({
         status: "success",
-        balance: balance,
+        balance,
         token: input || "SOL",
+      });
+    } catch (error: any) {
+      return JSON.stringify({
+        status: "error",
+        message: error.message,
+        code: error.code || "UNKNOWN_ERROR",
+      });
+    }
+  }
+}
+
+export class SolanaBalanceOtherTool extends Tool {
+  name = "solana_balance_other";
+  description = `Get the balance of a Solana wallet or token account different from the agent's wallet.
+
+  If no tokenAddress is provided, the SOL balance of the wallet will be returned.
+
+  Inputs:
+  walletAddress: string, eg "GDEkQF7UMr7RLv1KQKMtm8E2w3iafxJLtyXu3HVQZnME" (required)
+  tokenAddress: string, eg "SENDdRQtYMWaQrBroBrJ2Q53fgVuq95CV9UPGEvpCxa" (optional)`;
+
+  constructor(private solanaKit: SolanaAgentKit) {
+    super();
+  }
+
+  protected async _call(input: string): Promise<string> {
+    try {
+      const { walletAddress, tokenAddress } = JSON.parse(input);
+
+      const tokenPubKey = tokenAddress
+        ? new PublicKey(tokenAddress)
+        : undefined;
+
+      const balance = await this.solanaKit.getBalanceOther(
+        new PublicKey(walletAddress),
+        tokenPubKey,
+      );
+
+      return JSON.stringify({
+        status: "success",
+        balance,
+        wallet: walletAddress,
+        token: tokenAddress || "SOL",
       });
     } catch (error: any) {
       return JSON.stringify({
@@ -555,7 +598,7 @@ export class SolanaLendAssetTool extends Tool {
         status: "success",
         message: "Asset lent successfully",
         transaction: tx,
-        amount: amount,
+        amount,
       });
     } catch (error: any) {
       return JSON.stringify({
@@ -669,7 +712,7 @@ export class SolanaTokenDataTool extends Tool {
 
       return JSON.stringify({
         status: "success",
-        tokenData: tokenData,
+        tokenData,
       });
     } catch (error: any) {
       return JSON.stringify({
@@ -698,7 +741,7 @@ export class SolanaTokenDataByTickerTool extends Tool {
       const tokenData = await this.solanaKit.getTokenDataByTicker(ticker);
       return JSON.stringify({
         status: "success",
-        tokenData: tokenData,
+        tokenData,
       });
     } catch (error: any) {
       return JSON.stringify({
@@ -1005,7 +1048,7 @@ export class SolanaPythFetchPrice extends Tool {
       const response: PythFetchPriceResponse = {
         status: "success",
         priceFeedID: input,
-        price: price,
+        price,
       };
       return JSON.stringify(response);
     } catch (error: any) {
@@ -1079,7 +1122,7 @@ export class SolanaGetOwnedDomains extends Tool {
       return JSON.stringify({
         status: "success",
         message: "Owned domains fetched successfully",
-        domains: domains,
+        domains,
       });
     } catch (error: any) {
       return JSON.stringify({
@@ -1109,7 +1152,7 @@ export class SolanaGetOwnedTldDomains extends Tool {
       return JSON.stringify({
         status: "success",
         message: "TLD domains fetched successfully",
-        domains: domains,
+        domains,
       });
     } catch (error: any) {
       return JSON.stringify({
@@ -1136,7 +1179,7 @@ export class SolanaGetAllTlds extends Tool {
       return JSON.stringify({
         status: "success",
         message: "TLDs fetched successfully",
-        tlds: tlds,
+        tlds,
       });
     } catch (error: any) {
       return JSON.stringify({
@@ -1232,6 +1275,7 @@ export class SolanaCreateGibworkTask extends Tool {
 export function createSolanaTools(solanaKit: SolanaAgentKit) {
   return [
     new SolanaBalanceTool(solanaKit),
+    new SolanaBalanceOtherTool(solanaKit),
     new SolanaTransferTool(solanaKit),
     new SolanaDeployTokenTool(solanaKit),
     new SolanaDeployCollectionTool(solanaKit),

--- a/src/tools/get_balance_other.ts
+++ b/src/tools/get_balance_other.ts
@@ -1,0 +1,50 @@
+import {
+  LAMPORTS_PER_SOL,
+  ParsedAccountData,
+  PublicKey,
+} from "@solana/web3.js";
+import { SolanaAgentKit } from "../index";
+
+/**
+ * Get the balance of SOL or an SPL token for the specified wallet address (other than the agent's wallet)
+ * @param agent - SolanaAgentKit instance
+ * @param wallet_address - Public key of the wallet to check balance for
+ * @param token_address - Optional SPL token mint address. If not provided, returns SOL balance
+ * @returns Promise resolving to the balance as a number (in UI units) or 0 if account doesn't exist
+ */
+export async function get_balance_other(
+  agent: SolanaAgentKit,
+  wallet_address: PublicKey,
+  token_address?: PublicKey,
+): Promise<number> {
+  try {
+    if (!token_address) {
+      return (
+        (await agent.connection.getBalance(wallet_address)) / LAMPORTS_PER_SOL
+      );
+    }
+
+    const tokenAccounts = await agent.connection.getTokenAccountsByOwner(
+      wallet_address,
+      { mint: token_address },
+    );
+
+    if (tokenAccounts.value.length === 0) {
+      console.warn(
+        `No token accounts found for wallet ${wallet_address.toString()} and token ${token_address.toString()}`,
+      );
+      return 0;
+    }
+
+    const tokenAccount = await agent.connection.getParsedAccountInfo(
+      tokenAccounts.value[0].pubkey,
+    );
+    const tokenData = tokenAccount.value?.data as ParsedAccountData;
+
+    return tokenData.parsed?.info?.tokenAmount?.uiAmount || 0;
+  } catch (error) {
+    throw new Error(
+      `Error fetching on-chain balance for ${token_address?.toString()}: ${error}`,
+    );
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,6 +2,7 @@ export * from "./request_faucet_funds";
 export * from "./deploy_token";
 export * from "./deploy_collection";
 export * from "./get_balance";
+export * from "./get_balance_other";
 export * from "./mint_nft";
 export * from "./transfer";
 export * from "./trade";


### PR DESCRIPTION
# Pull Request Description

## Related Issue
Implements #60 

## Changes Made
This PR adds the following changes:
- Added `getBalanceOther` method in `SolanaAgentKit` class
- Implemented `get_balance_other` tool
  
## Implementation Details
- This tool enables the agent to query SOL and SPL token balances of other wallets

## Prompt Used
```
Prompt: What is the SOL balance of HHELE9Q7LsARJACq7cMCkoPStjZUomn4JphdHUMyK3op?
-------------------
{"status":"success","balance":49.893951194,"wallet":"HHELE9Q7LsARJACq7cMCkoPStjZUomn4JphdHUMyK3op","token":"SOL"}
-------------------
The wallet balance of HHELE9Q7LsARJACq7cMCkoPStjZUomn4JphdHUMyK3op is approximately 49.89 SOL.
-------------------

Prompt: Now get the balance of sSo14endRuUbvQaJS3dq36Q829a3A6BEfoeeRGJywEh token for that same wallet

-------------------
{"status":"success","balance":60.338328396,"wallet":"HHELE9Q7LsARJACq7cMCkoPStjZUomn4JphdHUMyK3op","token":"sSo14endRuUbvQaJS3dq36Q829a3A6BEfoeeRGJywEh"}
-------------------
The balance of the token sSo14endRuUbvQaJS3dq36Q829a3A6BEfoeeRGJywEh in the wallet HHELE9Q7LsARJACq7cMCkoPStjZUomn4JphdHUMyK3op is approximately 60.34 tokens.
-------------------
```

## Checklist
- [x] I have tested these changes locally
- [x] I have updated the documentation
~~- [ ] I have added a transaction link~~
- [x] I have added the prompt used to test it 
