### PR TITLE
Downgrade Node.js to Stable LTS for Compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "23"
+          node-version: "20"
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/check-langchain-tools.yml
+++ b/.github/workflows/check-langchain-tools.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "23"
+          node-version: "20"
           cache: "pnpm"
 
       - name: Install dependencies


### PR DESCRIPTION
 Updated Node.js Version in Workflow Configuration

Old: node-version: "23"
New: node-version: "20"
Reason: Ensures compatibility with the latest LTS (Long-Term Support) version of Node.js. Using an unreleased or unstable version could cause unexpected issues.
