### PR TITLE
Add Deside messaging plugin backed by Deside MCP SDK

### DIFF
--- a/packages/plugin-messaging/.npmignore
+++ b/packages/plugin-messaging/.npmignore
@@ -1,0 +1,7 @@
+src/
+tsconfig*.json
+.gitignore
+.eslintrc
+jest.config.js
+.rollup.cache/
+.turbo/

--- a/packages/plugin-messaging/README.md
+++ b/packages/plugin-messaging/README.md
@@ -1,0 +1,26 @@
+# @solana-agent-kit/plugin-messaging
+
+Deside messaging plugin for Solana Agent Kit.
+
+This plugin adds wallet-native messaging, identity, and discovery actions via
+Deside MCP, backed by `@desideapp/mcp-sdk`.
+
+## Methods
+
+- `sendMessage`
+- `readMessages`
+- `markRead`
+- `listConversations`
+- `getUserInfo`
+- `getMyIdentity`
+- `searchAgents`
+
+## Required config
+
+- `DESIDE_OAUTH_REDIRECT_URI`
+
+## Optional config
+
+- `DESIDE_MCP_BASE_URL`
+- `DESIDE_OAUTH_SCOPE`
+- `DESIDE_OAUTH_CLIENT_NAME`

--- a/packages/plugin-messaging/package.json
+++ b/packages/plugin-messaging/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@solana-agent-kit/plugin-messaging",
+  "version": "0.1.0",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "clean": "rm -rf dist .turbo node_modules",
+    "build": "tsup src/index.ts --dts --clean --format cjs,esm --out-dir dist",
+    "test": "jest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sendaifun/solana-agent-kit.git"
+  },
+  "homepage": "https://github.com/sendaifun/solana-agent-kit/tree/v2/packages/plugin-messaging",
+  "dependencies": {
+    "@desideapp/mcp-sdk": "^0.1.1",
+    "bs58": "^6.0.0",
+    "solana-agent-kit": "workspace:*",
+    "zod": "^3.24.1"
+  },
+  "peerDependencies": {
+    "@solana/web3.js": "^1.98.2",
+    "solana-agent-kit": "2.0.10"
+  },
+  "devDependencies": {
+    "tsup": "^8.4.0"
+  }
+}

--- a/packages/plugin-messaging/src/actions/getMyIdentity.ts
+++ b/packages/plugin-messaging/src/actions/getMyIdentity.ts
@@ -1,8 +1,8 @@
-import { Action, SolanaAgentKit } from "solana-agent-kit";
 import { z } from "zod";
 import { getMyIdentity } from "../shared";
+import type { PluginAction, SolanaAgentLike } from "../types";
 
-const getMyIdentityAction: Action = {
+const getMyIdentityAction: PluginAction = {
   name: "DESIDE_GET_MY_IDENTITY",
   similes: [
     "get my deside identity",
@@ -27,7 +27,7 @@ const getMyIdentityAction: Action = {
     ],
   ],
   schema: z.object({}),
-  handler: async (agent: SolanaAgentKit) => {
+  handler: async (agent: SolanaAgentLike) => {
     try {
       const identity = await getMyIdentity(agent);
       return {

--- a/packages/plugin-messaging/src/actions/getMyIdentity.ts
+++ b/packages/plugin-messaging/src/actions/getMyIdentity.ts
@@ -1,0 +1,46 @@
+import { Action, SolanaAgentKit } from "solana-agent-kit";
+import { z } from "zod";
+import { getMyIdentity } from "../shared";
+
+const getMyIdentityAction: Action = {
+  name: "DESIDE_GET_MY_IDENTITY",
+  similes: [
+    "get my deside identity",
+    "show my deside profile",
+    "check my deside identity",
+  ],
+  description: "Get the public Deside identity exposed for the connected wallet.",
+  examples: [
+    [
+      {
+        input: {},
+        output: {
+          status: "success",
+          identity: {
+            wallet: "9msyfXaZNffdQiqo68BTPNeuez3moU1vqdBmM86W5BWH",
+            recognized: false,
+            role: "user",
+          },
+        },
+        explanation: "Retrieve the Deside identity of the connected wallet.",
+      },
+    ],
+  ],
+  schema: z.object({}),
+  handler: async (agent: SolanaAgentKit) => {
+    try {
+      const identity = await getMyIdentity(agent);
+      return {
+        status: "success",
+        identity,
+      };
+    } catch (error: any) {
+      return {
+        status: "error",
+        message: `Failed to get Deside identity: ${error.message}`,
+      };
+    }
+  },
+};
+
+export default getMyIdentityAction;

--- a/packages/plugin-messaging/src/actions/getUserInfo.ts
+++ b/packages/plugin-messaging/src/actions/getUserInfo.ts
@@ -1,0 +1,50 @@
+import { Action, SolanaAgentKit } from "solana-agent-kit";
+import { z } from "zod";
+import { getUserInfo } from "../shared";
+
+const getUserInfoAction: Action = {
+  name: "DESIDE_GET_USER_INFO",
+  similes: [
+    "get deside user info",
+    "lookup deside wallet",
+    "show deside profile",
+  ],
+  description: "Get the public Deside profile for a wallet.",
+  examples: [
+    [
+      {
+        input: {
+          wallet: "Gwrn3UyMvrdSP8VsQZyTfAYp9qwrcu5ivBujKHufZJFZ",
+        },
+        output: {
+          status: "success",
+          profile: {
+            wallet: "Gwrn3UyMvrdSP8VsQZyTfAYp9qwrcu5ivBujKHufZJFZ",
+          },
+        },
+        explanation: "Fetch Deside public profile data for a wallet.",
+      },
+    ],
+  ],
+  schema: z.object({
+    wallet: z.string().describe("The wallet address to inspect on Deside."),
+  }),
+  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+    try {
+      const profile = await getUserInfo(agent, {
+        wallet: input.wallet,
+      });
+      return {
+        status: "success",
+        profile,
+      };
+    } catch (error: any) {
+      return {
+        status: "error",
+        message: `Failed to get Deside user info: ${error.message}`,
+      };
+    }
+  },
+};
+
+export default getUserInfoAction;

--- a/packages/plugin-messaging/src/actions/getUserInfo.ts
+++ b/packages/plugin-messaging/src/actions/getUserInfo.ts
@@ -1,8 +1,8 @@
-import { Action, SolanaAgentKit } from "solana-agent-kit";
 import { z } from "zod";
 import { getUserInfo } from "../shared";
+import type { PluginAction, SolanaAgentLike } from "../types";
 
-const getUserInfoAction: Action = {
+const getUserInfoAction: PluginAction = {
   name: "DESIDE_GET_USER_INFO",
   similes: [
     "get deside user info",
@@ -29,7 +29,7 @@ const getUserInfoAction: Action = {
   schema: z.object({
     wallet: z.string().describe("The wallet address to inspect on Deside."),
   }),
-  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+  handler: async (agent: SolanaAgentLike, input: Record<string, any>) => {
     try {
       const profile = await getUserInfo(agent, {
         wallet: input.wallet,

--- a/packages/plugin-messaging/src/actions/listConversations.ts
+++ b/packages/plugin-messaging/src/actions/listConversations.ts
@@ -1,8 +1,8 @@
-import { Action, SolanaAgentKit } from "solana-agent-kit";
 import { z } from "zod";
 import { listConversations } from "../shared";
+import type { PluginAction, SolanaAgentLike } from "../types";
 
-const listConversationsAction: Action = {
+const listConversationsAction: PluginAction = {
   name: "DESIDE_LIST_CONVERSATIONS",
   similes: [
     "list my deside conversations",
@@ -28,7 +28,7 @@ const listConversationsAction: Action = {
     limit: z.number().int().positive().optional().describe("Maximum number of conversations to return."),
     cursor: z.string().optional().describe("Pagination cursor returned by a previous call."),
   }),
-  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+  handler: async (agent: SolanaAgentLike, input: Record<string, any>) => {
     try {
       const conversations = await listConversations(agent, {
         limit: input.limit,

--- a/packages/plugin-messaging/src/actions/listConversations.ts
+++ b/packages/plugin-messaging/src/actions/listConversations.ts
@@ -1,0 +1,50 @@
+import { Action, SolanaAgentKit } from "solana-agent-kit";
+import { z } from "zod";
+import { listConversations } from "../shared";
+
+const listConversationsAction: Action = {
+  name: "DESIDE_LIST_CONVERSATIONS",
+  similes: [
+    "list my deside conversations",
+    "show deside conversations",
+    "view deside inbox",
+  ],
+  description: "List active Deside conversations for the connected wallet.",
+  examples: [
+    [
+      {
+        input: {
+          limit: 10,
+        },
+        output: {
+          status: "success",
+          conversations: [],
+        },
+        explanation: "List the most recent Deside conversations.",
+      },
+    ],
+  ],
+  schema: z.object({
+    limit: z.number().int().positive().optional().describe("Maximum number of conversations to return."),
+    cursor: z.string().optional().describe("Pagination cursor returned by a previous call."),
+  }),
+  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+    try {
+      const conversations = await listConversations(agent, {
+        limit: input.limit,
+        cursor: input.cursor,
+      });
+      return {
+        status: "success",
+        conversations,
+      };
+    } catch (error: any) {
+      return {
+        status: "error",
+        message: `Failed to list Deside conversations: ${error.message}`,
+      };
+    }
+  },
+};
+
+export default listConversationsAction;

--- a/packages/plugin-messaging/src/actions/markRead.ts
+++ b/packages/plugin-messaging/src/actions/markRead.ts
@@ -1,0 +1,55 @@
+import { Action, SolanaAgentKit } from "solana-agent-kit";
+import { z } from "zod";
+import { markRead } from "../shared";
+
+const markReadAction: Action = {
+  name: "DESIDE_MARK_READ",
+  similes: [
+    "mark deside conversation as read",
+    "mark dm as read",
+    "acknowledge conversation read",
+  ],
+  description: "Mark a Deside conversation as read up to a sequence number.",
+  examples: [
+    [
+      {
+        input: {
+          convId: "walletA:walletB",
+          seq: 12,
+        },
+        output: {
+          status: "success",
+          result: {
+            ok: true,
+          },
+        },
+        explanation: "Mark a conversation as read on Deside.",
+      },
+    ],
+  ],
+  schema: z.object({
+    convId: z.string().describe("Canonical conversation id returned by Deside."),
+    seq: z.number().int().positive().describe("Sequence number to mark as read."),
+    readAt: z.string().optional().describe("Optional ISO timestamp to forward to Deside."),
+  }),
+  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+    try {
+      const result = await markRead(agent, {
+        convId: input.convId,
+        seq: input.seq,
+        readAt: input.readAt,
+      });
+      return {
+        status: "success",
+        result,
+      };
+    } catch (error: any) {
+      return {
+        status: "error",
+        message: `Failed to mark Deside conversation as read: ${error.message}`,
+      };
+    }
+  },
+};
+
+export default markReadAction;

--- a/packages/plugin-messaging/src/actions/markRead.ts
+++ b/packages/plugin-messaging/src/actions/markRead.ts
@@ -1,8 +1,8 @@
-import { Action, SolanaAgentKit } from "solana-agent-kit";
 import { z } from "zod";
 import { markRead } from "../shared";
+import type { PluginAction, SolanaAgentLike } from "../types";
 
-const markReadAction: Action = {
+const markReadAction: PluginAction = {
   name: "DESIDE_MARK_READ",
   similes: [
     "mark deside conversation as read",
@@ -32,7 +32,7 @@ const markReadAction: Action = {
     seq: z.number().int().positive().describe("Sequence number to mark as read."),
     readAt: z.string().optional().describe("Optional ISO timestamp to forward to Deside."),
   }),
-  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+  handler: async (agent: SolanaAgentLike, input: Record<string, any>) => {
     try {
       const result = await markRead(agent, {
         convId: input.convId,

--- a/packages/plugin-messaging/src/actions/readMessages.ts
+++ b/packages/plugin-messaging/src/actions/readMessages.ts
@@ -1,8 +1,8 @@
-import { Action, SolanaAgentKit } from "solana-agent-kit";
 import { z } from "zod";
 import { readMessages } from "../shared";
+import type { PluginAction, SolanaAgentLike } from "../types";
 
-const readMessagesAction: Action = {
+const readMessagesAction: PluginAction = {
   name: "DESIDE_READ_MESSAGES",
   similes: [
     "read deside messages",
@@ -30,7 +30,7 @@ const readMessagesAction: Action = {
     limit: z.number().int().positive().optional().describe("Maximum number of messages to return."),
     beforeSeq: z.number().int().positive().optional().describe("Read messages older than this sequence number."),
   }),
-  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+  handler: async (agent: SolanaAgentLike, input: Record<string, any>) => {
     try {
       const messages = await readMessages(agent, {
         convId: input.convId,

--- a/packages/plugin-messaging/src/actions/readMessages.ts
+++ b/packages/plugin-messaging/src/actions/readMessages.ts
@@ -1,0 +1,53 @@
+import { Action, SolanaAgentKit } from "solana-agent-kit";
+import { z } from "zod";
+import { readMessages } from "../shared";
+
+const readMessagesAction: Action = {
+  name: "DESIDE_READ_MESSAGES",
+  similes: [
+    "read deside messages",
+    "show conversation messages",
+    "fetch dm history",
+  ],
+  description: "Read messages from a Deside conversation.",
+  examples: [
+    [
+      {
+        input: {
+          convId: "walletA:walletB",
+          limit: 20,
+        },
+        output: {
+          status: "success",
+          messages: [],
+        },
+        explanation: "Read recent messages from a Deside conversation.",
+      },
+    ],
+  ],
+  schema: z.object({
+    convId: z.string().describe("Canonical conversation id returned by Deside."),
+    limit: z.number().int().positive().optional().describe("Maximum number of messages to return."),
+    beforeSeq: z.number().int().positive().optional().describe("Read messages older than this sequence number."),
+  }),
+  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+    try {
+      const messages = await readMessages(agent, {
+        convId: input.convId,
+        limit: input.limit,
+        beforeSeq: input.beforeSeq,
+      });
+      return {
+        status: "success",
+        messages,
+      };
+    } catch (error: any) {
+      return {
+        status: "error",
+        message: `Failed to read Deside messages: ${error.message}`,
+      };
+    }
+  },
+};
+
+export default readMessagesAction;

--- a/packages/plugin-messaging/src/actions/searchAgents.ts
+++ b/packages/plugin-messaging/src/actions/searchAgents.ts
@@ -1,0 +1,57 @@
+import { Action, SolanaAgentKit } from "solana-agent-kit";
+import { z } from "zod";
+import { searchAgents } from "../shared";
+
+const searchAgentsAction: Action = {
+  name: "DESIDE_SEARCH_AGENTS",
+  similes: [
+    "search deside agents",
+    "find agent on deside",
+    "discover agents",
+  ],
+  description: "Search Deside agents by name, wallet, or category.",
+  examples: [
+    [
+      {
+        input: {
+          name: "qnt",
+          limit: 5,
+        },
+        output: {
+          status: "success",
+          agents: [],
+        },
+        explanation: "Search for agents registered on Deside.",
+      },
+    ],
+  ],
+  schema: z.object({
+    name: z.string().optional().describe("Agent name query."),
+    wallet: z.string().optional().describe("Wallet address query."),
+    category: z.string().optional().describe("Agent category query."),
+    limit: z.number().int().positive().optional().describe("Maximum number of results."),
+    offset: z.number().int().nonnegative().optional().describe("Pagination offset."),
+  }),
+  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+    try {
+      const agents = await searchAgents(agent, {
+        name: input.name,
+        wallet: input.wallet,
+        category: input.category,
+        limit: input.limit,
+        offset: input.offset,
+      });
+      return {
+        status: "success",
+        agents,
+      };
+    } catch (error: any) {
+      return {
+        status: "error",
+        message: `Failed to search Deside agents: ${error.message}`,
+      };
+    }
+  },
+};
+
+export default searchAgentsAction;

--- a/packages/plugin-messaging/src/actions/searchAgents.ts
+++ b/packages/plugin-messaging/src/actions/searchAgents.ts
@@ -1,8 +1,8 @@
-import { Action, SolanaAgentKit } from "solana-agent-kit";
 import { z } from "zod";
 import { searchAgents } from "../shared";
+import type { PluginAction, SolanaAgentLike } from "../types";
 
-const searchAgentsAction: Action = {
+const searchAgentsAction: PluginAction = {
   name: "DESIDE_SEARCH_AGENTS",
   similes: [
     "search deside agents",
@@ -32,7 +32,7 @@ const searchAgentsAction: Action = {
     limit: z.number().int().positive().optional().describe("Maximum number of results."),
     offset: z.number().int().nonnegative().optional().describe("Pagination offset."),
   }),
-  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+  handler: async (agent: SolanaAgentLike, input: Record<string, any>) => {
     try {
       const agents = await searchAgents(agent, {
         name: input.name,

--- a/packages/plugin-messaging/src/actions/sendMessage.ts
+++ b/packages/plugin-messaging/src/actions/sendMessage.ts
@@ -1,8 +1,8 @@
-import { Action, SolanaAgentKit } from "solana-agent-kit";
 import { z } from "zod";
 import { sendMessage } from "../shared";
+import type { PluginAction, SolanaAgentLike } from "../types";
 
-const sendMessageAction: Action = {
+const sendMessageAction: PluginAction = {
   name: "DESIDE_SEND_MESSAGE",
   similes: [
     "send deside message",
@@ -31,7 +31,7 @@ const sendMessageAction: Action = {
     toWallet: z.string().describe("Destination wallet address."),
     text: z.string().min(1).describe("Message body to send."),
   }),
-  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+  handler: async (agent: SolanaAgentLike, input: Record<string, any>) => {
     try {
       const result = await sendMessage(agent, {
         toWallet: input.toWallet,

--- a/packages/plugin-messaging/src/actions/sendMessage.ts
+++ b/packages/plugin-messaging/src/actions/sendMessage.ts
@@ -1,0 +1,53 @@
+import { Action, SolanaAgentKit } from "solana-agent-kit";
+import { z } from "zod";
+import { sendMessage } from "../shared";
+
+const sendMessageAction: Action = {
+  name: "DESIDE_SEND_MESSAGE",
+  similes: [
+    "send deside message",
+    "send direct message",
+    "dm a wallet on deside",
+  ],
+  description: "Send a direct message to another wallet through Deside.",
+  examples: [
+    [
+      {
+        input: {
+          toWallet: "Gwrn3UyMvrdSP8VsQZyTfAYp9qwrcu5ivBujKHufZJFZ",
+          text: "GM",
+        },
+        output: {
+          status: "success",
+          result: {
+            status: "delivered",
+          },
+        },
+        explanation: "Send a direct message to another wallet on Deside.",
+      },
+    ],
+  ],
+  schema: z.object({
+    toWallet: z.string().describe("Destination wallet address."),
+    text: z.string().min(1).describe("Message body to send."),
+  }),
+  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+    try {
+      const result = await sendMessage(agent, {
+        toWallet: input.toWallet,
+        text: input.text,
+      });
+      return {
+        status: "success",
+        result,
+      };
+    } catch (error: any) {
+      return {
+        status: "error",
+        message: `Failed to send Deside message: ${error.message}`,
+      };
+    }
+  },
+};
+
+export default sendMessageAction;

--- a/packages/plugin-messaging/src/index.ts
+++ b/packages/plugin-messaging/src/index.ts
@@ -1,0 +1,49 @@
+import type { Plugin } from "solana-agent-kit";
+import getMyIdentityAction from "./actions/getMyIdentity";
+import getUserInfoAction from "./actions/getUserInfo";
+import listConversationsAction from "./actions/listConversations";
+import markReadAction from "./actions/markRead";
+import readMessagesAction from "./actions/readMessages";
+import searchAgentsAction from "./actions/searchAgents";
+import sendMessageAction from "./actions/sendMessage";
+import {
+  getMyIdentity,
+  getUserInfo,
+  listConversations,
+  markRead,
+  readMessages,
+  searchAgents,
+  sendMessage,
+} from "./shared";
+
+const MessagingPlugin = {
+  name: "messaging",
+  methods: {
+    sendMessage,
+    readMessages,
+    markRead,
+    listConversations,
+    getUserInfo,
+    getMyIdentity,
+    searchAgents,
+  },
+  actions: [
+    sendMessageAction,
+    readMessagesAction,
+    markReadAction,
+    listConversationsAction,
+    getUserInfoAction,
+    getMyIdentityAction,
+    searchAgentsAction,
+  ],
+  initialize: function (): void {
+    for (const [methodName, method] of Object.entries(this.methods)) {
+      if (typeof method === "function") {
+        this.methods[methodName] = method;
+      }
+    }
+  },
+} satisfies Plugin;
+
+export type * from "./types";
+export default MessagingPlugin;

--- a/packages/plugin-messaging/src/index.ts
+++ b/packages/plugin-messaging/src/index.ts
@@ -1,4 +1,3 @@
-import type { Plugin } from "solana-agent-kit";
 import getMyIdentityAction from "./actions/getMyIdentity";
 import getUserInfoAction from "./actions/getUserInfo";
 import listConversationsAction from "./actions/listConversations";
@@ -15,27 +14,32 @@ import {
   searchAgents,
   sendMessage,
 } from "./shared";
+import type { MessagingPluginContract, PluginAction } from "./types";
 
-const MessagingPlugin = {
+const methods: Record<string, any> = {
+  sendMessage,
+  readMessages,
+  markRead,
+  listConversations,
+  getUserInfo,
+  getMyIdentity,
+  searchAgents,
+};
+
+const actions: PluginAction[] = [
+  sendMessageAction,
+  readMessagesAction,
+  markReadAction,
+  listConversationsAction,
+  getUserInfoAction,
+  getMyIdentityAction,
+  searchAgentsAction,
+];
+
+const MessagingPlugin: MessagingPluginContract = {
   name: "messaging",
-  methods: {
-    sendMessage,
-    readMessages,
-    markRead,
-    listConversations,
-    getUserInfo,
-    getMyIdentity,
-    searchAgents,
-  },
-  actions: [
-    sendMessageAction,
-    readMessagesAction,
-    markReadAction,
-    listConversationsAction,
-    getUserInfoAction,
-    getMyIdentityAction,
-    searchAgentsAction,
-  ],
+  methods,
+  actions,
   initialize: function (): void {
     for (const [methodName, method] of Object.entries(this.methods)) {
       if (typeof method === "function") {
@@ -43,7 +47,6 @@ const MessagingPlugin = {
       }
     }
   },
-} satisfies Plugin;
+};
 
-export type * from "./types";
 export default MessagingPlugin;

--- a/packages/plugin-messaging/src/shared.ts
+++ b/packages/plugin-messaging/src/shared.ts
@@ -1,0 +1,108 @@
+import { DesideMcpSdk, type DesideSigner } from "@desideapp/mcp-sdk";
+import type { SolanaAgentKit } from "solana-agent-kit";
+import type {
+  DesideMessagingConfig,
+  GetUserInfoInput,
+  ListConversationsInput,
+  MarkReadInput,
+  ReadMessagesInput,
+  SearchAgentsInput,
+  SendMessageInput,
+} from "./types";
+
+const sdkByAgent = new WeakMap<SolanaAgentKit, DesideMcpSdk>();
+
+function getPluginConfig(agent: SolanaAgentKit): DesideMessagingConfig {
+  return agent.config as DesideMessagingConfig;
+}
+
+export function getDesideSdk(agent: SolanaAgentKit): DesideMcpSdk {
+  const existing = sdkByAgent.get(agent);
+  if (existing) {
+    return existing;
+  }
+
+  const config = getPluginConfig(agent);
+  if (!config.DESIDE_OAUTH_REDIRECT_URI) {
+    throw new Error("DESIDE_OAUTH_REDIRECT_URI is required for Deside messaging");
+  }
+
+  const sdk = new DesideMcpSdk({
+    baseUrl: config.DESIDE_MCP_BASE_URL,
+    oauthRedirectUri: config.DESIDE_OAUTH_REDIRECT_URI,
+    oauthScope: config.DESIDE_OAUTH_SCOPE,
+    oauthClientName: config.DESIDE_OAUTH_CLIENT_NAME || "solana-agent-kit-plugin-messaging",
+    signatureEncoding: "base64",
+  });
+
+  sdkByAgent.set(agent, sdk);
+  return sdk;
+}
+
+export function getDesideSigner(agent: SolanaAgentKit): DesideSigner {
+  return {
+    getAddress: () => agent.wallet.publicKey.toBase58(),
+    signMessage: async (message: string) => {
+      const signature = await agent.wallet.signMessage(new TextEncoder().encode(message));
+      return Buffer.from(signature).toString("base64");
+    },
+  };
+}
+
+async function getReadyContext(agent: SolanaAgentKit) {
+  const sdk = getDesideSdk(agent);
+  const signer = getDesideSigner(agent);
+  await sdk.connect(signer);
+  return { sdk, signer };
+}
+
+export async function sendMessage(agent: SolanaAgentKit, input: SendMessageInput) {
+  const { sdk, signer } = await getReadyContext(agent);
+  return sdk.sendDm(signer, {
+    to_wallet: input.toWallet,
+    text: input.text,
+  });
+}
+
+export async function readMessages(agent: SolanaAgentKit, input: ReadMessagesInput) {
+  const { sdk, signer } = await getReadyContext(agent);
+  return sdk.readDms(signer, {
+    conv_id: input.convId,
+    limit: input.limit,
+    before_seq: input.beforeSeq,
+  });
+}
+
+export async function markRead(agent: SolanaAgentKit, input: MarkReadInput) {
+  const { sdk, signer } = await getReadyContext(agent);
+  return sdk.markDmRead(signer, {
+    conv_id: input.convId,
+    seq: input.seq,
+    read_at: input.readAt,
+  });
+}
+
+export async function listConversations(
+  agent: SolanaAgentKit,
+  input: ListConversationsInput = {},
+) {
+  const { sdk, signer } = await getReadyContext(agent);
+  return sdk.listConversations(signer, input);
+}
+
+export async function getUserInfo(agent: SolanaAgentKit, input: GetUserInfoInput) {
+  const { sdk, signer } = await getReadyContext(agent);
+  return sdk.getUserInfo(signer, {
+    wallet: input.wallet,
+  });
+}
+
+export async function getMyIdentity(agent: SolanaAgentKit) {
+  const { sdk, signer } = await getReadyContext(agent);
+  return sdk.getMyIdentity(signer);
+}
+
+export async function searchAgents(agent: SolanaAgentKit, input: SearchAgentsInput) {
+  const { sdk, signer } = await getReadyContext(agent);
+  return sdk.searchAgents(signer, input);
+}

--- a/packages/plugin-messaging/src/shared.ts
+++ b/packages/plugin-messaging/src/shared.ts
@@ -1,5 +1,4 @@
 import { DesideMcpSdk, type DesideSigner } from "@desideapp/mcp-sdk";
-import type { SolanaAgentKit } from "solana-agent-kit";
 import type {
   DesideMessagingConfig,
   GetUserInfoInput,
@@ -8,15 +7,16 @@ import type {
   ReadMessagesInput,
   SearchAgentsInput,
   SendMessageInput,
+  SolanaAgentLike,
 } from "./types";
 
-const sdkByAgent = new WeakMap<SolanaAgentKit, DesideMcpSdk>();
+const sdkByAgent = new WeakMap<SolanaAgentLike, DesideMcpSdk>();
 
-function getPluginConfig(agent: SolanaAgentKit): DesideMessagingConfig {
+function getPluginConfig(agent: SolanaAgentLike): DesideMessagingConfig {
   return agent.config as DesideMessagingConfig;
 }
 
-export function getDesideSdk(agent: SolanaAgentKit): DesideMcpSdk {
+export function getDesideSdk(agent: SolanaAgentLike): DesideMcpSdk {
   const existing = sdkByAgent.get(agent);
   if (existing) {
     return existing;
@@ -39,7 +39,7 @@ export function getDesideSdk(agent: SolanaAgentKit): DesideMcpSdk {
   return sdk;
 }
 
-export function getDesideSigner(agent: SolanaAgentKit): DesideSigner {
+export function getDesideSigner(agent: SolanaAgentLike): DesideSigner {
   return {
     getAddress: () => agent.wallet.publicKey.toBase58(),
     signMessage: async (message: string) => {
@@ -49,14 +49,19 @@ export function getDesideSigner(agent: SolanaAgentKit): DesideSigner {
   };
 }
 
-async function getReadyContext(agent: SolanaAgentKit) {
+async function getReadyContext(
+  agent: SolanaAgentLike,
+): Promise<{ sdk: DesideMcpSdk; signer: DesideSigner }> {
   const sdk = getDesideSdk(agent);
   const signer = getDesideSigner(agent);
   await sdk.connect(signer);
   return { sdk, signer };
 }
 
-export async function sendMessage(agent: SolanaAgentKit, input: SendMessageInput) {
+export async function sendMessage(
+  agent: SolanaAgentLike,
+  input: SendMessageInput,
+): Promise<unknown> {
   const { sdk, signer } = await getReadyContext(agent);
   return sdk.sendDm(signer, {
     to_wallet: input.toWallet,
@@ -64,7 +69,10 @@ export async function sendMessage(agent: SolanaAgentKit, input: SendMessageInput
   });
 }
 
-export async function readMessages(agent: SolanaAgentKit, input: ReadMessagesInput) {
+export async function readMessages(
+  agent: SolanaAgentLike,
+  input: ReadMessagesInput,
+): Promise<unknown> {
   const { sdk, signer } = await getReadyContext(agent);
   return sdk.readDms(signer, {
     conv_id: input.convId,
@@ -73,7 +81,10 @@ export async function readMessages(agent: SolanaAgentKit, input: ReadMessagesInp
   });
 }
 
-export async function markRead(agent: SolanaAgentKit, input: MarkReadInput) {
+export async function markRead(
+  agent: SolanaAgentLike,
+  input: MarkReadInput,
+): Promise<unknown> {
   const { sdk, signer } = await getReadyContext(agent);
   return sdk.markDmRead(signer, {
     conv_id: input.convId,
@@ -83,26 +94,32 @@ export async function markRead(agent: SolanaAgentKit, input: MarkReadInput) {
 }
 
 export async function listConversations(
-  agent: SolanaAgentKit,
+  agent: SolanaAgentLike,
   input: ListConversationsInput = {},
-) {
+): Promise<unknown> {
   const { sdk, signer } = await getReadyContext(agent);
   return sdk.listConversations(signer, input);
 }
 
-export async function getUserInfo(agent: SolanaAgentKit, input: GetUserInfoInput) {
+export async function getUserInfo(
+  agent: SolanaAgentLike,
+  input: GetUserInfoInput,
+): Promise<unknown> {
   const { sdk, signer } = await getReadyContext(agent);
   return sdk.getUserInfo(signer, {
     wallet: input.wallet,
   });
 }
 
-export async function getMyIdentity(agent: SolanaAgentKit) {
+export async function getMyIdentity(agent: SolanaAgentLike): Promise<unknown> {
   const { sdk, signer } = await getReadyContext(agent);
   return sdk.getMyIdentity(signer);
 }
 
-export async function searchAgents(agent: SolanaAgentKit, input: SearchAgentsInput) {
+export async function searchAgents(
+  agent: SolanaAgentLike,
+  input: SearchAgentsInput,
+): Promise<unknown> {
   const { sdk, signer } = await getReadyContext(agent);
   return sdk.searchAgents(signer, input);
 }

--- a/packages/plugin-messaging/src/types.ts
+++ b/packages/plugin-messaging/src/types.ts
@@ -1,3 +1,42 @@
+import type { z } from "zod";
+
+export type SolanaAgentWallet = {
+  publicKey: {
+    toBase58(): string;
+  };
+  signMessage(message: Uint8Array): Promise<Uint8Array>;
+};
+
+export type SolanaAgentLike = {
+  wallet: SolanaAgentWallet;
+  config: Record<string, unknown>;
+};
+
+export type PluginAction = {
+  name: string;
+  similes: string[];
+  description: string;
+  examples: Array<
+    Array<{
+      input: Record<string, any>;
+      output: Record<string, any>;
+      explanation: string;
+    }>
+  >;
+  schema: z.ZodTypeAny;
+  handler: (
+    agent: SolanaAgentLike,
+    input: Record<string, any>,
+  ) => Promise<Record<string, any>>;
+};
+
+export type MessagingPluginContract = {
+  name: string;
+  methods: Record<string, any>;
+  actions: PluginAction[];
+  initialize(agent: SolanaAgentLike): void;
+};
+
 export type SendMessageInput = {
   toWallet: string;
   text: string;

--- a/packages/plugin-messaging/src/types.ts
+++ b/packages/plugin-messaging/src/types.ts
@@ -1,0 +1,40 @@
+export type SendMessageInput = {
+  toWallet: string;
+  text: string;
+};
+
+export type ReadMessagesInput = {
+  convId: string;
+  limit?: number;
+  beforeSeq?: number;
+};
+
+export type MarkReadInput = {
+  convId: string;
+  seq: number;
+  readAt?: string;
+};
+
+export type ListConversationsInput = {
+  limit?: number;
+  cursor?: string;
+};
+
+export type GetUserInfoInput = {
+  wallet: string;
+};
+
+export type SearchAgentsInput = {
+  name?: string;
+  wallet?: string;
+  category?: string;
+  limit?: number;
+  offset?: number;
+};
+
+export type DesideMessagingConfig = {
+  DESIDE_MCP_BASE_URL?: string;
+  DESIDE_OAUTH_SCOPE?: string;
+  DESIDE_OAUTH_CLIENT_NAME?: string;
+  DESIDE_OAUTH_REDIRECT_URI?: string;
+};

--- a/packages/plugin-messaging/tsconfig.cjs.json
+++ b/packages/plugin-messaging/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "module": "CommonJS"
+  }
+}

--- a/packages/plugin-messaging/tsconfig.json
+++ b/packages/plugin-messaging/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,10 +109,10 @@ importers:
         version: 0.2.7(zod@3.24.1)
       '@langchain/core':
         specifier: ^0.3.44
-        version: 0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1))
+        version: 0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1))
       '@openai/agents':
         specifier: ^0.0.7
-        version: 0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
+        version: 0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
       '@solana/spl-token':
         specifier: ^0.4.13
         version: 0.4.13(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.7.2)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)(utf-8-validate@5.0.10)
@@ -267,6 +267,28 @@ importers:
       zod:
         specifier: ^3.24.1
         version: 3.24.1
+
+  packages/plugin-messaging:
+    dependencies:
+      '@desideapp/mcp-sdk':
+        specifier: ^0.1.1
+        version: 0.1.1
+      '@solana/web3.js':
+        specifier: ^1.98.2
+        version: 1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      bs58:
+        specifier: ^6.0.0
+        version: 6.0.0
+      solana-agent-kit:
+        specifier: workspace:*
+        version: link:../core
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.63
+    devDependencies:
+      tsup:
+        specifier: ^8.4.0
+        version: 8.4.0(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
 
   packages/plugin-misc:
     dependencies:
@@ -468,22 +490,22 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: ^1.3.10
-        version: 1.3.20(zod@3.24.4)
+        version: 1.3.20(zod@3.25.63)
       '@anthropic-ai/sdk':
         specifier: ^0.39.0
         version: 0.39.0(encoding@0.1.13)
       '@langchain/core':
         specifier: ^0.3.44
-        version: 0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4))
+        version: 0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63))
       '@langchain/langgraph':
         specifier: ^0.2.63
-        version: 0.2.67(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))(react@19.0.0)(zod-to-json-schema@3.24.1(zod@3.24.4))
+        version: 0.2.67(@langchain/core@0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))(react@19.0.0)(zod-to-json-schema@3.24.1(zod@3.25.63))
       '@langchain/openai':
         specifier: ^0.5.5
-        version: 0.5.7(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))(encoding@0.1.13)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 0.5.7(@langchain/core@0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))(encoding@0.1.13)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@openai/agents':
         specifier: ^0.0.7
-        version: 0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+        version: 0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
       '@solana-agent-kit/plugin-blinks':
         specifier: workspace:*
         version: link:../packages/plugin-blinks
@@ -504,7 +526,7 @@ importers:
         version: 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
       ai:
         specifier: ^4.1.5
-        version: 4.1.5(react@19.0.0)(zod@3.24.4)
+        version: 4.1.5(react@19.0.0)(zod@3.25.63)
       bs58:
         specifier: ^6.0.0
         version: 6.0.0
@@ -513,13 +535,13 @@ importers:
         version: 16.4.7
       openai:
         specifier: ^5.3.0
-        version: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+        version: 5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
       solana-agent-kit:
         specifier: workspace:*
         version: link:../packages/core
       zod-to-json-schema:
         specifier: ^3.24.1
-        version: 3.24.1(zod@3.24.4)
+        version: 3.24.1(zod@3.25.63)
     devDependencies:
       tsx:
         specifier: ^4.19.2
@@ -851,6 +873,10 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
+  '@desideapp/mcp-sdk@0.1.1':
+    resolution: {integrity: sha512-OtsB4Cpje3VeB4BbSNu+REXIgn6lBT7NPLWF6EKTZPC3FvUvHeQ5nuLuxO5e+ECkEznDPnVQiAEFErDz5L0STw==}
+    engines: {node: '>=20'}
+
   '@drift-labs/sdk@2.108.0-beta.6':
     resolution: {integrity: sha512-3bq1FO8Zuv5uvGsQqL58Er5+cWxz/H2FHG6BZKfKZDGv/xBpvLdYZIFWZBXrQ3Md8qa9D0DI44NMsWTrCOA8HQ==}
     engines: {node: '>=20.18.0'}
@@ -864,12 +890,6 @@ packages:
 
   '@esbuild/aix-ppc64@0.23.1':
     resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/aix-ppc64@0.25.1':
-    resolution: {integrity: sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
@@ -892,12 +912,6 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.25.1':
-    resolution: {integrity: sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.25.2':
     resolution: {integrity: sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==}
     engines: {node: '>=18'}
@@ -912,12 +926,6 @@ packages:
 
   '@esbuild/android-arm@0.23.1':
     resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-arm@0.25.1':
-    resolution: {integrity: sha512-dp+MshLYux6j/JjdqVLnMglQlFu+MuVeNrmT5nk6q07wNhCdSnB7QZj+7G8VMUGh1q+vj2Bq8kRsuyA00I/k+Q==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
@@ -940,12 +948,6 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.25.1':
-    resolution: {integrity: sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.25.2':
     resolution: {integrity: sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==}
     engines: {node: '>=18'}
@@ -960,12 +962,6 @@ packages:
 
   '@esbuild/darwin-arm64@0.23.1':
     resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-arm64@0.25.1':
-    resolution: {integrity: sha512-5hEZKPf+nQjYoSr/elb62U19/l1mZDdqidGfmFutVUjjUZrOazAtwK+Kr+3y0C/oeJfLlxo9fXb1w7L+P7E4FQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
@@ -988,12 +984,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.25.1':
-    resolution: {integrity: sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
   '@esbuild/darwin-x64@0.25.2':
     resolution: {integrity: sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==}
     engines: {node: '>=18'}
@@ -1008,12 +998,6 @@ packages:
 
   '@esbuild/freebsd-arm64@0.23.1':
     resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-arm64@0.25.1':
-    resolution: {integrity: sha512-1MrCZs0fZa2g8E+FUo2ipw6jw5qqQiH+tERoS5fAfKnRx6NXH31tXBKI3VpmLijLH6yriMZsxJtaXUyFt/8Y4A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
@@ -1036,12 +1020,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.25.1':
-    resolution: {integrity: sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
   '@esbuild/freebsd-x64@0.25.2':
     resolution: {integrity: sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==}
     engines: {node: '>=18'}
@@ -1056,12 +1034,6 @@ packages:
 
   '@esbuild/linux-arm64@0.23.1':
     resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm64@0.25.1':
-    resolution: {integrity: sha512-jaN3dHi0/DDPelk0nLcXRm1q7DNJpjXy7yWaWvbfkPvI+7XNSc/lDOnCLN7gzsyzgu6qSAmgSvP9oXAhP973uQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
@@ -1084,12 +1056,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.25.1':
-    resolution: {integrity: sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
   '@esbuild/linux-arm@0.25.2':
     resolution: {integrity: sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==}
     engines: {node: '>=18'}
@@ -1104,12 +1070,6 @@ packages:
 
   '@esbuild/linux-ia32@0.23.1':
     resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.25.1':
-    resolution: {integrity: sha512-OJykPaF4v8JidKNGz8c/q1lBO44sQNUQtq1KktJXdBLn1hPod5rE/Hko5ugKKZd+D2+o1a9MFGUEIUwO2YfgkQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
@@ -1132,12 +1092,6 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.25.1':
-    resolution: {integrity: sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
   '@esbuild/linux-loong64@0.25.2':
     resolution: {integrity: sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==}
     engines: {node: '>=18'}
@@ -1152,12 +1106,6 @@ packages:
 
   '@esbuild/linux-mips64el@0.23.1':
     resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.25.1':
-    resolution: {integrity: sha512-1osBbPEFYwIE5IVB/0g2X6i1qInZa1aIoj1TdL4AaAb55xIIgbg8Doq6a5BzYWgr+tEcDzYH67XVnTmUzL+nXg==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
@@ -1180,12 +1128,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.25.1':
-    resolution: {integrity: sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
   '@esbuild/linux-ppc64@0.25.2':
     resolution: {integrity: sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==}
     engines: {node: '>=18'}
@@ -1200,12 +1142,6 @@ packages:
 
   '@esbuild/linux-riscv64@0.23.1':
     resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.25.1':
-    resolution: {integrity: sha512-nSut/Mx5gnilhcq2yIMLMe3Wl4FK5wx/o0QuuCLMtmJn+WeWYoEGDN1ipcN72g1WHsnIbxGXd4i/MF0gTcuAjQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
@@ -1228,12 +1164,6 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.25.1':
-    resolution: {integrity: sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.25.2':
     resolution: {integrity: sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==}
     engines: {node: '>=18'}
@@ -1252,12 +1182,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.1':
-    resolution: {integrity: sha512-xbfUhu/gnvSEg+EGovRc+kjBAkrvtk38RlerAzQxvMzlB4fXpCFCeUAYzJvrnhFtdeyVCDANSjJvOvGYoeKzFA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.25.2':
     resolution: {integrity: sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==}
     engines: {node: '>=18'}
@@ -1269,12 +1193,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
-
-  '@esbuild/netbsd-arm64@0.25.1':
-    resolution: {integrity: sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
 
   '@esbuild/netbsd-arm64@0.25.2':
     resolution: {integrity: sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==}
@@ -1290,12 +1208,6 @@ packages:
 
   '@esbuild/netbsd-x64@0.23.1':
     resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.25.1':
-    resolution: {integrity: sha512-X53z6uXip6KFXBQ+Krbx25XHV/NCbzryM6ehOAeAil7X7oa4XIq+394PWGnwaSQ2WRA0KI6PUO6hTO5zeF5ijA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
@@ -1318,12 +1230,6 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-arm64@0.25.1':
-    resolution: {integrity: sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.25.2':
     resolution: {integrity: sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==}
     engines: {node: '>=18'}
@@ -1338,12 +1244,6 @@ packages:
 
   '@esbuild/openbsd-x64@0.23.1':
     resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.25.1':
-    resolution: {integrity: sha512-T3H78X2h1tszfRSf+txbt5aOp/e7TAz3ptVKu9Oyir3IAOFPGV6O9c2naym5TOriy1l0nNf6a4X5UXRZSGX/dw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
@@ -1366,12 +1266,6 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.25.1':
-    resolution: {integrity: sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.25.2':
     resolution: {integrity: sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==}
     engines: {node: '>=18'}
@@ -1386,12 +1280,6 @@ packages:
 
   '@esbuild/win32-arm64@0.23.1':
     resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-arm64@0.25.1':
-    resolution: {integrity: sha512-GE7XvrdOzrb+yVKB9KsRMq+7a2U/K5Cf/8grVFRAGJmfADr/e/ODQ134RK2/eeHqYV5eQRFxb1hY7Nr15fv1NQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1414,12 +1302,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.1':
-    resolution: {integrity: sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.25.2':
     resolution: {integrity: sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==}
     engines: {node: '>=18'}
@@ -1434,12 +1316,6 @@ packages:
 
   '@esbuild/win32-x64@0.23.1':
     resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.25.1':
-    resolution: {integrity: sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -3965,11 +3841,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  esbuild@0.25.1:
-    resolution: {integrity: sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   esbuild@0.25.2:
     resolution: {integrity: sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==}
     engines: {node: '>=18'}
@@ -4406,11 +4277,12 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -6900,11 +6772,11 @@ snapshots:
 
   '@adraffy/ens-normalize@1.10.1': {}
 
-  '@ai-sdk/openai@1.3.20(zod@3.24.4)':
+  '@ai-sdk/openai@1.3.20(zod@3.25.63)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.4)
-      zod: 3.24.4
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.63)
+      zod: 3.25.63
 
   '@ai-sdk/provider-utils@2.1.2(zod@3.24.1)':
     dependencies:
@@ -6915,15 +6787,6 @@ snapshots:
     optionalDependencies:
       zod: 3.24.1
 
-  '@ai-sdk/provider-utils@2.1.2(zod@3.24.4)':
-    dependencies:
-      '@ai-sdk/provider': 1.0.6
-      eventsource-parser: 3.0.0
-      nanoid: 3.3.8
-      secure-json-parse: 2.7.0
-    optionalDependencies:
-      zod: 3.24.4
-
   '@ai-sdk/provider-utils@2.1.2(zod@3.25.63)':
     dependencies:
       '@ai-sdk/provider': 1.0.6
@@ -6933,12 +6796,12 @@ snapshots:
     optionalDependencies:
       zod: 3.25.63
 
-  '@ai-sdk/provider-utils@2.2.7(zod@3.24.4)':
+  '@ai-sdk/provider-utils@2.2.7(zod@3.25.63)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       nanoid: 3.3.8
       secure-json-parse: 2.7.0
-      zod: 3.24.4
+      zod: 3.25.63
 
   '@ai-sdk/provider@1.0.6':
     dependencies:
@@ -6958,16 +6821,6 @@ snapshots:
       react: 19.0.0
       zod: 3.24.1
 
-  '@ai-sdk/react@1.1.3(react@19.0.0)(zod@3.24.4)':
-    dependencies:
-      '@ai-sdk/provider-utils': 2.1.2(zod@3.24.4)
-      '@ai-sdk/ui-utils': 1.1.3(zod@3.24.4)
-      swr: 2.3.3(react@19.0.0)
-      throttleit: 2.1.0
-    optionalDependencies:
-      react: 19.0.0
-      zod: 3.24.4
-
   '@ai-sdk/react@1.1.3(react@19.0.0)(zod@3.25.63)':
     dependencies:
       '@ai-sdk/provider-utils': 2.1.2(zod@3.25.63)
@@ -6985,14 +6838,6 @@ snapshots:
       zod-to-json-schema: 3.24.1(zod@3.24.1)
     optionalDependencies:
       zod: 3.24.1
-
-  '@ai-sdk/ui-utils@1.1.3(zod@3.24.4)':
-    dependencies:
-      '@ai-sdk/provider': 1.0.6
-      '@ai-sdk/provider-utils': 2.1.2(zod@3.24.4)
-      zod-to-json-schema: 3.24.1(zod@3.24.4)
-    optionalDependencies:
-      zod: 3.24.4
 
   '@ai-sdk/ui-utils@1.1.3(zod@3.25.63)':
     dependencies:
@@ -7586,6 +7431,10 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
+  '@desideapp/mcp-sdk@0.1.1':
+    dependencies:
+      bs58: 6.0.0
+
   '@drift-labs/sdk@2.108.0-beta.6(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@coral-xyz/anchor': 0.29.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.6.3)(utf-8-validate@5.0.10)
@@ -7725,9 +7574,6 @@ snapshots:
   '@esbuild/aix-ppc64@0.23.1':
     optional: true
 
-  '@esbuild/aix-ppc64@0.25.1':
-    optional: true
-
   '@esbuild/aix-ppc64@0.25.2':
     optional: true
 
@@ -7735,9 +7581,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.23.1':
-    optional: true
-
-  '@esbuild/android-arm64@0.25.1':
     optional: true
 
   '@esbuild/android-arm64@0.25.2':
@@ -7749,9 +7592,6 @@ snapshots:
   '@esbuild/android-arm@0.23.1':
     optional: true
 
-  '@esbuild/android-arm@0.25.1':
-    optional: true
-
   '@esbuild/android-arm@0.25.2':
     optional: true
 
@@ -7759,9 +7599,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.23.1':
-    optional: true
-
-  '@esbuild/android-x64@0.25.1':
     optional: true
 
   '@esbuild/android-x64@0.25.2':
@@ -7773,9 +7610,6 @@ snapshots:
   '@esbuild/darwin-arm64@0.23.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.1':
-    optional: true
-
   '@esbuild/darwin-arm64@0.25.2':
     optional: true
 
@@ -7783,9 +7617,6 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.23.1':
-    optional: true
-
-  '@esbuild/darwin-x64@0.25.1':
     optional: true
 
   '@esbuild/darwin-x64@0.25.2':
@@ -7797,9 +7628,6 @@ snapshots:
   '@esbuild/freebsd-arm64@0.23.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.1':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.25.2':
     optional: true
 
@@ -7807,9 +7635,6 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.23.1':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.25.1':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.2':
@@ -7821,9 +7646,6 @@ snapshots:
   '@esbuild/linux-arm64@0.23.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.1':
-    optional: true
-
   '@esbuild/linux-arm64@0.25.2':
     optional: true
 
@@ -7831,9 +7653,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.23.1':
-    optional: true
-
-  '@esbuild/linux-arm@0.25.1':
     optional: true
 
   '@esbuild/linux-arm@0.25.2':
@@ -7845,9 +7664,6 @@ snapshots:
   '@esbuild/linux-ia32@0.23.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.1':
-    optional: true
-
   '@esbuild/linux-ia32@0.25.2':
     optional: true
 
@@ -7855,9 +7671,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.23.1':
-    optional: true
-
-  '@esbuild/linux-loong64@0.25.1':
     optional: true
 
   '@esbuild/linux-loong64@0.25.2':
@@ -7869,9 +7682,6 @@ snapshots:
   '@esbuild/linux-mips64el@0.23.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.1':
-    optional: true
-
   '@esbuild/linux-mips64el@0.25.2':
     optional: true
 
@@ -7879,9 +7689,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.23.1':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.25.1':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.2':
@@ -7893,9 +7700,6 @@ snapshots:
   '@esbuild/linux-riscv64@0.23.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.1':
-    optional: true
-
   '@esbuild/linux-riscv64@0.25.2':
     optional: true
 
@@ -7903,9 +7707,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.23.1':
-    optional: true
-
-  '@esbuild/linux-s390x@0.25.1':
     optional: true
 
   '@esbuild/linux-s390x@0.25.2':
@@ -7917,16 +7718,10 @@ snapshots:
   '@esbuild/linux-x64@0.23.1':
     optional: true
 
-  '@esbuild/linux-x64@0.25.1':
-    optional: true
-
   '@esbuild/linux-x64@0.25.2':
     optional: true
 
   '@esbuild/linux-x64@0.25.4':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.25.1':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.2':
@@ -7938,9 +7733,6 @@ snapshots:
   '@esbuild/netbsd-x64@0.23.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.1':
-    optional: true
-
   '@esbuild/netbsd-x64@0.25.2':
     optional: true
 
@@ -7948,9 +7740,6 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.23.1':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.25.1':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.2':
@@ -7962,9 +7751,6 @@ snapshots:
   '@esbuild/openbsd-x64@0.23.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.1':
-    optional: true
-
   '@esbuild/openbsd-x64@0.25.2':
     optional: true
 
@@ -7972,9 +7758,6 @@ snapshots:
     optional: true
 
   '@esbuild/sunos-x64@0.23.1':
-    optional: true
-
-  '@esbuild/sunos-x64@0.25.1':
     optional: true
 
   '@esbuild/sunos-x64@0.25.2':
@@ -7986,9 +7769,6 @@ snapshots:
   '@esbuild/win32-arm64@0.23.1':
     optional: true
 
-  '@esbuild/win32-arm64@0.25.1':
-    optional: true
-
   '@esbuild/win32-arm64@0.25.2':
     optional: true
 
@@ -7998,9 +7778,6 @@ snapshots:
   '@esbuild/win32-ia32@0.23.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.1':
-    optional: true
-
   '@esbuild/win32-ia32@0.25.2':
     optional: true
 
@@ -8008,9 +7785,6 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.23.1':
-    optional: true
-
-  '@esbuild/win32-x64@0.25.1':
     optional: true
 
   '@esbuild/win32-x64@0.25.2':
@@ -8554,14 +8328,14 @@ snapshots:
 
   '@jup-ag/api@6.0.39': {}
 
-  '@langchain/core@0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1))':
+  '@langchain/core@0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.19
-      langsmith: 0.3.15(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1))
+      langsmith: 0.3.15(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -8571,14 +8345,14 @@ snapshots:
     transitivePeerDependencies:
       - openai
 
-  '@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4))':
+  '@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.19
-      langsmith: 0.3.15(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4))
+      langsmith: 0.3.15(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -8588,40 +8362,40 @@ snapshots:
     transitivePeerDependencies:
       - openai
 
-  '@langchain/langgraph-checkpoint@0.0.17(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))':
+  '@langchain/langgraph-checkpoint@0.0.17(@langchain/core@0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))':
     dependencies:
-      '@langchain/core': 0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4))
+      '@langchain/core': 0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63))
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@0.0.70(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))(react@19.0.0)':
+  '@langchain/langgraph-sdk@0.0.70(@langchain/core@0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))(react@19.0.0)':
     dependencies:
       '@types/json-schema': 7.0.15
       p-queue: 6.6.2
       p-retry: 4.6.2
       uuid: 9.0.1
     optionalDependencies:
-      '@langchain/core': 0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4))
+      '@langchain/core': 0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63))
       react: 19.0.0
 
-  '@langchain/langgraph@0.2.67(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))(react@19.0.0)(zod-to-json-schema@3.24.1(zod@3.24.4))':
+  '@langchain/langgraph@0.2.67(@langchain/core@0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))(react@19.0.0)(zod-to-json-schema@3.24.1(zod@3.25.63))':
     dependencies:
-      '@langchain/core': 0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4))
-      '@langchain/langgraph-checkpoint': 0.0.17(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))
-      '@langchain/langgraph-sdk': 0.0.70(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))(react@19.0.0)
+      '@langchain/core': 0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63))
+      '@langchain/langgraph-checkpoint': 0.0.17(@langchain/core@0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))
+      '@langchain/langgraph-sdk': 0.0.70(@langchain/core@0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))(react@19.0.0)
       uuid: 10.0.0
-      zod: 3.24.4
+      zod: 3.25.63
     optionalDependencies:
-      zod-to-json-schema: 3.24.1(zod@3.24.4)
+      zod-to-json-schema: 3.24.1(zod@3.25.63)
     transitivePeerDependencies:
       - react
 
-  '@langchain/openai@0.5.7(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))(encoding@0.1.13)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@langchain/openai@0.5.7(@langchain/core@0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))(encoding@0.1.13)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4))
+      '@langchain/core': 0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63))
       js-tiktoken: 1.0.19
-      openai: 4.93.0(encoding@0.1.13)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
-      zod: 3.24.4
-      zod-to-json-schema: 3.24.1(zod@3.24.4)
+      openai: 4.93.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
+      zod: 3.25.63
+      zod-to-json-schema: 3.24.1(zod@3.25.63)
     transitivePeerDependencies:
       - encoding
       - ws
@@ -8901,7 +8675,7 @@ snapshots:
     dependencies:
       ansicolors: 0.3.2
       assert: 2.1.0
-      bn.js: 5.2.1
+      bn.js: 5.2.2
       debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
@@ -9605,14 +9379,14 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@openai/agents-core@0.0.7(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)':
+  '@openai/agents-core@0.0.7(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)':
     dependencies:
       '@openai/zod': zod@3.25.63
       debug: 4.4.0
-      openai: 5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
+      openai: 5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.12.1
-      zod: 3.24.1
+      zod: 3.25.63
     transitivePeerDependencies:
       - supports-color
       - ws
@@ -9629,35 +9403,35 @@ snapshots:
       - supports-color
       - ws
 
-  '@openai/agents-core@0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)':
+  '@openai/agents-core@0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)':
     dependencies:
       '@openai/zod': zod@3.25.63
       debug: 4.4.0
-      openai: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+      openai: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.12.1
-      zod: 3.24.4
+      zod: 3.25.63
     transitivePeerDependencies:
       - supports-color
       - ws
 
-  '@openai/agents-openai@0.0.7(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)':
+  '@openai/agents-openai@0.0.7(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)':
     dependencies:
-      '@openai/agents-core': 0.0.7(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
+      '@openai/agents-core': 0.0.7(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
       '@openai/zod': zod@3.25.63
       debug: 4.4.0
-      openai: 5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
+      openai: 5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
     transitivePeerDependencies:
       - supports-color
       - ws
       - zod
 
-  '@openai/agents-openai@0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)':
+  '@openai/agents-openai@0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)':
     dependencies:
-      '@openai/agents-core': 0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+      '@openai/agents-core': 0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
       '@openai/zod': zod@3.25.63
       debug: 4.4.0
-      openai: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+      openai: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
     transitivePeerDependencies:
       - supports-color
       - ws
@@ -9676,9 +9450,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@openai/agents-realtime@0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(zod@3.24.4)':
+  '@openai/agents-realtime@0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(zod@3.25.63)':
     dependencies:
-      '@openai/agents-core': 0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+      '@openai/agents-core': 0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
       '@openai/zod': zod@3.25.63
       '@types/ws': 8.18.1
       debug: 4.4.0
@@ -9689,13 +9463,13 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@openai/agents@0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)':
+  '@openai/agents@0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)':
     dependencies:
-      '@openai/agents-core': 0.0.7(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
-      '@openai/agents-openai': 0.0.7(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
-      '@openai/agents-realtime': 0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(zod@3.24.1)
+      '@openai/agents-core': 0.0.7(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
+      '@openai/agents-openai': 0.0.7(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
+      '@openai/agents-realtime': 0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(zod@3.25.63)
       debug: 4.4.0
-      openai: 5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
+      openai: 5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -9703,13 +9477,13 @@ snapshots:
       - ws
       - zod
 
-  '@openai/agents@0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)':
+  '@openai/agents@0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)':
     dependencies:
-      '@openai/agents-core': 0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
-      '@openai/agents-openai': 0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
-      '@openai/agents-realtime': 0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(zod@3.24.4)
+      '@openai/agents-core': 0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
+      '@openai/agents-openai': 0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
+      '@openai/agents-realtime': 0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(zod@3.24.1)
       debug: 4.4.0
-      openai: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+      openai: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -10024,7 +9798,7 @@ snapshots:
   '@pythnetwork/pyth-solana-receiver@0.7.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.6.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@coral-xyz/anchor': 0.29.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.6.3)(utf-8-validate@5.0.10)
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.7.2
       '@pythnetwork/price-service-sdk': 1.7.1
       '@pythnetwork/solana-utils': 0.4.3(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.6.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.6.3)(utf-8-validate@5.0.10)
@@ -10037,7 +9811,7 @@ snapshots:
   '@pythnetwork/pyth-solana-receiver@0.7.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@coral-xyz/anchor': 0.29.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.7.2
       '@pythnetwork/price-service-sdk': 1.7.1
       '@pythnetwork/solana-utils': 0.4.3(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
@@ -11150,7 +10924,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.27.1
       '@noble/curves': 1.8.2
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.7.2
       '@solana/buffer-layout': 4.0.1
       agentkeepalive: 4.6.0
       bigint-buffer: 1.1.5
@@ -11172,7 +10946,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.27.1
       '@noble/curves': 1.8.2
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.7.2
       '@solana/buffer-layout': 4.0.1
       agentkeepalive: 4.6.0
       bigint-buffer: 1.1.5
@@ -11855,18 +11629,6 @@ snapshots:
       react: 19.0.0
       zod: 3.24.1
 
-  ai@4.1.5(react@19.0.0)(zod@3.24.4):
-    dependencies:
-      '@ai-sdk/provider': 1.0.6
-      '@ai-sdk/provider-utils': 2.1.2(zod@3.24.4)
-      '@ai-sdk/react': 1.1.3(react@19.0.0)(zod@3.24.4)
-      '@ai-sdk/ui-utils': 1.1.3(zod@3.24.4)
-      '@opentelemetry/api': 1.9.0
-      jsondiffpatch: 0.6.0
-    optionalDependencies:
-      react: 19.0.0
-      zod: 3.24.4
-
   ai@4.1.5(react@19.0.0)(zod@3.25.63):
     dependencies:
       '@ai-sdk/provider': 1.0.6
@@ -12257,7 +12019,7 @@ snapshots:
 
   borsh@0.7.0:
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 5.2.2
       bs58: 4.0.1
       text-encoding-utf-8: 1.0.2
 
@@ -12328,9 +12090,9 @@ snapshots:
       node-gyp-build: 4.8.4
     optional: true
 
-  bundle-require@5.1.0(esbuild@0.25.1):
+  bundle-require@5.1.0(esbuild@0.25.4):
     dependencies:
-      esbuild: 0.25.1
+      esbuild: 0.25.4
       load-tsconfig: 0.2.5
 
   bytes@3.1.2: {}
@@ -12794,34 +12556,6 @@ snapshots:
       '@esbuild/win32-ia32': 0.23.1
       '@esbuild/win32-x64': 0.23.1
 
-  esbuild@0.25.1:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.1
-      '@esbuild/android-arm': 0.25.1
-      '@esbuild/android-arm64': 0.25.1
-      '@esbuild/android-x64': 0.25.1
-      '@esbuild/darwin-arm64': 0.25.1
-      '@esbuild/darwin-x64': 0.25.1
-      '@esbuild/freebsd-arm64': 0.25.1
-      '@esbuild/freebsd-x64': 0.25.1
-      '@esbuild/linux-arm': 0.25.1
-      '@esbuild/linux-arm64': 0.25.1
-      '@esbuild/linux-ia32': 0.25.1
-      '@esbuild/linux-loong64': 0.25.1
-      '@esbuild/linux-mips64el': 0.25.1
-      '@esbuild/linux-ppc64': 0.25.1
-      '@esbuild/linux-riscv64': 0.25.1
-      '@esbuild/linux-s390x': 0.25.1
-      '@esbuild/linux-x64': 0.25.1
-      '@esbuild/netbsd-arm64': 0.25.1
-      '@esbuild/netbsd-x64': 0.25.1
-      '@esbuild/openbsd-arm64': 0.25.1
-      '@esbuild/openbsd-x64': 0.25.1
-      '@esbuild/sunos-x64': 0.25.1
-      '@esbuild/win32-arm64': 0.25.1
-      '@esbuild/win32-ia32': 0.25.1
-      '@esbuild/win32-x64': 0.25.1
-
   esbuild@0.25.2:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.2
@@ -12877,7 +12611,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.4
       '@esbuild/win32-ia32': 0.25.4
       '@esbuild/win32-x64': 0.25.4
-    optional: true
 
   escalade@3.2.0: {}
 
@@ -13996,7 +13729,7 @@ snapshots:
 
   keccak256@1.0.6:
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 5.2.2
       buffer: 6.0.3
       keccak: 3.0.4
 
@@ -14010,7 +13743,7 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  langsmith@0.3.15(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)):
+  langsmith@0.3.15(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -14020,9 +13753,9 @@ snapshots:
       semver: 7.7.1
       uuid: 10.0.0
     optionalDependencies:
-      openai: 5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
+      openai: 5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
 
-  langsmith@0.3.15(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)):
+  langsmith@0.3.15(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -14032,7 +13765,7 @@ snapshots:
       semver: 7.7.1
       uuid: 10.0.0
     optionalDependencies:
-      openai: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+      openai: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
 
   lazy-ass@1.6.0: {}
 
@@ -14456,7 +14189,7 @@ snapshots:
       regex: 5.1.1
       regex-recursion: 5.1.1
 
-  openai@4.93.0(encoding@0.1.13)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4):
+  openai@4.93.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63):
     dependencies:
       '@types/node': 18.19.74
       '@types/node-fetch': 2.6.12
@@ -14466,25 +14199,25 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0(encoding@0.1.13)
     optionalDependencies:
-      ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      zod: 3.24.4
+      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      zod: 3.25.63
     transitivePeerDependencies:
       - encoding
 
-  openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1):
+  openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63):
     optionalDependencies:
       ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      zod: 3.24.1
+      zod: 3.25.63
 
   openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1):
     optionalDependencies:
       ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       zod: 3.24.1
 
-  openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4):
+  openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63):
     optionalDependencies:
       ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      zod: 3.24.4
+      zod: 3.25.63
 
   optionator@0.9.4:
     dependencies:
@@ -15592,12 +15325,12 @@ snapshots:
 
   tsup@8.4.0(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.7.1):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.25.1)
+      bundle-require: 5.1.0(esbuild@0.25.4)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.0
-      esbuild: 0.25.1
+      esbuild: 0.25.4
       joycon: 3.1.1
       picocolors: 1.1.1
       postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.2)(yaml@2.7.1)
@@ -15619,12 +15352,12 @@ snapshots:
 
   tsup@8.4.0(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.25.1)
+      bundle-require: 5.1.0(esbuild@0.25.4)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.0
-      esbuild: 0.25.1
+      esbuild: 0.25.4
       joycon: 3.1.1
       picocolors: 1.1.1
       postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(yaml@2.7.1)
@@ -16136,7 +15869,7 @@ snapshots:
       util: 0.12.5
       web3-errors: 1.3.1
       web3-types: 1.10.0
-      zod: 3.24.4
+      zod: 3.25.63
 
   web3@4.16.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.1):
     dependencies:


### PR DESCRIPTION
## Summary

This PR adds a new Solana Agent Kit plugin for Deside messaging.

It introduces `@solana-agent-kit/plugin-messaging`, backed by the published shared SDK `@desideapp/mcp-sdk`.

## What’s included

- New plugin package: `@solana-agent-kit/plugin-messaging`
- Solana wallet-based auth against Deside MCP
- Methods and actions for:
  - `sendMessage`
  - `readMessages`
  - `markRead`
  - `listConversations`
  - `getUserInfo`
  - `getMyIdentity`
  - `searchAgents`

## External dependency

This plugin uses the published Deside MCP SDK:

- npm: `@desideapp/mcp-sdk`
- repo: https://github.com/DesideApp/mcp-sdk

## Validation

Validated against the production MCP endpoint:

- `https://mcp.deside.io/mcp`

Checks completed:

- `pnpm --filter @solana-agent-kit/plugin-messaging build`
- `pnpm exec tsc --project packages/plugin-messaging/tsconfig.json --noEmit --pretty false`
- production smoke covering:
  - auth/session bootstrap
  - identity
  - conversations
  - send message

Latest production smoke result:
- `sendMessage` -> `status = delivered`, `seq = 14`

## Notes

- The plugin is a thin adapter over `@desideapp/mcp-sdk`
- The typed build issue was resolved by narrowing the plugin’s local type boundary instead of typing against the full root package surface
