### PR TITLE
fix: added round down to scaled amounts for Jupiter trades

### DIFF
--- a/packages/plugin-token/src/jupiter/tools/trade.ts
+++ b/packages/plugin-token/src/jupiter/tools/trade.ts
@@ -38,7 +38,7 @@ export async function trade(
       : (await getMintInfo(agent.connection, inputMint.toBase58())).decimals;
 
     // Calculate the correct amount based on actual decimals
-    const scaledAmount = inputAmount * Math.pow(10, inputDecimals);
+    const scaledAmount = Math.floor(inputAmount * Math.pow(10, inputDecimals));
 
     const quoteResponse = await (
       await fetch(


### PR DESCRIPTION
# Pull Request Description

## Related Issue
Fixes the issue that inputAmounts with a higher decimal precision than the number of decimals available cause the tool to fail. 

## Changes Made
This PR adds the following changes:
<!-- List the key changes made in this PR -->
- Wrap the scaledAmounts in Math.floor()
- 
  
## Implementation Details
<!-- Provide technical details about the implementation -->
- Added flooring to scaled input amounts
- 

## Additional Notes
<!-- Any additional information that reviewers should know -->

## Checklist
- [ x] I have tested these changes locally
- [ ] I have updated the documentation
- [ ] I have added a transaction link
- [ ] I have added the prompt used to test it 
