### PR TITLE
fix: replace ZodType<any> with minimal schema type to prevent TS OOM

### DIFF
--- a/packages/adapter-mcp/src/index.ts
+++ b/packages/adapter-mcp/src/index.ts
@@ -4,8 +4,11 @@ import { type Action, SolanaAgentKit } from "solana-agent-kit";
 import { z } from "zod";
 
 // Define the raw shape type that MCP tools expect
+type MinimalZodSchema =
+  Pick<z.ZodTypeAny, "parse" | "optional" | "_def">;
+
 export type MCPSchemaShape = {
-  [key: string]: z.ZodType<any>;
+  [key: string]: MinimalZodSchema;
 };
 
 // Type guards for Zod schema types
@@ -34,11 +37,11 @@ export function zodToMCPShape(schema: z.ZodTypeAny): {
     throw new Error("MCP tools require an object schema at the top level");
   }
 
-  const shape = schema.shape;
+  const shape: Record<string, z.ZodTypeAny> = schema.shape;
   const result: MCPSchemaShape = {};
 
   for (const [key, value] of Object.entries(shape)) {
-    result[key] = isZodOptional(value as any) ? (value as any).unwrap() : value;
+    result[key] = isZodOptional(value) ? value.unwrap() : value;
   }
 
   return {


### PR DESCRIPTION
## Related Issue
Before, MCPSchemaShape was using ZodType<any>. This caused TypeScript to expand very deep Zod generics, which led to errors like "Type instantiation is excessively deep and possibly infinite" and sometimes Node OOM errors.
You can see the build fail without setting NODE_OPTIONS=--max-old-space-size, because the Node worker runs out of memory.

## What this commit did?

This commit adds a MinimalZodSchema type:
Pick<z.ZodTypeAny, "parse" | "optional" | "_def">
and uses it for MCPSchemaShape.

Fixes the recursion and memory issue in TypeScript.
Keeps runtime the same (schemas are still real Zod schemas).
Makes the code safer by removing as any for .unwrap().

## Changes Made
Fix: Replaced ZodType<any> with a minimal schema type.
Old: MCPSchemaShape = Record<string, z.ZodType<any>>
New:
MCPSchemaShape = Record<string, MinimalZodSchema>
MinimalZodSchema = Pick<z.ZodTypeAny, "parse" | "optional" | "_def">

## Benefits
No more build failures or OOM from TypeScript recursion.
Runtime behavior is the same.
Code is more type-safe and easier to read.

If anything is unclear in this description, please ping me and I’ll explain more.