### PR TITLE
feat: migrated lulo withdraw function with blink

### DIFF
--- a/packages/plugin-defi/src/lulo/tools/lulo_withdraw.ts
+++ b/packages/plugin-defi/src/lulo/tools/lulo_withdraw.ts
@@ -14,34 +14,25 @@ export async function luloWithdraw(
   amount: number,
 ) {
   try {
-    if (!agent.config?.FLEXLEND_API_KEY) {
-      throw new Error("Lulo API key not found in agent configuration");
-    }
-
     const response = await fetch(
-      `https://api.flexlend.fi/generate/account/withdraw?priorityFee=50000`,
+      `https://lulo.dial.to/api/actions/withdraw/${mintAddress}/${amount}`,
       {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "x-wallet-pubkey": agent.wallet.publicKey.toBase58(),
-          "x-api-key": agent.config?.FLEXLEND_API_KEY,
         },
         body: JSON.stringify({
-          owner: agent.wallet.publicKey.toBase58(),
-          mintAddress: mintAddress,
-          depositAmount: amount,
+          account: agent.wallet.publicKey.toBase58(),
         }),
       },
     );
 
-    const {
-      data: { transactionMeta },
-    } = await response.json();
+
+    const data = await response.json();
 
     // Deserialize the transaction
     const luloTxn = VersionedTransaction.deserialize(
-      Buffer.from(transactionMeta[0].transaction, "base64"),
+      Buffer.from(data.transaction, "base64"),
     );
 
     // Get a recent blockhash and set it


### PR DESCRIPTION
# Pull Request Description

## Related Issue
Improves maintainability and functionality by replacing direct API integration with a Blink API.

## Changes Made
This PR adds the following changes:
- Implemented blink functionality for the withdraw feature
- Updated API endpoint to use the new Lulo blink
- Added support for token tickers across all tokens that Lulo supports

## Implementation Details
- Switched from the previous Flexlend API endpoint to our blink endpoint (`https://lulo.dial.to/api/actions/withdraw/${mintAddress}/${amount}`)
- Updated signing 
 
## Transaction executed by agent 
Example transaction: https://explorer.solana.com/tx/2zMMMxUs6QuFZE3iBHbpbgPqA46kvqz9shqcBguLSwMjKKNAnQH5AfS5SDypJ3KpDiKiyKsGgib3VMyFVCYYZBj6

## Prompt Used
<!-- If relevant, include the prompt or configuration used -->
```
  // Initialize agent with your wallet
   const agent = new SolanaAgentKit(wallet, rpcUrl, {})
     .use(DefiPlugin);

   // Withdraw 1 unit of USDC (using the token mint address)
   const result = await agent.methods.luloWithdraw(
     agent, 
     "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", 
     1
   );
```

## Additional Notes


## Checklist
- [X] I have tested these changes locally
- [] I have updated the documentation (since it is just a replacement, I expect that this was already done)
- [X] I have added a transaction link
- [X] I have added the prompt used to test it 
