### PR TITLE
Fix broken LangGraph docs link

### DIFF
--- a/docs/v1/examples/langgraph.mdx
+++ b/docs/v1/examples/langgraph.mdx
@@ -280,7 +280,7 @@ describe('Workflow', () => {
 
 ## Resources
 
-- [LangGraph Documentation](https://js.langchain.com/docs/modules/graphs)
+- [LangGraph Documentation](https://js.langchain.com/docs/tutorials/graph/)
 - [Solana Agent Kit GitHub](https://github.com/sendaifun/solana-agent-kit)
 - [Tavily API Docs](https://docs.tavily.com)
 - [TypeScript Guidelines](https://www.typescriptlang.org/docs/handbook/intro.html)


### PR DESCRIPTION
Replaced outdated LangGraph documentation link (/docs/modules/graphs) with a working one:
https://js.langchain.com/docs/tutorials/graph

The previous link returned a 404 error.
