### PR TITLE
Fix: stop examples from installing dependencies in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install -r --no-frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - name: Run lint and fix
         run: pnpm run lint:fix

--- a/.github/workflows/check-langchain-tools.yml
+++ b/.github/workflows/check-langchain-tools.yml
@@ -1,9 +1,9 @@
 name: Check LangChain Tool Names
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   check-langchain-tool-names:
@@ -24,6 +24,6 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install -r --no-frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - run: pnpm run check-tool-names:langchain


### PR DESCRIPTION
# Pull Request Description
This PR fixes the CI/CD issue with examples having their dependencies installed. At the moment the para example depends on packages that haven't been released yet so if there's an attempt to install the dependencies it will fail.

## Changes Made
This PR adds the following changes:
<!-- List the key changes made in this PR -->
- Removed the `-r` flag from the pnpm install commands in the workflow files

## Checklist
- [x] I have tested these changes locally
- [ ] I have updated the documentation
- [ ] I have added a transaction link
- [ ] I have added the prompt used to test it 
