### PR TITLE
Fix Typo in Return Object Key for Raydium AMM V4 Action

### DIFF
--- a/packages/plugin-defi/src/raydium/actions/raydiumCreateAmmV4.ts
+++ b/packages/plugin-defi/src/raydium/actions/raydiumCreateAmmV4.ts
@@ -75,7 +75,7 @@ const raydiumCreateAmmV4Action: Action = {
 
       return {
         status: "success",
-        transactoin: txId,
+        transaction: txId,
         message: "Successfully created Raydium AMM V4 pool",
       };
     } catch (error: any) {


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the return object of the raydiumCreateAmmV4Action function. The key transaction was previously misspelled as transactoin. This fix ensures the returned object uses the correct key, improving code clarity and preventing potential bugs related to property access. No other logic or functionality was changed.