### PR TITLE
fix(ranger): use VersionedMessage.deserialize

### DIFF
--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -28,6 +28,7 @@ export interface Config {
   COINGECKO_PRO_API_KEY?: string;
   COINGECKO_DEMO_API_KEY?: string;
   MESSARI_API_KEY?: string;
+  RANGER_API_KEY?: string;
 }
 
 export interface PumpFunTokenOptions {

--- a/packages/plugin-defi/src/ranger/tools/ranger_perp_trading.ts
+++ b/packages/plugin-defi/src/ranger/tools/ranger_perp_trading.ts
@@ -11,6 +11,29 @@ import { RANGER_SOR_API_BASE } from "../index";
 
 /**
  * Open perp trade on Ranger (uses SOR API)
+ *
+ * Calls the SOR API endpoint POST /v1/increase_position to open or increase a perp position.
+ *
+ * Request body fields:
+ *   - fee_payer: string (your Solana wallet public key)
+ *   - symbol: string (e.g., "SOL", "BTC")
+ *   - side: "Long" | "Short"
+ *   - size: number (position size in base asset)
+ *   - collateral: number (collateral in USDC)
+ *   - size_denomination: string (must match symbol)
+ *   - collateral_denomination: string (must be "USDC")
+ *   - adjustment_type: string ("Increase")
+ *   - ...other optional params (see SOR API docs)
+ *
+ * Response fields:
+ *   - message: string (base64-encoded Solana transaction message)
+ *   - meta: object (venue allocations, total size/collateral, price impact, etc.)
+ *
+ * The function decodes and deserializes the message, adds a recent blockhash, and signs/sends the transaction.
+ *
+ * @see https://github.com/ranger-finance/sor-sdk
+ * @see https://gist.github.com/yongkangc/9ce79d6f6bf4df9ca5b52359adced1ee
+ * @see SOR API docs for full details
  */
 export async function openPerpTradeRanger({
   agent,
@@ -64,6 +87,25 @@ export async function openPerpTradeRanger({
 
 /**
  * Close perp trade on Ranger (uses SOR API)
+ *
+ * Calls the SOR API endpoint POST /v1/close_position to close a perp position.
+ *
+ * Request body fields:
+ *   - fee_payer: string (your Solana wallet public key)
+ *   - symbol: string (e.g., "SOL", "BTC")
+ *   - side: "Long" | "Short"
+ *   - adjustment_type: string (e.g., "CloseFlash", "CloseJupiter", "CloseAll")
+ *   - ...other optional params (see SOR API docs)
+ *
+ * Response fields:
+ *   - message: string (base64-encoded Solana transaction message)
+ *   - meta: object (venue allocations, etc.)
+ *
+ * The function decodes and deserializes the message, adds a recent blockhash, and signs/sends the transaction.
+ *
+ * @see https://github.com/ranger-finance/sor-sdk
+ * @see https://gist.github.com/yongkangc/9ce79d6f6bf4df9ca5b52359adced1ee
+ * @see SOR API docs for full details
  */
 export async function closePerpTradeRanger({
   agent,
@@ -109,6 +151,29 @@ export async function closePerpTradeRanger({
 
 /**
  * Increase perp position on Ranger (uses SOR API)
+ *
+ * Calls the SOR API endpoint POST /v1/increase_position to increase the size of an existing perp position.
+ *
+ * Request body fields:
+ *   - fee_payer: string (your Solana wallet public key)
+ *   - symbol: string (e.g., "SOL", "BTC")
+ *   - side: "Long" | "Short"
+ *   - size: number (position size in base asset)
+ *   - collateral: number (collateral in USDC)
+ *   - size_denomination: string (must match symbol)
+ *   - collateral_denomination: string (must be "USDC")
+ *   - adjustment_type: string ("Increase")
+ *   - ...other optional params (see SOR API docs)
+ *
+ * Response fields:
+ *   - message: string (base64-encoded Solana transaction message)
+ *   - meta: object (venue allocations, total size/collateral, price impact, etc.)
+ *
+ * The function decodes and deserializes the message, adds a recent blockhash, and signs/sends the transaction.
+ *
+ * @see https://github.com/ranger-finance/sor-sdk
+ * @see https://gist.github.com/yongkangc/9ce79d6f6bf4df9ca5b52359adced1ee
+ * @see SOR API docs for full details
  */
 export async function increasePerpPositionRanger({
   agent,
@@ -162,6 +227,26 @@ export async function increasePerpPositionRanger({
 
 /**
  * Decrease perp position on Ranger (uses SOR API)
+ *
+ * Calls the SOR API endpoint POST /v1/decrease_position to decrease the size of an existing perp position.
+ *
+ * Request body fields:
+ *   - fee_payer: string (your Solana wallet public key)
+ *   - symbol: string (e.g., "SOL", "BTC")
+ *   - side: "Long" | "Short"
+ *   - size: number (amount to decrease)
+ *   - adjustment_type: string (e.g., "DecreaseFlash", "DecreaseJupiter")
+ *   - ...other optional params (see SOR API docs)
+ *
+ * Response fields:
+ *   - message: string (base64-encoded Solana transaction message)
+ *   - meta: object (venue allocations, etc.)
+ *
+ * The function decodes and deserializes the message, adds a recent blockhash, and signs/sends the transaction.
+ *
+ * @see https://github.com/ranger-finance/sor-sdk
+ * @see https://gist.github.com/yongkangc/9ce79d6f6bf4df9ca5b52359adced1ee
+ * @see SOR API docs for full details
  */
 export async function decreasePerpPositionRanger({
   agent,
@@ -210,6 +295,25 @@ export async function decreasePerpPositionRanger({
 
 /**
  * Withdraw balance from Ranger (uses SOR API)
+ *
+ * Calls the SOR API endpoint POST /v1/withdraw_balance to withdraw available balance from a venue account (e.g., Drift).
+ *
+ * Request body fields:
+ *   - fee_payer: string (your Solana wallet public key)
+ *   - symbol: string (token symbol, e.g., "USDC")
+ *   - amount: number (amount to withdraw)
+ *   - adjustment_type: string ("WithdrawBalanceDrift")
+ *   - ...other optional params (see SOR API docs)
+ *
+ * Response fields:
+ *   - message: string (base64-encoded Solana transaction message)
+ *   - meta: object (venue, amount, symbol, etc.)
+ *
+ * The function decodes and deserializes the message, adds a recent blockhash, and signs/sends the transaction.
+ *
+ * @see https://github.com/ranger-finance/sor-sdk
+ * @see https://gist.github.com/yongkangc/9ce79d6f6bf4df9ca5b52359adced1ee
+ * @see SOR API docs for full details
  */
 export async function withdrawBalanceRanger({
   agent,
@@ -255,6 +359,27 @@ export async function withdrawBalanceRanger({
 
 /**
  * Withdraw collateral from Ranger (uses SOR API)
+ *
+ * Calls the SOR API endpoint POST /v1/withdraw_collateral to withdraw collateral from an existing position.
+ *
+ * Request body fields:
+ *   - fee_payer: string (your Solana wallet public key)
+ *   - symbol: string (e.g., "SOL", "BTC")
+ *   - side: "Long" | "Short"
+ *   - collateral: number (amount to withdraw)
+ *   - collateral_denomination: string (must be "USDC")
+ *   - adjustment_type: string ("WithdrawCollateralFlash", etc.)
+ *   - ...other optional params (see SOR API docs)
+ *
+ * Response fields:
+ *   - message: string (base64-encoded Solana transaction message)
+ *   - meta: object (venue, amount, symbol, etc.)
+ *
+ * The function decodes and deserializes the message, adds a recent blockhash, and signs/sends the transaction.
+ *
+ * @see https://github.com/ranger-finance/sor-sdk
+ * @see https://gist.github.com/yongkangc/9ce79d6f6bf4df9ca5b52359adced1ee
+ * @see SOR API docs for full details
  */
 export async function withdrawCollateralRanger({
   agent,

--- a/packages/plugin-defi/src/ranger/tools/ranger_perp_trading.ts
+++ b/packages/plugin-defi/src/ranger/tools/ranger_perp_trading.ts
@@ -1,6 +1,11 @@
 import type { SolanaAgentKit } from "solana-agent-kit";
 import { signOrSendTX } from "solana-agent-kit";
-import { TransactionMessage, VersionedTransaction } from "@solana/web3.js";
+import {
+  TransactionMessage,
+  VersionedTransaction,
+  VersionedMessage,
+  Message,
+} from "@solana/web3.js";
 import base64js from "base64-js";
 import { RANGER_SOR_API_BASE } from "../index";
 
@@ -50,7 +55,7 @@ export async function openPerpTradeRanger({
   const data = await response.json();
   const messageBase64 = data.message;
   const messageBytes = base64js.toByteArray(messageBase64);
-  const transactionMessage = TransactionMessage.deserialize(messageBytes);
+  const transactionMessage = deserializeTransactionMessage(messageBytes);
   const transaction = new VersionedTransaction(transactionMessage);
   const { blockhash } = await agent.connection.getLatestBlockhash();
   transaction.message.recentBlockhash = blockhash;
@@ -95,7 +100,7 @@ export async function closePerpTradeRanger({
   const data = await response.json();
   const messageBase64 = data.message;
   const messageBytes = base64js.toByteArray(messageBase64);
-  const transactionMessage = TransactionMessage.deserialize(messageBytes);
+  const transactionMessage = deserializeTransactionMessage(messageBytes);
   const transaction = new VersionedTransaction(transactionMessage);
   const { blockhash } = await agent.connection.getLatestBlockhash();
   transaction.message.recentBlockhash = blockhash;
@@ -148,7 +153,7 @@ export async function increasePerpPositionRanger({
   const data = await response.json();
   const messageBase64 = data.message;
   const messageBytes = base64js.toByteArray(messageBase64);
-  const transactionMessage = TransactionMessage.deserialize(messageBytes);
+  const transactionMessage = deserializeTransactionMessage(messageBytes);
   const transaction = new VersionedTransaction(transactionMessage);
   const { blockhash } = await agent.connection.getLatestBlockhash();
   transaction.message.recentBlockhash = blockhash;
@@ -196,7 +201,7 @@ export async function decreasePerpPositionRanger({
   const data = await response.json();
   const messageBase64 = data.message;
   const messageBytes = base64js.toByteArray(messageBase64);
-  const transactionMessage = TransactionMessage.deserialize(messageBytes);
+  const transactionMessage = deserializeTransactionMessage(messageBytes);
   const transaction = new VersionedTransaction(transactionMessage);
   const { blockhash } = await agent.connection.getLatestBlockhash();
   transaction.message.recentBlockhash = blockhash;
@@ -241,7 +246,7 @@ export async function withdrawBalanceRanger({
   const data = await response.json();
   const messageBase64 = data.message;
   const messageBytes = base64js.toByteArray(messageBase64);
-  const transactionMessage = TransactionMessage.deserialize(messageBytes);
+  const transactionMessage = deserializeTransactionMessage(messageBytes);
   const transaction = new VersionedTransaction(transactionMessage);
   const { blockhash } = await agent.connection.getLatestBlockhash();
   transaction.message.recentBlockhash = blockhash;
@@ -293,9 +298,18 @@ export async function withdrawCollateralRanger({
   const data = await response.json();
   const messageBase64 = data.message;
   const messageBytes = base64js.toByteArray(messageBase64);
-  const transactionMessage = TransactionMessage.deserialize(messageBytes);
+  const transactionMessage = deserializeTransactionMessage(messageBytes);
   const transaction = new VersionedTransaction(transactionMessage);
   const { blockhash } = await agent.connection.getLatestBlockhash();
   transaction.message.recentBlockhash = blockhash;
   return signOrSendTX(agent, transaction);
+}
+
+// Helper function for deserialization
+function deserializeTransactionMessage(messageBytes: Uint8Array) {
+  try {
+    return VersionedMessage.deserialize(messageBytes);
+  } catch {
+    return Message.from(messageBytes);
+  }
 }


### PR DESCRIPTION


# Pull Request Description

## Changes Made
This PR adds the following changes:
- Refactored deserialization logic for SOR API transaction messages to support both versioned and legacy Solana transactions.
- Added a helper function to first try `VersionedMessage.deserialize`, then fallback to `Message.from`.
- Updated all SOR API transaction functions (`openPerpTradeRanger`, `closePerpTradeRanger`, etc.) to use the new deserialization pattern.
- Added detailed JSDoc documentation for each function, describing the SOR API endpoint, request/response, and transaction flow.

## Implementation Details
- The deserialization logic now ensures compatibility with both versioned and legacy Solana transaction messages, improving robustness when handling SOR API responses.
- Documentation was added based on the official SOR API docs, including request/response fields and usage notes.
- Imports for `VersionedMessage` and `Message` from `@solana/web3.js` were added.
- All functions now use the shared `deserializeTransactionMessage` helper.

## Transaction executed by agent 
Example transaction:  
<!-- Replace with a real transaction signature or link if available -->
`5KKsT9nUG9tKwUhtw3WP...`  
<!-- Or: [Solscan link](https://solscan.io/tx/5KKsT9nUG9tKwUhtw3WP...) -->


## Additional Notes
- Please ensure you have installed all required dependencies (`@solana/web3.js`, `base64-js`, and `solana-agent-kit`) to avoid linter errors.
- The new deserialization logic is based on best practices for handling Solana transaction messages from external APIs.
- See the SOR API docs for more details: [SOR API Docs](https://github.com/ranger-finance/sor-sdk) and [Example](https://gist.github.com/yongkangc/9ce79d6f6bf4df9ca5b52359adced1ee).

