### PR TITLE
Fix Token Symbol Capitalization and Correct Spelling for Polygon Blockchain

### DIFF
--- a/src/actions/mayan/swap.ts
+++ b/src/actions/mayan/swap.ts
@@ -14,7 +14,7 @@ const swapAction: Action = {
           amount: "0.02",
           fromChain: "solana",
           fromToken: "SOL",
-          toChain: "polygan",
+          toChain: "polygon",
           toToken: "pol",
           dstAddr: "0x0cae42c0ce52e6e64c1e384ff98e686c6ee225f0",
         },
@@ -30,9 +30,9 @@ const swapAction: Action = {
         input: {
           amount: "0.02",
           fromChain: "solana",
-          fromToken: "sol",
+          fromToken: "SOL",
           toChain: "solana",
-          toToken: "hnt",
+          toToken: "HNT",
           dstAddr: "4ZgCP2idpqrxuQNfsjakJEm9nFyZ2xnT4CrDPKPULJPk",
         },
         output: {
@@ -49,7 +49,7 @@ const swapAction: Action = {
         input: {
           amount: "0.02",
           fromChain: "solana",
-          fromToken: "sol",
+          fromToken: "SOL",
           toChain: "solana",
           toToken: "HNT",
           dstAddr: "4ZgCP2idpqrxuQNfsjakJEm9nFyZ2xnT4CrDPKPULJPk",


### PR DESCRIPTION
File: src/actions/mayan/swap.ts
Change: Capitalization of Token Symbols

Old Word: sol, hnt
New Word: SOL, HNT
Reason for Change:
The token symbols SOL (for Solana) and HNT (for Helium) are commonly represented in uppercase. This ensures consistency and aligns with standard practices in the crypto ecosystem, where token symbols are typically uppercase. This also prevents any ambiguity, ensuring users can clearly identify tokens with the correct symbols.

Change: Chain Name for Polygon

Old Word: polygan
New Word: polygon
Reason for Change:
The correct spelling of the Polygon blockchain is "polygon" (with an "o" in the middle). This change fixes a typo, ensuring that the name of the blockchain is correctly represented in the code.