### PR TITLE
fix(docs): update CONTRIBUTING.md link to correct root path in core README

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -877,7 +877,7 @@ The toolkit relies on several key Solana and Metaplex libraries:
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.
-Refer to [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines on how to contribute to this project.
+Refer to [CONTRIBUTING.md](../../CONTRIBUTING.md) for detailed guidelines on how to contribute to this project.
 
 ## Contributors
 


### PR DESCRIPTION
The link to CONTRIBUTING.md in packages/core/README.md was updated to point to the correct file location in the repository root (../../CONTRIBUTING.md). This ensures contributors can easily access the contribution guidelines without encountering a broken link.