### PR TITLE
fix: 404 link

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -858,7 +858,7 @@ The repository includes an advanced example of building a multi-agent system usi
 - Fully typed TypeScript implementation
 - Environment-based configuration
 
-Check out the [LangGraph example](examples/agent-kit-langgraph) for a complete implementation of an advanced Solana agent system.
+Check out the [LangGraph example](/examples/misc/agent-kit-langgraph) for a complete implementation of an advanced Solana agent system.
 
 ## Dependencies
 


### PR DESCRIPTION
nothing fancy, just changed the link on Langgraph example, as I tried to click on it and there was a 404 error bcuz of wrong path