### PR TITLE
fix: metaplex nft collection creation and nft creation

### DIFF
--- a/packages/core/src/types/wallet.ts
+++ b/packages/core/src/types/wallet.ts
@@ -91,6 +91,7 @@ export async function signOrSendTX(
   feeTier?: keyof typeof feeTiers,
 ): Promise<
   | string
+  | string[]
   | Transaction
   | VersionedTransaction
   | Transaction[]
@@ -107,17 +108,20 @@ export async function signOrSendTX(
       );
     }
 
+    const txSigs: string[] = [];
     for (const tx of instructionsOrTransaction) {
       if (agent.wallet.signAndSendTransaction) {
         const { signature } = await agent.wallet.signAndSendTransaction(
           tx as Transaction,
         );
-        return signature;
+        txSigs.push(signature);
       }
       throw new Error(
         "Wallet does not support signAndSendTransaction please implement it manually or use the signOnly option",
       );
     }
+
+    return txSigs;
   }
 
   if (

--- a/packages/plugin-nft/src/metaplex/tools/deploy_collection.ts
+++ b/packages/plugin-nft/src/metaplex/tools/deploy_collection.ts
@@ -2,6 +2,7 @@ import { createCollection, ruleSet } from "@metaplex-foundation/mpl-core";
 import { generateSigner, publicKey } from "@metaplex-foundation/umi";
 import {
   toWeb3JsInstruction,
+  toWeb3JsKeypair,
   toWeb3JsPublicKey,
 } from "@metaplex-foundation/umi-web3js-adapters";
 import { Transaction } from "@solana/web3.js";
@@ -58,6 +59,7 @@ export async function deploy_collection(
     const { blockhash } = await agent.connection.getLatestBlockhash();
     tx.recentBlockhash = blockhash;
     tx.feePayer = agent.wallet.publicKey;
+    tx.partialSign(toWeb3JsKeypair(collectionSigner));
 
     const sigOrTx = await signOrSendTX(agent, tx);
 

--- a/packages/plugin-nft/src/metaplex/tools/mint_nft.ts
+++ b/packages/plugin-nft/src/metaplex/tools/mint_nft.ts
@@ -4,6 +4,7 @@ import { generateSigner } from "@metaplex-foundation/umi";
 import {
   fromWeb3JsPublicKey,
   toWeb3JsInstruction,
+  toWeb3JsKeypair,
   toWeb3JsPublicKey,
 } from "@metaplex-foundation/umi-web3js-adapters";
 import { PublicKey, Transaction } from "@solana/web3.js";
@@ -59,6 +60,7 @@ export async function mintCollectionNFT(
     const { blockhash } = await agent.connection.getLatestBlockhash();
     tx.recentBlockhash = blockhash;
     tx.feePayer = agent.wallet.publicKey;
+    tx.partialSign(toWeb3JsKeypair(assetSigner));
 
     const sigOrTx = await signOrSendTX(agent, tx);
 

--- a/packages/plugin-nft/src/utils.ts
+++ b/packages/plugin-nft/src/utils.ts
@@ -1,9 +1,12 @@
 import { mplCore } from "@metaplex-foundation/mpl-core";
 import { mplToolbox } from "@metaplex-foundation/mpl-toolbox";
 import { createUmi } from "@metaplex-foundation/umi-bundle-defaults";
-import { fromWeb3JsPublicKey } from "@metaplex-foundation/umi-web3js-adapters";
+import {
+  fromWeb3JsPublicKey,
+  fromWeb3JsTransaction,
+  toWeb3JsTransaction,
+} from "@metaplex-foundation/umi-web3js-adapters";
 import { SolanaAgentKit } from "@packages/core/dist";
-import { PublicKey } from "@solana/web3.js";
 
 export function initUmi(agent: SolanaAgentKit) {
   const umi = createUmi(agent.connection.rpcEndpoint)
@@ -11,10 +14,16 @@ export function initUmi(agent: SolanaAgentKit) {
     .use(mplToolbox());
   umi.identity = {
     publicKey: fromWeb3JsPublicKey(agent.wallet.publicKey),
-    // @ts-expect-error Umi types are not compatible with SolanaAgentKit
-    signTransaction: agent.wallet.signTransaction,
-    // @ts-expect-error Umi types are not compatible with SolanaAgentKit
-    signAllTransactions: agent.wallet.signAllTransactions,
+    signTransaction: async (tx) =>
+      fromWeb3JsTransaction(
+        await agent.wallet.signTransaction(toWeb3JsTransaction(tx)),
+      ),
+    signAllTransactions: async (txs) => {
+      const signedTxs = await agent.wallet.signAllTransactions(
+        txs.map((tx) => toWeb3JsTransaction(tx)),
+      );
+      return signedTxs.map((tx) => fromWeb3JsTransaction(tx));
+    },
     signMessage: agent.wallet.signMessage,
   };
   umi.payer = umi.identity;


### PR DESCRIPTION
# Pull Request Description

This PR fixes the failure when launching an NFT and an NFT collection. It was identified by @scriptscrypt 

## Changes Made
This PR adds the following changes:
<!-- List the key changes made in this PR -->
- Update transaction signing and sending of multiple transactions
- Partially sign nft creation and collection creation transactions with the asset and collection signers respectively 

## Transaction executed by agent 
<!-- If applicable, provide example usage, transactions, or screenshots -->
Example transaction: 
https://solscan.io/tx/3CvYHSMViM5cJPCBL2tkjkKRcLzNRT4kXHM62G2Xnd2kZHTbaa6np63pJV6Ts72Y9oThhZaFP87AzU8eWF2ySCVM

## Prompt Used
<!-- If relevant, include the prompt or configuration used -->
```
please create an NFT colleciton using this metadata URI https://gateway.pinata.cloud/ipfs/QmPmu3ZkKSBPJqBJaAaVBuj5M8JprJCT6xBZUDfmZUnv2s , and name "test" use default values for all other fields
```

## Checklist
- [x] I have tested these changes locally
- [ ] I have updated the documentation
- [x] I have added a transaction link
- [x] I have added the prompt used to test it 
