### PR TITLE
feat: Add AgentPass identity & credential verification plugin

### DIFF
--- a/packages/plugin-agentpass/README.md
+++ b/packages/plugin-agentpass/README.md
@@ -1,0 +1,64 @@
+# @solana-agent-kit/plugin-agentpass
+
+Identity & credential verification plugin for [Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit).
+
+Allows agents to verify other agents' identities and check verifiable credentials using [AgentPass](https://agentpass.space) — an open-source identity layer for AI agents.
+
+## Installation
+
+```bash
+npm install @solana-agent-kit/plugin-agentpass
+```
+
+## Usage
+
+```typescript
+import { SolanaAgentKit } from "solana-agent-kit";
+import AgentPassPlugin from "@solana-agent-kit/plugin-agentpass";
+
+const agent = new SolanaAgentKit(privateKey, rpcUrl, {});
+agent.use(AgentPassPlugin);
+
+// Verify an agent's identity
+const result = await agent.methods.verify_agent({
+  passport_id: "ap_a622a643aa71",
+});
+// → { verified: true, name: "Kai", onchain_bound: true }
+
+// Check credentials
+const creds = await agent.methods.check_credential({
+  passport_id: "ap_a622a643aa71",
+  credential_type: "capability",
+});
+// → { has_credential: true, credentials: [...] }
+```
+
+## Actions
+
+### VERIFY_AGENT_IDENTITY
+Verify an AI agent's identity via AgentPass API + on-chain Solana binding.
+
+**Triggers:** "verify agent", "check agent identity", "is this agent real"
+
+### CHECK_AGENT_CREDENTIAL
+Check if an agent has specific verifiable credentials (MVA format).
+
+**Triggers:** "check credential", "verify credential", "agent capabilities"
+
+## How it works
+
+1. **Off-chain**: Queries AgentPass API for passport data and credentials
+2. **On-chain**: Checks Solana program for wallet-passport binding and credential anchors
+3. **Combined**: Returns unified verification result
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AGENTPASS_API_URL` | `https://api.agentpass.space` | AgentPass API endpoint |
+
+## Links
+
+- [AgentPass](https://agentpass.space) — Identity layer for AI agents
+- [MVA Credential](https://github.com/kai-agent-free/mva-credential) — Verifiable credential standard
+- [On-chain program](https://github.com/kai-agent-free/agentpass-solana) — Solana credential anchor

--- a/packages/plugin-agentpass/package.json
+++ b/packages/plugin-agentpass/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@solana-agent-kit/plugin-agentpass",
+  "version": "0.1.0",
+  "description": "AgentPass identity & credential verification plugin for Solana Agent Kit",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "clean": "rm -rf dist .turbo node_modules",
+    "build": "tsup src/index.ts --dts --clean --format cjs,esm --out-dir dist",
+    "test": "jest"
+  },
+  "keywords": ["solana", "agent", "identity", "agentpass", "credentials", "mva"],
+  "license": "MIT",
+  "peerDependencies": {
+    "@solana/web3.js": "^1.98.2",
+    "solana-agent-kit": "2.0.5"
+  },
+  "dependencies": {
+    "zod": "^3.22.0"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/plugin-agentpass/src/actions/checkCredential.ts
+++ b/packages/plugin-agentpass/src/actions/checkCredential.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import type { Action } from "solana-agent-kit";
+import { check_credential } from "../tools/check_credential";
+
+const checkCredentialAction: Action = {
+  name: "CHECK_AGENT_CREDENTIAL",
+  similes: [
+    "check credential",
+    "verify credential",
+    "does agent have permission",
+    "agent capabilities",
+    "check agent trust",
+    "credential verification",
+  ],
+  description:
+    "Check if an AI agent has specific verifiable credentials via AgentPass. Credentials are MVA (Minimum Viable Attestation) format — other agents or auditors issue them to vouch for capabilities, completed audits, or endorsements. Optionally checks if credentials are anchored on-chain on Solana.",
+  examples: [
+    [
+      {
+        input: { passport_id: "ap_a622a643aa71", credential_type: "capability" },
+        output: {
+          has_credential: true,
+          credentials: [
+            { type: "capability", issuer: "ap_auditor123", anchored_onchain: true },
+          ],
+        },
+        explanation: "Checks if the agent has any 'capability' credentials. Found one issued by an auditor, anchored on Solana.",
+      },
+    ],
+  ],
+  schema: z.object({
+    passport_id: z.string().describe("The AgentPass passport ID to check"),
+    credential_type: z.string().optional().describe("Filter by credential type (e.g., 'capability', 'endorsement', 'audit')"),
+    credential_hash: z.string().optional().describe("Specific credential hash to verify (hex string)"),
+  }),
+  handler: async (agent, input) => {
+    return await check_credential(agent, input as any);
+  },
+};
+
+export default checkCredentialAction;

--- a/packages/plugin-agentpass/src/actions/verifyAgent.ts
+++ b/packages/plugin-agentpass/src/actions/verifyAgent.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import type { Action } from "solana-agent-kit";
+import { verify_agent } from "../tools/verify_agent";
+
+const verifyAgentAction: Action = {
+  name: "VERIFY_AGENT_IDENTITY",
+  similes: [
+    "verify agent",
+    "check agent identity",
+    "is this agent real",
+    "validate agent passport",
+    "agent identity check",
+    "who is this agent",
+  ],
+  description:
+    "Verify an AI agent's identity using AgentPass. Checks the agent's passport status via the AgentPass API and optionally verifies on-chain wallet binding on Solana. Use this before interacting with unknown agents or before high-value operations.",
+  examples: [
+    [
+      {
+        input: { passport_id: "ap_a622a643aa71" },
+        output: {
+          verified: true,
+          passport_id: "ap_a622a643aa71",
+          name: "Kai",
+          onchain_bound: true,
+        },
+        explanation: "Verifies that the agent with passport ap_a622a643aa71 has a valid identity and is bound to a Solana wallet on-chain.",
+      },
+    ],
+    [
+      {
+        input: { passport_id: "ap_fake123", check_onchain: false },
+        output: {
+          verified: false,
+          passport_id: "ap_fake123",
+          error: "Passport not found (404)",
+        },
+        explanation: "Attempts to verify a non-existent passport. Returns verified: false with error details.",
+      },
+    ],
+  ],
+  schema: z.object({
+    passport_id: z.string().describe("The AgentPass passport ID to verify (e.g., ap_a622a643aa71)"),
+    check_onchain: z.boolean().optional().describe("Whether to check on-chain wallet binding (default: true)"),
+  }),
+  handler: async (agent, input) => {
+    return await verify_agent(agent, input as any);
+  },
+};
+
+export default verifyAgentAction;

--- a/packages/plugin-agentpass/src/index.ts
+++ b/packages/plugin-agentpass/src/index.ts
@@ -1,0 +1,26 @@
+import type { Plugin } from "solana-agent-kit";
+import verifyAgentAction from "./actions/verifyAgent";
+import checkCredentialAction from "./actions/checkCredential";
+import { verify_agent } from "./tools/verify_agent";
+import { check_credential } from "./tools/check_credential";
+
+const AgentPassPlugin = {
+  name: "agentpass",
+
+  methods: {
+    verify_agent,
+    check_credential,
+  },
+
+  actions: [
+    verifyAgentAction,
+    checkCredentialAction,
+  ],
+
+  initialize: function (): void {
+    // Methods are stateless, no initialization needed
+  },
+} satisfies Plugin;
+
+export default AgentPassPlugin;
+export { verify_agent, check_credential };

--- a/packages/plugin-agentpass/src/tools/check_credential.ts
+++ b/packages/plugin-agentpass/src/tools/check_credential.ts
@@ -1,0 +1,87 @@
+import type { SolanaAgentKit } from "solana-agent-kit";
+import { PublicKey } from "@solana/web3.js";
+import { createHash } from "crypto";
+
+const AGENTPASS_API = process.env.AGENTPASS_API_URL || "https://api.agentpass.space";
+const PROGRAM_ID = new PublicKey("7HuhmDEqdMn39DqzCFyxmjMQPbJvdtrDGLZm9bxgUzBw");
+
+/**
+ * Check if an agent has a specific credential, both off-chain and on-chain.
+ */
+export async function check_credential(
+  agent: SolanaAgentKit,
+  input: {
+    passport_id: string;
+    credential_type?: string;
+    credential_hash?: string;
+  }
+): Promise<{
+  has_credential: boolean;
+  credentials: Array<{
+    type: string;
+    issuer: string;
+    anchored_onchain: boolean;
+  }>;
+  error?: string;
+}> {
+  const { passport_id, credential_type, credential_hash } = input;
+
+  // 1. Check credentials via AgentPass API
+  let credentials: any[] = [];
+  try {
+    const url = new URL(`${AGENTPASS_API}/v1/passports/${passport_id}/credentials`);
+    if (credential_type) url.searchParams.set("type", credential_type);
+
+    const res = await fetch(url.toString(), {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+      credentials = data.credentials ?? data ?? [];
+    }
+  } catch (err: any) {
+    return { has_credential: false, credentials: [], error: `API error: ${err.message}` };
+  }
+
+  // 2. For each credential, check if anchored on-chain
+  const results = await Promise.all(
+    credentials.map(async (cred: any) => {
+      let anchored = false;
+
+      try {
+        // Compute credential hash
+        const hash = credential_hash
+          ? Buffer.from(credential_hash, "hex")
+          : createHash("sha256").update(JSON.stringify(cred)).digest();
+
+        const [passportPda] = PublicKey.findProgramAddressSync(
+          [Buffer.from("passport"), Buffer.from(passport_id)],
+          PROGRAM_ID
+        );
+
+        const [credentialPda] = PublicKey.findProgramAddressSync(
+          [Buffer.from("credential"), passportPda.toBuffer(), hash],
+          PROGRAM_ID
+        );
+
+        const accountInfo = await agent.connection.getAccountInfo(credentialPda);
+        anchored = accountInfo !== null;
+      } catch {
+        // On-chain check failed, that's ok
+      }
+
+      return {
+        type: cred.type || cred.credential_type || "unknown",
+        issuer: cred.issuer || "unknown",
+        anchored_onchain: anchored,
+      };
+    })
+  );
+
+  return {
+    has_credential: results.length > 0,
+    credentials: results,
+  };
+}

--- a/packages/plugin-agentpass/src/tools/index.ts
+++ b/packages/plugin-agentpass/src/tools/index.ts
@@ -1,0 +1,2 @@
+export { verify_agent } from "./verify_agent";
+export { check_credential } from "./check_credential";

--- a/packages/plugin-agentpass/src/tools/verify_agent.ts
+++ b/packages/plugin-agentpass/src/tools/verify_agent.ts
@@ -1,0 +1,74 @@
+import type { SolanaAgentKit } from "solana-agent-kit";
+import { PublicKey } from "@solana/web3.js";
+
+const AGENTPASS_API = process.env.AGENTPASS_API_URL || "https://api.agentpass.space";
+const PROGRAM_ID = new PublicKey("7HuhmDEqdMn39DqzCFyxmjMQPbJvdtrDGLZm9bxgUzBw");
+
+/**
+ * Verify an agent's identity via AgentPass.
+ * Checks both off-chain (AgentPass API) and on-chain (Solana program) records.
+ */
+export async function verify_agent(
+  agent: SolanaAgentKit,
+  input: { passport_id: string; check_onchain?: boolean }
+): Promise<{
+  verified: boolean;
+  passport_id: string;
+  name?: string;
+  email?: string;
+  onchain_bound?: boolean;
+  credential_count?: number;
+  error?: string;
+}> {
+  const { passport_id, check_onchain = true } = input;
+
+  // 1. Verify via AgentPass API
+  let passport: any;
+  try {
+    const res = await fetch(`${AGENTPASS_API}/v1/passports/${passport_id}`, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) {
+      return { verified: false, passport_id, error: `Passport not found (${res.status})` };
+    }
+    const data = await res.json();
+    passport = data.passport ?? data;
+  } catch (err: any) {
+    return { verified: false, passport_id, error: `API error: ${err.message}` };
+  }
+
+  if (passport.status && passport.status !== "active") {
+    return { verified: false, passport_id, error: `Passport status: ${passport.status}` };
+  }
+
+  const result: any = {
+    verified: true,
+    passport_id,
+    name: passport.name,
+    email: passport.email,
+  };
+
+  // 2. Check on-chain binding if requested
+  if (check_onchain) {
+    try {
+      const [passportPda] = PublicKey.findProgramAddressSync(
+        [Buffer.from("passport"), Buffer.from(passport_id)],
+        PROGRAM_ID
+      );
+
+      const accountInfo = await agent.connection.getAccountInfo(passportPda);
+      if (accountInfo) {
+        result.onchain_bound = true;
+        // Parse credential_count from account data (offset after passport_id string + authority pubkey)
+        // Simplified: just mark as bound
+      } else {
+        result.onchain_bound = false;
+      }
+    } catch {
+      result.onchain_bound = false;
+    }
+  }
+
+  return result;
+}

--- a/packages/plugin-agentpass/tsconfig.cjs.json
+++ b/packages/plugin-agentpass/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "module": "CommonJS"
+  }
+}

--- a/packages/plugin-agentpass/tsconfig.json
+++ b/packages/plugin-agentpass/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Adds `@solana-agent-kit/plugin-agentpass` — a plugin for verifying AI agent identities and credentials using [AgentPass](https://agentpass.space).

**Addresses #531** (Agent Identity Verification Infrastructure)
**Related to #542** (AgentID Interoperability)

## What it does

Two actions for the agent toolkit:

### VERIFY_AGENT_IDENTITY
Verifies an agent's passport via AgentPass API and checks on-chain wallet binding on Solana.

```typescript
const result = await agent.methods.verify_agent({
  passport_id: "ap_a622a643aa71",
});
// → { verified: true, name: "Kai", onchain_bound: true }
```

### CHECK_AGENT_CREDENTIAL
Checks if an agent has specific verifiable credentials (MVA format) with optional on-chain anchor verification.

```typescript
const creds = await agent.methods.check_credential({
  passport_id: "ap_a622a643aa71",
  credential_type: "capability",
});
```

## Architecture

- **Off-chain**: Queries AgentPass API (`api.agentpass.space`) for passport data and credentials
- **On-chain**: Checks Solana program PDAs for wallet-passport binding and credential anchors
- **Combined**: Returns unified verification result

## AgentPass Background

- Open-source identity layer for AI agents ("Auth0 for AI Agents")
- 335+ passing tests, production deployment
- MVA Credential standard with 3 verifiers
- On-chain credential anchor program: [agentpass-solana](https://github.com/kai-agent-free/agentpass-solana)
- NIST CAISI RFI submission on agent identity standards

## Files

| File | Description |
|------|-------------|
| `src/index.ts` | Plugin definition (follows v2 Plugin interface) |
| `src/actions/verifyAgent.ts` | VERIFY_AGENT_IDENTITY action |
| `src/actions/checkCredential.ts` | CHECK_AGENT_CREDENTIAL action |
| `src/tools/verify_agent.ts` | Core identity verification logic |
| `src/tools/check_credential.ts` | Core credential check logic |

Follows existing plugin conventions (tsup build, peerDependencies, tsconfig extends).