### PR TITLE
fix: add missing dependencies for agent-kit-langgraph

### DIFF
--- a/examples/agent-kit-langgraph/package.json
+++ b/examples/agent-kit-langgraph/package.json
@@ -12,6 +12,8 @@
     "@langchain/community": "^0.3.20",
     "@langchain/core": "^0.3.26",
     "@langchain/langgraph": "^0.2.36",
+    "@langchain/openai": "^0.4.4",
+    "@solana/web3.js": "^1.98.0",
     "dotenv": "^16.4.7",
     "solana-agent-kit": "^1.3.0",
     "zod": "^3.24.1"


### PR DESCRIPTION
# Description

Add missing dependencies to examples/agent-kit-langgraph/package.json:
- @langchain/openai: Required for LangChain integration
- @solana/web3.js: Required for Solana blockchain interaction

## Changes Made

- Added `@langchain/openai` v0.4.4
- Added `@solana/web3.js` v1.98.0

## Testing

- Confirmed that the application starts successfully with `pnpm dev src/index.ts`
- Verified that both packages are properly resolved

## Additional Notes

This PR fixes the following errors that were occurring:
- ERR_MODULE_NOT_FOUND: Cannot find package '@langchain/openai'
- ERR_MODULE_NOT_FOUND: Cannot find package '@solana/web3.js'

## Checklist

- [x] I have read the CONTRIBUTING.md document
- [x] My code follows the code style of this project
- [x] My commits follow conventional commit format