### PR TITLE
feat(trade): use DFlow declarative swaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Anyone - whether an SF-based AI researcher or a crypto-native builder - can brin
   - Royalty configuration
 
 - **DeFi Integration**
-  - Jupiter Exchange swaps
+  - DFlow swaps
   - Launch on Pump via PumpPortal
   - Raydium pool creation (CPMM, CLMM, AMMv4)
   - Orca Whirlpool integration

--- a/examples/agent-kit-langgraph/src/tools/swap.ts
+++ b/examples/agent-kit-langgraph/src/tools/swap.ts
@@ -26,7 +26,7 @@ export const swapTool = tool(
   {
     name: "swap",
     description:
-      "call to swap/trade tokens from one token to the other using Jupiter exchange",
+      "call to swap/trade tokens from one token to the other using DFlow",
     schema: z.object({
       outputMint: z
         .string()

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"@bonfida/spl-name-service": "^3.0.7",
 		"@cks-systems/manifest-sdk": "0.1.59",
 		"@coral-xyz/anchor": "0.29",
+		"@dflow-protocol/swap-api-utils": "0.1.2",
 		"@langchain/core": "^0.3.26",
 		"@langchain/groq": "^0.1.2",
 		"@langchain/langgraph": "^0.2.36",

--- a/src/actions/trade.ts
+++ b/src/actions/trade.ts
@@ -3,6 +3,7 @@ import { Action } from "../types/action";
 import { SolanaAgentKit } from "../agent";
 import { z } from "zod";
 import { trade } from "../tools";
+import { normalizeScaled } from "../utils/format";
 
 const tradeAction: Action = {
   name: "TRADE",
@@ -13,44 +14,44 @@ const tradeAction: Action = {
     "convert tokens",
     "swap sol",
   ],
-  description: `This tool can be used to swap tokens to another token (It uses Jupiter Exchange).`,
+  description: `This tool can be used to swap tokens to another token (It uses DFlow).`,
   examples: [
     [
       {
         input: {
           outputMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-          inputAmount: 1,
+          inputAmount: 0.25,
         },
         output: {
           status: "success",
           message: "Trade executed successfully",
-          transaction:
-            "5UfgJ5vVZxUxefDGqzqkVLHzHxVTyYH9StYyHKgvHYmXJgqJKxEqy9k4Rz9LpXrHF9kUZB7",
-          inputAmount: 1,
+          inputAmount: "0.25",
           inputToken: "SOL",
+          outputAmount: "53.613066",
           outputToken: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          orderAddress: "45NbncPuuEwdijcbeizUVp215sG636LYctPc64a492Ur",
         },
-        explanation: "Swap 1 SOL for USDC",
+        explanation: "Swap 0.25 SOL for USDC",
       },
     ],
     [
       {
         input: {
           outputMint: "So11111111111111111111111111111111111111112",
-          inputAmount: 100,
+          inputAmount: 50,
           inputMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
           slippageBps: 100,
         },
         output: {
           status: "success",
           message: "Trade executed successfully",
-          transaction:
-            "4VfgJ5vVZxUxefDGqzqkVLHzHxVTyYH9StYyHKgvHYmXJgqJKxEqy9k4Rz9LpXrHF9kUZB7",
-          inputAmount: 100,
+          inputAmount: "50",
           inputToken: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          outputAmount: "0.233879797",
           outputToken: "So11111111111111111111111111111111111111112",
+          orderAddress: "9wT8YPyCJFS4BQmVyw2AiE8EhrZtLUu8VKdZHbVm97tX",
         },
-        explanation: "Swap 100 USDC for SOL with 1% slippage",
+        explanation: "Swap 50 USDC for SOL with 1% slippage",
       },
     ],
   ],
@@ -61,7 +62,7 @@ const tradeAction: Action = {
     slippageBps: z.number().min(0).max(10000).optional(),
   }),
   handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
-    const tx = await trade(
+    const result = await trade(
       agent,
       new PublicKey(input.outputMint),
       input.inputAmount,
@@ -74,10 +75,11 @@ const tradeAction: Action = {
     return {
       status: "success",
       message: "Trade executed successfully",
-      transaction: tx,
-      inputAmount: input.inputAmount,
+      inputAmount: normalizeScaled(result.qtyIn, result.inputDecimals),
       inputToken: input.inputMint || "SOL",
+      outputAmount: normalizeScaled(result.qtyOut, result.outputDecimals),
       outputToken: input.outputMint,
+      orderAddress: result.orderAddress,
     };
   },
 };

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -32,6 +32,7 @@ import {
   openPerpTradeShort,
   openPerpTradeLong,
   transfer,
+  TradeResult,
   getTokenDataByAddress,
   getTokenDataByTicker,
   stakeWithJup,
@@ -123,6 +124,7 @@ export class SolanaAgentKit {
   ) {
     this.connection = new Connection(
       rpc_url || "https://api.mainnet-beta.solana.com",
+      "confirmed",
     );
     this.wallet = Keypair.fromSecretKey(bs58.decode(private_key));
     this.wallet_address = this.wallet.publicKey;
@@ -200,7 +202,7 @@ export class SolanaAgentKit {
     inputAmount: number,
     inputMint?: PublicKey,
     slippageBps: number = DEFAULT_OPTIONS.SLIPPAGE_BPS,
-  ): Promise<string> {
+  ): Promise<TradeResult> {
     return trade(this, outputMint, inputAmount, inputMint, slippageBps);
   }
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -28,8 +28,8 @@ export const DEFAULT_OPTIONS = {
 } as const;
 
 /**
- * Jupiter API URL
+ * DFlow Swap API URL
  */
-export const JUP_API = "https://quote-api.jup.ag/v6";
-export const JUP_REFERRAL_ADDRESS =
+export const DFLOW_SWAP_API = "https://quote-api.dflow.net";
+export const REFERRAL_PROGRAM_ADDRESS =
   "REFER4ZgmyYx9c6He5XfaTMiGfdLwRnkV4RPp9t9iF3";

--- a/src/tools/trade.ts
+++ b/src/tools/trade.ts
@@ -1,20 +1,41 @@
-import { VersionedTransaction, PublicKey } from "@solana/web3.js";
+import {
+  Intent,
+  monitorOrder,
+  ORDER_STATUS,
+  SubmitIntentResponse,
+} from "@dflow-protocol/swap-api-utils";
+import { Connection, PublicKey, Transaction } from "@solana/web3.js";
 import { SolanaAgentKit } from "../index";
 import {
   TOKENS,
   DEFAULT_OPTIONS,
-  JUP_API,
-  JUP_REFERRAL_ADDRESS,
+  DFLOW_SWAP_API,
+  REFERRAL_PROGRAM_ADDRESS,
 } from "../constants";
-import { getMint } from "@solana/spl-token";
+import { unpackMint } from "@solana/spl-token";
+import { assertUnreachable } from "../utils/coding";
+
+export type TradeResult = {
+  /** Address of the declarative swap order */
+  orderAddress: string;
+  /** Input quantity consumed */
+  qtyIn: bigint;
+  /** Output quantity */
+  qtyOut: bigint;
+  /** Number of decimals for the input mint */
+  inputDecimals: number;
+  /** Number of decimals for the output mint */
+  outputDecimals: number;
+};
+
 /**
- * Swap tokens using Jupiter Exchange
+ * Swap tokens using DFlow
  * @param agent SolanaAgentKit instance
  * @param outputMint Target token mint address
  * @param inputAmount Amount to swap (in token decimals)
  * @param inputMint Source token mint address (defaults to USDC)
  * @param slippageBps Slippage tolerance in basis points (default: 300 = 3%)
- * @returns Transaction signature
+ * @returns Trade result object containing details about the swap
  */
 
 export async function trade(
@@ -23,71 +44,189 @@ export async function trade(
   inputAmount: number,
   inputMint: PublicKey = TOKENS.USDC,
   slippageBps: number = DEFAULT_OPTIONS.SLIPPAGE_BPS,
-): Promise<string> {
+): Promise<TradeResult> {
   try {
-    // Check if input token is native SOL
-    const isNativeSol = inputMint.equals(TOKENS.SOL);
+    const rpcEndpoint = agent.connection.rpcEndpoint;
+    if (rpcEndpoint.includes("api.mainnet-beta.solana.com")) {
+      throw new Error(
+        `Cannot swap using RPC endpoint ${rpcEndpoint}. Please use a paid RPC endpoint.`,
+      );
+    }
 
-    // For native SOL, we use LAMPORTS_PER_SOL, otherwise fetch mint info
-    const inputDecimals = isNativeSol
-      ? 9 // SOL always has 9 decimals
-      : (await getMint(agent.connection, inputMint)).decimals;
+    const [inputDecimals, outputDecimals] = await getDecimals(
+      agent.connection,
+      inputMint,
+      outputMint,
+    );
 
     // Calculate the correct amount based on actual decimals
     const scaledAmount = inputAmount * Math.pow(10, inputDecimals);
 
-    const quoteResponse = await (
-      await fetch(
-        `${JUP_API}/quote?` +
-          `inputMint=${isNativeSol ? TOKENS.SOL.toString() : inputMint.toString()}` +
-          `&outputMint=${outputMint.toString()}` +
-          `&amount=${scaledAmount}` +
-          `&slippageBps=${slippageBps}` +
-          `&onlyDirectRoutes=true` +
-          `&maxAccounts=20` +
-          `${agent.config.JUPITER_FEE_BPS ? `&platformFeeBps=${agent.config.JUPITER_FEE_BPS}` : ""}`,
-      )
-    ).json();
-
-    // Get serialized transaction
     let feeAccount;
     if (agent.config.JUPITER_REFERRAL_ACCOUNT) {
       [feeAccount] = PublicKey.findProgramAddressSync(
         [
           Buffer.from("referral_ata"),
           new PublicKey(agent.config.JUPITER_REFERRAL_ACCOUNT).toBuffer(),
-          TOKENS.SOL.toBuffer(),
+          outputMint.toBuffer(),
         ],
-        new PublicKey(JUP_REFERRAL_ADDRESS),
+        new PublicKey(REFERRAL_PROGRAM_ADDRESS),
       );
     }
 
-    const { swapTransaction } = await (
-      await fetch("https://quote-api.jup.ag/v6/swap", {
+    const intentResponse = await fetch(
+      `${DFLOW_SWAP_API}/intent?` +
+        `userPublicKey=${agent.wallet_address.toString()}` +
+        `&inputMint=${inputMint.toString()}` +
+        `&outputMint=${outputMint.toString()}` +
+        `&amount=${scaledAmount}` +
+        `&slippageBps=${slippageBps}` +
+        `${agent.config.JUPITER_FEE_BPS ? `&platformFeeBps=${agent.config.JUPITER_FEE_BPS}` : ""}` +
+        `${feeAccount ? `&feeAccount=${feeAccount}` : ""}` +
+        `${agent.config.JUPITER_REFERRAL_ACCOUNT ? `&referralAccount=${agent.config.JUPITER_REFERRAL_ACCOUNT}` : ""}`,
+    );
+    if (!intentResponse.ok) {
+      const msg = await parseApiError(intentResponse);
+      throw new Error("Failed to fetch quote" + (msg ? `: ${msg}` : ""));
+    }
+    const intentData: Intent = await intentResponse.json();
+    if (!intentData.openTransaction) {
+      throw new Error("Cannot execute quote");
+    }
+
+    const openTransaction = Transaction.from(
+      Buffer.from(intentData.openTransaction, "base64"),
+    );
+    openTransaction.sign(agent.wallet);
+
+    const submitIntentResponse = await fetch(
+      `${DFLOW_SWAP_API}/submit-intent`,
+      {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          quoteResponse,
-          userPublicKey: agent.wallet_address.toString(),
-          wrapAndUnwrapSol: true,
-          dynamicComputeUnitLimit: true,
-          prioritizationFeeLamports: "auto",
-          feeAccount: feeAccount ? feeAccount.toString() : null,
+          quoteResponse: intentData,
+          signedOpenTransaction: openTransaction.serialize().toString("base64"),
         }),
-      })
-    ).json();
-    // Deserialize transaction
-    const swapTransactionBuf = Buffer.from(swapTransaction, "base64");
+      },
+    );
+    if (!submitIntentResponse.ok) {
+      const msg = await parseApiError(submitIntentResponse);
+      throw new Error("Failed to submit intent" + (msg ? `: ${msg}` : ""));
+    }
+    const submitIntentData: SubmitIntentResponse =
+      await submitIntentResponse.json();
 
-    const transaction = VersionedTransaction.deserialize(swapTransactionBuf);
-    // Sign and send transaction
-    transaction.sign([agent.wallet]);
-    const signature = await agent.connection.sendTransaction(transaction);
+    const result = await monitorOrder({
+      connection: agent.connection,
+      intent: intentData,
+      signedOpenTransaction: openTransaction,
+      submitIntentResponse: submitIntentData,
+    });
 
-    return signature;
+    switch (result.status) {
+      case ORDER_STATUS.OPEN_EXPIRED: {
+        throw new Error("Transaction expired");
+      }
+
+      case ORDER_STATUS.OPEN_FAILED: {
+        throw new Error("Transaction failed");
+      }
+
+      case ORDER_STATUS.CLOSED: {
+        if (result.fills.length > 0) {
+          const qtyIn = result.fills.reduce((acc, x) => acc + x.qtyIn, 0n);
+          const qtyOut = result.fills.reduce((acc, x) => acc + x.qtyOut, 0n);
+          return {
+            orderAddress: submitIntentData.orderAddress,
+            qtyIn,
+            qtyOut,
+            inputDecimals,
+            outputDecimals,
+          };
+        } else {
+          throw new Error("Order not filled");
+        }
+      }
+
+      case ORDER_STATUS.PENDING_CLOSE: {
+        if (result.fills.length > 0) {
+          const qtyIn = result.fills.reduce((acc, x) => acc + x.qtyIn, 0n);
+          const qtyOut = result.fills.reduce((acc, x) => acc + x.qtyOut, 0n);
+          return {
+            orderAddress: submitIntentData.orderAddress,
+            qtyIn,
+            qtyOut,
+            inputDecimals,
+            outputDecimals,
+          };
+        } else {
+          throw new Error("Order not filled");
+        }
+      }
+
+      default: {
+        assertUnreachable(result);
+      }
+    }
   } catch (error: any) {
     throw new Error(`Swap failed: ${error.message}`);
+  }
+}
+
+async function getDecimals(
+  connection: Connection,
+  inputMint: PublicKey,
+  outputMint: PublicKey,
+): Promise<[number, number]> {
+  let inputMintAccount, outputMintAccount;
+  try {
+    [inputMintAccount, outputMintAccount] =
+      await connection.getMultipleAccountsInfo([inputMint, outputMint]);
+  } catch {
+    throw new Error("Failed to fetch mint accounts");
+  }
+
+  if (!inputMintAccount) {
+    throw new Error("Invalid input mint");
+  }
+  if (!outputMintAccount) {
+    throw new Error("Invalid output mint");
+  }
+
+  let inputDecimals;
+  try {
+    inputDecimals = unpackMint(inputMint, inputMintAccount).decimals;
+  } catch {
+    throw new Error("Invalid input mint");
+  }
+
+  let outputDecimals;
+  try {
+    outputDecimals = unpackMint(outputMint, outputMintAccount).decimals;
+  } catch {
+    throw new Error("Invalid output mint");
+  }
+
+  return [inputDecimals, outputDecimals];
+}
+
+async function parseApiError(response: Response): Promise<string | null> {
+  try {
+    const body = await response.text();
+    try {
+      const parsed = JSON.parse(body);
+      if (parsed.msg) {
+        return parsed.msg;
+      } else {
+        return body;
+      }
+    } catch {
+      return body;
+    }
+  } catch {
+    return null;
   }
 }

--- a/src/utils/coding.ts
+++ b/src/utils/coding.ts
@@ -1,0 +1,3 @@
+export function assertUnreachable(x: never): never {
+  throw new Error(`Didn't expect to get here: ${x}`);
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,14 @@
+export function normalizeScaled(scaled: bigint, decimals: number): string {
+  const scaledStr = scaled.toString();
+  if (scaledStr.length <= decimals) {
+    return `0.${scaledStr.padStart(decimals, "0").replace(/0+$/, "")}`.replace(
+      /\.$/,
+      "",
+    );
+  }
+  const integerPart = scaledStr.slice(0, scaledStr.length - decimals);
+  let decimalPart = scaledStr.slice(-decimals);
+  // Remove trailing zeros
+  decimalPart = decimalPart.replace(/0+$/, "");
+  return `${integerPart || "0"}.${decimalPart}`.replace(/\.$/, "");
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2021",
     "module": "commonjs",
-    "lib": ["es2020", "dom"],
+    "lib": ["es2021", "dom"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
# Pull Request Description
This replaces the trade tool's buggy implementation that used jup.ag with a significantly more reliable implementation that uses DFlow declarative swaps.

This also changes the connection's default commitment to `confirmed`, which reduces the amount of time users spend waiting for transactions to be confirmed. Transaction confirmation takes about 12 seconds less when the connection uses `confirmed` commitment compared to using a connection with unspecified commitment (which defaults to `finalized`).

## Changes Made
In addition to reducing realized slippage, reducing time to inclusion, and improving pricing, this fixes a few major issues that were present in the old implementation and adds some nice-to-haves:
1. It now actually waits for the transaction to succeed before reporting that the transaction has succeeded. With the old implementation, it would immediately report that the transaction succeeded without actually checking for transaction success, which would result in the agent frequently reporting that a transaction had succeeded even though it failed or was never included in a block.
2. It now reports the quantities that were traded (both input and output). Previously it reported only the input quantity.
3. It now supports multi-leg routes. Previously it only used direct routes, which resulted in higher price impact trades and limited support to token pairs that have a direct route between them.
  
## Implementation Details
- Reimplemented the trade tool to use DFlow declarative swaps
- Bumped `target` to `es2021` to make use of some Promise APIs
- The trade action disallows using api.mainnet-beta.solana.com as the RPC endpoint, as it is heavily rate limited and provides a poor UX for trading. If the trade action is invoked by an agent running with this RPC endpoint, the agent tells the user to use a paid RPC endpoint instead.

## Transaction executed by agent 
Example transactions:
1. [0.3 SOL -> USDC](https://solscan.io/account/BwcXj2kSij1kh8ALqBhJAwqNUJZTCDjNFPHVchPJ3iKc)
2. [64.932518 USDC -> SOL](https://solscan.io/account/9NgqHfHB1ixaZx8ThixwHsKmemrhywmKPrpe6XKPuYFQ)

## Prompt Used
```
Prompt: swap 0.3 SOL to USDC

-------------------
{"status":"success","message":"Trade executed successfully","inputAmount":"0.3","inputToken":"So11111111111111111111111111111111111111112","outputAmount":"64.932518","outputToken":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","orderAddress":"BwcXj2kSij1kh8ALqBhJAwqNUJZTCDjNFPHVchPJ3iKc"}
-------------------
The swap of 0.3 SOL to USDC has been executed successfully. You received approximately 64.932518 USDC.

If you need any further assistance, just let me know!
-------------------

Prompt: swap 64.932518 USDC to SOL

-------------------
{"status":"success","message":"Trade executed successfully","inputAmount":"64.932518","inputToken":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","outputAmount":"0.2999806","outputToken":"So11111111111111111111111111111111111111112","orderAddress":"9NgqHfHB1ixaZx8ThixwHsKmemrhywmKPrpe6XKPuYFQ"}
-------------------
The swap was executed successfully! You have exchanged **64.932518 USDC** for approximately **0.2999806 SOL**. 

If you need further assistance, feel free to ask!
-------------------
```

## Additional Notes

https://github.com/user-attachments/assets/a90f259d-6985-4625-b046-a17e165ceb3b



## Checklist
- [x] I have tested these changes locally
- [ ] I have updated the documentation
- [x] I have added a transaction link
- [x] I have added the prompt used to test it 
