### PR TITLE
Fix broken README.md links in v1 CollectionDeployment docs

### DIFF
--- a/docs/v1/interfaces/CollectionDeployment.mdx
+++ b/docs/v1/interfaces/CollectionDeployment.mdx
@@ -3,11 +3,11 @@ title: "CollectionDeployment"
 description: "Documentation for CollectionDeployment"
 ---
 
-[**solana-agent-kit v1.3.7**](../README.md)
+[**solana-agent-kit v1.3.7**](../introduction.mdx)
 
 ***
 
-[solana-agent-kit](../README.md) / CollectionDeployment
+[solana-agent-kit](../introduction.mdx) / CollectionDeployment
 
 # Interface: CollectionDeployment
 


### PR DESCRIPTION
Replaced outdated links to ../README.md with ../introduction.mdx in docs/v1/interfaces/CollectionDeployment.mdx to resolve missing file errors and ensure navigation points to the correct introduction page for v1 documentation.