### PR TITLE
Fix: Add RPC URL to KeypairWallet parameters

### DIFF
--- a/packages/core/src/utils/keypairWallet.ts
+++ b/packages/core/src/utils/keypairWallet.ts
@@ -1,11 +1,11 @@
-import { TransactionOrVersionedTransaction } from "../types";
+import type { TransactionOrVersionedTransaction } from "../types";
 import type { BaseWallet } from "../types/wallet";
 import {
-  ConfirmOptions,
+  type ConfirmOptions,
   Connection,
-  Keypair,
-  PublicKey,
-  Transaction,
+  type Keypair,
+  type PublicKey,
+  type Transaction,
   VersionedTransaction,
 } from "@solana/web3.js";
 
@@ -27,14 +27,16 @@ export const isVersionedTransaction = (
 export class KeypairWallet implements BaseWallet {
   publicKey: PublicKey;
   private payer: Keypair;
+  rpcUrl: string;
 
   /**
    * Constructs a KeypairWallet with a given Keypair
    * @param keypair - The Keypair to use for signing transactions
    */
-  constructor(keypair: Keypair) {
+  constructor(keypair: Keypair, rpcUrl: string) {
     this.publicKey = keypair.publicKey;
     this.payer = keypair;
+    this.rpcUrl = rpcUrl;
   }
 
   defaultOptions: ConfirmOptions = {
@@ -79,11 +81,13 @@ export class KeypairWallet implements BaseWallet {
       | VersionedTransaction
       | TransactionOrVersionedTransaction,
   >(transaction: T): Promise<string> {
-    const connection = new Connection(process.env.RPC_URL as string);
+    const connection = new Connection(this.rpcUrl);
 
-    if (transaction instanceof VersionedTransaction)
+    if (transaction instanceof VersionedTransaction) {
       transaction.sign([this.payer]);
-    else transaction.partialSign(this.payer);
+    } else {
+      transaction.partialSign(this.payer);
+    }
 
     return await connection.sendRawTransaction(transaction.serialize());
   }


### PR DESCRIPTION
# Pull Request Description

This PR adds RPC URL as a parameter to be passed to the KeypairWallet class. Reason being that the sendTransaction function requires an RPC URL in order to send transactions.

## Changes Made
This PR adds the following changes:
<!-- List the key changes made in this PR -->
- Adds a parameter for an RPC URL in the KeypairWallet class

## Checklist
- [x] I have tested these changes locally
- [x] I have updated the documentation
- [ ] I have added a transaction link
- [ ] I have added the prompt used to test it 
