### PR TITLE
Add non-custodial wallet provider via sak-agentwallet-adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,6 +864,14 @@ The repository includes an advanced example of building a multi-agent system usi
 
 Check out the [LangGraph example](examples/agent-kit-langgraph) for a complete implementation of an advanced Solana agent system.
 
+## 🔐 Community Wallet Providers
+
+Alternative wallet backends that plug into Solana Agent Kit.
+
+| Provider | npm | Description |
+|----------|-----|-------------|
+| [sak-agentwallet-adapter](https://www.npmjs.com/package/sak-agentwallet-adapter) | `sak-agentwallet-adapter` | Self-custodial wallet — agent holds its own keypair. No Privy, no Turnkey, no vendor dependency. Works as a drop-in `WalletAdapter` for SAK. |
+
 ## Dependencies
 
 The toolkit relies on several key Solana and Metaplex libraries:


### PR DESCRIPTION
Built a wallet adapter for Solana Agent Kit that gives agents self-custodial wallets.

**What it does:**
- Drop-in `WalletAdapter` for SAK — works with existing tools
- Agent holds its own Solana keypair directly
- No Privy account, no Turnkey API key, no vendor dependency
- If the vendor goes down, the agent's wallet still works

**npm:** [`sak-agentwallet-adapter`](https://www.npmjs.com/package/sak-agentwallet-adapter)
**License:** MIT

This PR adds a Community Wallet Providers section to the README and lists `sak-agentwallet-adapter` as the first entry.

Related: #523