### PR TITLE
Fix: V1 Jupiter is deprecated change to V2

### DIFF
--- a/packages/plugin-token/src/jupiter/tools/get_token_by_ticker.ts
+++ b/packages/plugin-token/src/jupiter/tools/get_token_by_ticker.ts
@@ -9,7 +9,7 @@ export async function getTokenByTicker(
 ): Promise<JupiterTokenData> {
   try {
     const response = await fetch(
-      "https://api.jup.ag/tokens/v1/tagged/verified",
+      "https://lite-api.jup.ag/tokens/v2/tag?query=verified",
     );
 
     if (!response.ok) {


### PR DESCRIPTION
# Pull Request Description

## Related Issue
Fixes # (issue number)

## Changes Made
This PR adds the following changes:
- Update Jupiter API URL for fetching verified tokens
- Migrate from deprecated v1 API to new v2 API endpoint

## Implementation Details
- Replace deprecated URL `https://api.jup.ag/tokens/v1/tagged/verified` with `https://lite-api.jup.ag/tokens/v2/tag?query=verified`
- Single line modification to perform this API migration
- Maintain functional compatibility with the new API endpoint

## Transaction executed by agent 
<!-- If applicable, provide example usage, transactions, or screenshots -->
Example transaction: 
Failed to fetch token data for ticker: CUDIS. Token fetch failed: Failed to fetch price: Unauthorized -> 
Successfully fetched token data for ticker: CUDIS


## Prompt Used

## Additional Notes
This change is necessary as the Jupiter v1 API is deprecated. The new v2 API provides the same data but with an updated URL structure. No business logic changes are required - only the endpoint URL has been modified.

## Checklist
- [x] I have tested these changes locally