### PR TITLE
docs: add Community Plugins section — @liqdlad/solana-agent-kit-plugin (A2A-Swap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,35 @@ You can choose to install any of the plugins listed below or you could choose to
 npm install @solana-agent-kit/plugin-token @solana-agent-kit/plugin-nft @solana-agent-kit/plugin-defi @solana-agent-kit/plugin-misc @solana-agent-kit/plugin-blinks
 ```
 
+## 🌐 Community Plugins
+
+Third-party plugins that extend Solana Agent Kit with additional protocols and capabilities:
+
+### A2A-Swap (`@liqdlad/solana-agent-kit-plugin`)
+
+Agent-native constant-product AMM on Solana. Ultra-cheap swaps (~40k CU), fixed 0.020% protocol fee, pure PDA custody, auto-compounding LP fees, on-chain capability card for agent self-discovery.
+
+```bash
+npm install @liqdlad/solana-agent-kit-plugin
+```
+
+```typescript
+import A2ASwapPlugin from "@liqdlad/solana-agent-kit-plugin";
+
+const agent = new SolanaAgentKit(wallet, rpcUrl, {})
+  .use(A2ASwapPlugin);
+
+// 5 AI actions registered automatically:
+// A2A_SWAP, A2A_ADD_LIQUIDITY, A2A_REMOVE_LIQUIDITY,
+// A2A_GET_POOL_INFO, A2A_GET_CAPABILITY_CARD
+
+// Programmatic API:
+await agent.methods.a2aSwap(agent, SOL, USDC, 1_000_000_000n);
+await agent.methods.a2aPoolInfo(agent, SOL, USDC);
+```
+
+Ideal for autonomous agents and high-frequency execution. [GitHub](https://github.com/liqdlad-rgb/a2a-swap) · [npm](https://www.npmjs.com/package/@liqdlad/solana-agent-kit-plugin)
+
 ## Quick Start
 
 Initializing the wallet interface and agent with plugins:
@@ -910,3 +939,4 @@ This toolkit handles transaction generation, signing and sending, using provided
 ## Attributions
 
 System prompt logic adapted from Coinbase AgentKit (Apache 2.0)
+


### PR DESCRIPTION
## Summary

Adds a new **`## 🌐 Community Plugins`** section to the README, placed immediately after the official Plugin Installation section. The section documents `@liqdlad/solana-agent-kit-plugin` — a production-ready, drop-in plugin for A2A-Swap.

---

### Why A2A-Swap belongs in this list

**A2A-Swap** is an agent-native constant-product AMM deployed on Solana mainnet, purpose-built for autonomous AI agents. It follows the exact SAK v2 plugin architecture and provides unique capabilities no other AMM plugin currently offers:

| Feature | A2A-Swap | Jupiter / Raydium |
|---------|----------|--------------------|
| Compute units | **~40,000 CU** | 200k–400k+ |
| Protocol fee | **Fixed 0.020%** | Variable |
| Execution | **Single on-chain instruction** | Multi-hop |
| Auto-compound fees | **Yes** | No |
| On-chain capability card | **Yes** | No |
| Ideal for | **Agent loops, high-frequency** | Best-price routing |

The plugin:
- Implements the SAK v2 `Plugin` interface exactly (`name`, `methods`, `actions`, `initialize(agent)`)
- Registers 5 AI actions with 12–13 LLM-optimized similes each (Zod-validated)
- Provides 8 programmatic methods on `agent.methods`
- Works out of the box with `createVercelAITools`, `createLangchainTools`, and `createOpenAITools`
- Uses `KeypairWallet` for server-side agent signing (standard SAK pattern)

### Links

- **npm:** https://www.npmjs.com/package/@liqdlad/solana-agent-kit-plugin
- **GitHub:** https://github.com/liqdlad-rgb/a2a-swap
- **Program (mainnet):** `8XJfG4mHqRZjByAd7HxHdEALfB8jVtJVQsdhGEmysTFq` ([Solscan](https://solscan.io/account/8XJfG4mHqRZjByAd7HxHdEALfB8jVtJVQsdhGEmysTFq))
- **SOL/USDC pool:** `BtBL5wpMbmabFimeUmLtjZAAeh4xWWf76NSpefMXb4TC` (live mainnet)

### What changed

Single section added to `README.md` between `## 📦 Plugin Installation` and `## Quick Start`:

```markdown
## 🌐 Community Plugins

Third-party plugins that extend Solana Agent Kit with additional protocols and capabilities:

### A2A-Swap (`@liqdlad/solana-agent-kit-plugin`)
...
```

No other files were modified. No dependencies added to the monorepo.