### PR TITLE
fix: add wallet address action and tool to V2

### DIFF
--- a/packages/plugin-token/README.md
+++ b/packages/plugin-token/README.md
@@ -25,6 +25,7 @@ This plugin provides a set of tools and actions to interact with, create and tra
 - `get_token_balance` - Get detailed token balances including metadata
 - `request_faucet_funds` - Request tokens from a faucet (devnet/testnet)
 - `transfer` - Transfer SOL or tokens to another address
+- `getWalletAddress` - Get the wallet address of the current user
 
 ### Mayan
 - `swap` - Cross-chain token swaps using Mayan DEX

--- a/packages/plugin-token/src/index.ts
+++ b/packages/plugin-token/src/index.ts
@@ -20,6 +20,7 @@ import getTPSAction from "./solana/actions/getTPS";
 import closeEmptyTokenAccountsAction from "./solana/actions/closeEmptyTokenAccounts";
 import requestFundsAction from "./solana/actions/requestFunds";
 import transferAction from "./solana/actions/transfer";
+import walletAddressAction from "./solana/actions/walletAddress";
 
 // mayan
 import mayanSwapAction from "./mayan/actions/swap";
@@ -55,6 +56,7 @@ import {
   get_token_balance,
   request_faucet_funds,
   transfer,
+  getWalletAddress,
 } from "./solana/tools";
 import { swap } from "./mayan/tools";
 import { launchPumpFunToken } from "./pumpfun/tools";
@@ -83,6 +85,7 @@ const TokenPlugin = {
     closeEmptyTokenAccounts,
     getTPS,
     get_balance,
+    getWalletAddress,
     get_balance_other,
     get_token_balance,
     request_faucet_funds,
@@ -121,6 +124,7 @@ const TokenPlugin = {
     spreadTokenUsingSolutiofiAction,
     closeAccountsUsingSolutiofiAction,
     mergeTokensUsingSolutiofiAction,
+    walletAddressAction,
   ],
 
   // Initialize function

--- a/packages/plugin-token/src/solana/actions/index.ts
+++ b/packages/plugin-token/src/solana/actions/index.ts
@@ -4,3 +4,4 @@ export * from "./getTPS";
 export * from "./requestFunds";
 export * from "./transfer";
 export * from "./tokenBalances";
+export * from "./walletAddress";

--- a/packages/plugin-token/src/solana/actions/walletAddress.ts
+++ b/packages/plugin-token/src/solana/actions/walletAddress.ts
@@ -1,0 +1,38 @@
+import { Action, SolanaAgentKit } from "solana-agent-kit";
+import { z } from "zod";
+import { getWalletAddress } from "../tools";
+
+const walletAddressAction: Action = {
+  name: "WALLET_ADDRESS",
+  similes: [
+    "get wallet address",
+    "show wallet address",
+    "display wallet address",
+    "my wallet address",
+  ],
+  description: `Get your wallet address.`,
+  examples: [
+    [
+      {
+        input: {},
+        output: {
+          status: "success",
+          message: "Wallet address retrieved successfully",
+          address: "8x2dR8Mpzuz2YqyZyZjUbYWKSWesBo5jMx2Q9Y86udVk",
+        },
+        explanation: "Get your wallet address",
+      },
+    ],
+  ],
+  schema: z.object({}),
+  handler: async (agent: SolanaAgentKit) => {
+    const address = getWalletAddress(agent);
+    return {
+      status: "success",
+      message: "Wallet address retrieved successfully",
+      address,
+    };
+  },
+};
+
+export default walletAddressAction;

--- a/packages/plugin-token/src/solana/tools/get_wallet_address.ts
+++ b/packages/plugin-token/src/solana/tools/get_wallet_address.ts
@@ -1,0 +1,5 @@
+import { SolanaAgentKit } from "@packages/core/dist";
+
+export function getWalletAddress(agent: SolanaAgentKit): string {
+  return agent.wallet.publicKey.toBase58();
+}

--- a/packages/plugin-token/src/solana/tools/index.ts
+++ b/packages/plugin-token/src/solana/tools/index.ts
@@ -5,3 +5,4 @@ export * from "./transfer";
 export * from "./get_balance";
 export * from "./get_balance_other";
 export * from "./get_token_balances";
+export * from "./get_wallet_address";


### PR DESCRIPTION
# Pull Request Description

This PR adds the wallet address tool from v1 to v2.

## Changes Made
This PR adds the following changes:
<!-- List the key changes made in this PR -->
- Added the wallet address tool from v1 to v2
- Added the wallet address action from v1 to v2

## Transaction executed by agent 
<!-- If applicable, provide example usage, transactions, or screenshots -->
Example transaction: 
<img width="692" alt="Screenshot 2025-04-01 at 21 03 06" src="https://github.com/user-attachments/assets/1a2fedc6-78e2-4b1a-8255-a10fd6455869" />


## Prompt Used
<!-- If relevant, include the prompt or configuration used -->
```
what's my wallet address
```

## Additional Notes
<!-- Any additional information that reviewers should know -->

## Checklist
- [x] I have tested these changes locally
- [x] I have updated the documentation
- [ ] I have added a transaction link
- [x] I have added the prompt used to test it 
