### PR TITLE
feat:v2: switch to jupiter token list for token data search

### DIFF
--- a/packages/core/src/vercel-ai/index.ts
+++ b/packages/core/src/vercel-ai/index.ts
@@ -1,7 +1,7 @@
 import { tool, type CoreTool } from "ai";
-import { SolanaAgentKit } from "../agent";
+import type { SolanaAgentKit } from "../agent";
 import { executeAction } from "../utils/actionExecutor";
-import { Action } from "../types/action";
+import type { Action } from "../types/action";
 
 export function createSolanaTools(
   solanaAgentKit: SolanaAgentKit,
@@ -18,6 +18,14 @@ export function createSolanaTools(
       Similes: ${action.similes.map(
         (simile) => `
         ${simile}
+      `,
+      )}
+
+      Examples: ${action.examples.map(
+        (example) => `
+        Input: ${JSON.stringify(example[0].input)}
+        Output: ${JSON.stringify(example[0].output)}
+        Explanation: ${example[0].explanation}
       `,
       )}
       `.slice(0, 1023),

--- a/packages/plugin-token/README.md
+++ b/packages/plugin-token/README.md
@@ -7,12 +7,12 @@ This plugin provides a set of tools and actions to interact with, create and tra
 ### Dexscreener
 - `getTokenDataByAddress` - Get token data using a token's mint address
 - `getTokenAddressFromTicker` - Get a token's mint address using its ticker symbol
-- `getTokenDataByTicker` - Get token data using a token's ticker symbol
 
 ### Jupiter
 - `fetchPrice` - Get the current price of a token in USDC
 - `stakeWithJup` - Stake SOL to receive jupSOL
 - `trade` - Swap tokens using Jupiter's aggregator
+- `getTokenByTicker` - Get token data using a token's ticker symbol
 
 ### Light Protocol
 - `sendCompressedAirdrop` - Send compressed token airdrops to multiple addresses efficiently

--- a/packages/plugin-token/src/dexscreener/actions/index.ts
+++ b/packages/plugin-token/src/dexscreener/actions/index.ts
@@ -1,2 +1,1 @@
 export * from "./getTokenData";
-export * from "./getTokenDataByTicker";

--- a/packages/plugin-token/src/dexscreener/tools/get_token_data.ts
+++ b/packages/plugin-token/src/dexscreener/tools/get_token_data.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from "@solana/web3.js";
-import { JupiterTokenData } from "../../jupiter/types";
+import type { JupiterTokenData } from "../../jupiter/types";
 
 export async function getTokenDataByAddress(
   mint: PublicKey,

--- a/packages/plugin-token/src/index.ts
+++ b/packages/plugin-token/src/index.ts
@@ -1,14 +1,14 @@
-import { Plugin, SolanaAgentKit } from "solana-agent-kit";
+import type { Plugin, SolanaAgentKit } from "solana-agent-kit";
 
 // Import all actions
 // dexscreener
 import getTokenDataAction from "./dexscreener/actions/getTokenData";
-import tokenDataByTickerAction from "./dexscreener/actions/getTokenDataByTicker";
 
 // jupiter
 import fetchPriceAction from "./jupiter/actions/fetchPrice";
 import stakeWithJupAction from "./jupiter/actions/stakeWithJup";
 import tradeAction from "./jupiter/actions/trade";
+import tokenDataByTickerAction from "./jupiter/actions/getTokenDataByTicker";
 
 // lightprotocol
 import compressedAirdropAction from "./lightprotocol/actions/compressedAirdrop";
@@ -43,9 +43,13 @@ import mergeTokensUsingSolutiofiAction from "./solutiofi/actions/mergeTokens";
 import {
   getTokenDataByAddress,
   getTokenAddressFromTicker,
-  getTokenDataByTicker,
 } from "./dexscreener/tools";
-import { fetchPrice, stakeWithJup, trade } from "./jupiter/tools";
+import {
+  fetchPrice,
+  stakeWithJup,
+  trade,
+  getTokenByTicker,
+} from "./jupiter/tools";
 import { sendCompressedAirdrop } from "./lightprotocol/tools";
 import {
   closeEmptyTokenAccounts,
@@ -75,7 +79,7 @@ const TokenPlugin = {
   methods: {
     getTokenDataByAddress,
     getTokenAddressFromTicker,
-    getTokenDataByTicker,
+    getTokenByTicker,
     fetchPrice,
     stakeWithJup,
     trade,
@@ -126,11 +130,11 @@ const TokenPlugin = {
   // Initialize function
   initialize: function (agent: SolanaAgentKit): void {
     // Initialize all methods with the agent instance
-    Object.entries(this.methods).forEach(([methodName, method]) => {
+    for (const [methodName, method] of Object.entries(this.methods)) {
       if (typeof method === "function") {
         this.methods[methodName] = method.bind(null, agent);
       }
-    });
+    }
 
     // Any necessary initialization logic
     if (!agent.config.OPENAI_API_KEY) {

--- a/packages/plugin-token/src/jupiter/actions/getTokenDataByTicker.ts
+++ b/packages/plugin-token/src/jupiter/actions/getTokenDataByTicker.ts
@@ -1,16 +1,16 @@
-import { Action, SolanaAgentKit } from "solana-agent-kit";
+import type { Action, SolanaAgentKit } from "solana-agent-kit";
 import { z } from "zod";
-import { getTokenDataByTicker } from "../tools";
+import { getTokenByTicker } from "../tools";
 
 const tokenDataByTickerAction: Action = {
-  name: "GET_TOKEN_DATA_BY_TICKER",
+  name: "GET_TOKEN_DATA_OR_INFO_BY_TICKER_OR_SYMBOL",
   similes: [
-    "token data by ticker",
-    "fetch token info by ticker",
+    "token data by symbol",
+    "fetch token info by symbol",
     "lookup token ticker info",
     "get token info by ticker",
   ],
-  description: "Get the token data for a given token ticker",
+  description: "Get the token data for a given token ticker or symbol",
   examples: [
     [
       {
@@ -38,7 +38,7 @@ const tokenDataByTickerAction: Action = {
       const ticker = input.ticker as string;
 
       // Use agent’s method to get token data by ticker
-      const tokenData = await getTokenDataByTicker(ticker);
+      const tokenData = await getTokenByTicker(ticker);
 
       return {
         status: "success",

--- a/packages/plugin-token/src/jupiter/actions/index.ts
+++ b/packages/plugin-token/src/jupiter/actions/index.ts
@@ -1,3 +1,4 @@
 export * from "./fetchPrice";
 export * from "./stakeWithJup";
 export * from "./trade";
+export * from "./getTokenDataByTicker";

--- a/packages/plugin-token/src/jupiter/tools/fetch_price.ts
+++ b/packages/plugin-token/src/jupiter/tools/fetch_price.ts
@@ -1,4 +1,4 @@
-import { PublicKey } from "@solana/web3.js";
+import type { PublicKey } from "@solana/web3.js";
 
 /**
  * Fetch the price of a given token quoted in USDC using Jupiter API
@@ -7,7 +7,9 @@ import { PublicKey } from "@solana/web3.js";
  */
 export async function fetchPrice(tokenId: PublicKey): Promise<string> {
   try {
-    const response = await fetch(`https://api.jup.ag/price/v2?ids=${tokenId}`);
+    const response = await fetch(
+      `https://api.jup.ag/price/v2?ids=${tokenId.toBase58()}`,
+    );
 
     if (!response.ok) {
       throw new Error(`Failed to fetch price: ${response.statusText}`);

--- a/packages/plugin-token/src/jupiter/tools/get_token_by_ticker.ts
+++ b/packages/plugin-token/src/jupiter/tools/get_token_by_ticker.ts
@@ -1,0 +1,38 @@
+import type { JupiterTokenData } from "../types";
+
+/**
+ * Fetches token data by ticker
+ * @param ticker Thea token ticker
+ */
+export async function getTokenByTicker(
+  ticker: string,
+): Promise<JupiterTokenData> {
+  try {
+    const response = await fetch(
+      "https://api.jup.ag/tokens/v1/tagged/verified",
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch price: ${response.statusText}`);
+    }
+
+    const data: JupiterTokenData[] = await response.json();
+
+    const tokenData = data
+      // sort in decreasing daily volume
+      .toSorted((a, b) => (b.daily_volume ?? 0) - (a.daily_volume ?? 0))
+      .find(
+        (token: JupiterTokenData) =>
+          token.symbol.toLowerCase() === ticker.toLowerCase(),
+      );
+
+    if (!tokenData) {
+      throw new Error("Token data not available for the given ticker.");
+    }
+
+    return tokenData;
+  } catch (e) {
+    // @ts-expect-error - error is any
+    throw new Error(`Token fetch failed: ${e.message}`);
+  }
+}

--- a/packages/plugin-token/src/jupiter/tools/index.ts
+++ b/packages/plugin-token/src/jupiter/tools/index.ts
@@ -1,3 +1,4 @@
 export * from "./fetch_price";
 export * from "./stake_with_jup";
 export * from "./trade";
+export * from "./get_token_by_ticker";


### PR DESCRIPTION
# Pull Request Description

This PR replaces the dexscreener token data by ticker action with one provided by jupiter using the jupiter verified token list. However, it should be kept in mind that this can conflict with the debridge token list when the defi plugin is used in v2

## Related Issue

https://linear.app/sendbuilders/issue/SEND-73/token-search-filter-by-volume

## Changes Made
This PR adds the following changes:
<!-- List the key changes made in this PR -->
- Deleted the dexscreener get token data by ticker action
- Replaced it with one provided by jupiter 

## Transaction executed by agent 
<!-- If applicable, provide example usage, transactions, or screenshots -->
Example transaction: 
<img width="621" alt="Screenshot 2025-04-02 at 12 40 47" src="https://github.com/user-attachments/assets/0f706e44-ab4b-43de-abbb-7e947ab3bf44" />


## Prompt Used
<!-- If relevant, include the prompt or configuration used -->
```
get the data of the token with ticker SEND
```

## Additional Notes
<!-- Any additional information that reviewers should know -->

## Checklist
- [x] I have tested these changes locally
- [x] I have updated the documentation
- [ ] I have added a transaction link
- [x] I have added the prompt used to test it 
