### PR TITLE
feat: add Lavarage — spot margin leverage trading

### DIFF
--- a/packages/plugin-defi/src/index.ts
+++ b/packages/plugin-defi/src/index.ts
@@ -227,12 +227,26 @@ import {
   lavarageGetPositionStatusAction,
   lavarageListTokensAction,
   lavarageGetMaxLeverageAction,
+  lavarageRepayAction,
+  lavarageIncreaseBorrowAction,
+  lavarageAddCollateralAction,
+  lavarageGetQuoteAction,
+  lavarageTradeHistoryAction,
   lavarageOpenPosition,
   lavarageClosePosition,
   lavarageGetPositions,
   lavarageGetPositionStatus,
   lavarageListTokens,
   lavarageGetMaxLeverage,
+  lavarageRepay,
+  lavaragePartialRepay,
+  lavarageIncreaseBorrow,
+  lavarageAddCollateral,
+  lavarageSplitPosition,
+  lavarageMergePositions,
+  lavarageGetQuote,
+  lavarageCloseQuote,
+  lavarageTradeHistory,
 } from "./lavarage";
 
 // Define and export the plugin
@@ -355,13 +369,22 @@ const DefiPlugin = {
     getChainData,
     executeSwap,
 
-    // Lavarage methods — spot margin leverage on any Solana token
+    // Lavarage methods — spot margin leverage + borrow on any Solana token
     lavarageOpenPosition,
     lavarageClosePosition,
     lavarageGetPositions,
     lavarageGetPositionStatus,
     lavarageListTokens,
     lavarageGetMaxLeverage,
+    lavarageRepay,
+    lavaragePartialRepay,
+    lavarageIncreaseBorrow,
+    lavarageAddCollateral,
+    lavarageSplitPosition,
+    lavarageMergePositions,
+    lavarageGetQuote,
+    lavarageCloseQuote,
+    lavarageTradeHistory,
   },
 
   // Combine all actions
@@ -468,13 +491,18 @@ const DefiPlugin = {
     getChainDataAction,
     executeSwapAction,
 
-    // Lavarage actions — spot margin leverage on any Solana token (up to 12x)
+    // Lavarage actions — spot margin leverage + borrow on any Solana token
     lavarageOpenPositionAction,
     lavarageClosePositionAction,
     lavarageGetPositionsAction,
     lavarageGetPositionStatusAction,
     lavarageListTokensAction,
     lavarageGetMaxLeverageAction,
+    lavarageRepayAction,
+    lavarageIncreaseBorrowAction,
+    lavarageAddCollateralAction,
+    lavarageGetQuoteAction,
+    lavarageTradeHistoryAction,
   ],
 
   // Initialize function

--- a/packages/plugin-defi/src/index.ts
+++ b/packages/plugin-defi/src/index.ts
@@ -232,6 +232,7 @@ import {
   lavarageAddCollateralAction,
   lavarageGetQuoteAction,
   lavarageTradeHistoryAction,
+  lavarageBorrowAction,
   lavarageOpenPosition,
   lavarageClosePosition,
   lavarageGetPositions,
@@ -503,6 +504,7 @@ const DefiPlugin = {
     lavarageAddCollateralAction,
     lavarageGetQuoteAction,
     lavarageTradeHistoryAction,
+    lavarageBorrowAction,
   ],
 
   // Initialize function

--- a/packages/plugin-defi/src/index.ts
+++ b/packages/plugin-defi/src/index.ts
@@ -219,6 +219,22 @@ import {
   executeSwap,
 } from "./okx/tools";
 
+// Import Lavarage actions & tools
+import {
+  lavarageOpenPositionAction,
+  lavarageClosePositionAction,
+  lavarageGetPositionsAction,
+  lavarageGetPositionStatusAction,
+  lavarageListTokensAction,
+  lavarageGetMaxLeverageAction,
+  lavarageOpenPosition,
+  lavarageClosePosition,
+  lavarageGetPositions,
+  lavarageGetPositionStatus,
+  lavarageListTokens,
+  lavarageGetMaxLeverage,
+} from "./lavarage";
+
 // Define and export the plugin
 const DefiPlugin = {
   name: "defi",
@@ -338,6 +354,14 @@ const DefiPlugin = {
     getLiquidity,
     getChainData,
     executeSwap,
+
+    // Lavarage methods — spot margin leverage on any Solana token
+    lavarageOpenPosition,
+    lavarageClosePosition,
+    lavarageGetPositions,
+    lavarageGetPositionStatus,
+    lavarageListTokens,
+    lavarageGetMaxLeverage,
   },
 
   // Combine all actions
@@ -443,6 +467,14 @@ const DefiPlugin = {
     getLiquidityAction,
     getChainDataAction,
     executeSwapAction,
+
+    // Lavarage actions — spot margin leverage on any Solana token (up to 12x)
+    lavarageOpenPositionAction,
+    lavarageClosePositionAction,
+    lavarageGetPositionsAction,
+    lavarageGetPositionStatusAction,
+    lavarageListTokensAction,
+    lavarageGetMaxLeverageAction,
   ],
 
   // Initialize function

--- a/packages/plugin-defi/src/lavarage/actions/addCollateral.ts
+++ b/packages/plugin-defi/src/lavarage/actions/addCollateral.ts
@@ -1,0 +1,28 @@
+import type { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { lavarageAddCollateral } from "../tools";
+
+export const lavarageAddCollateralAction: Action = {
+  name: "LAVARAGE_ADD_COLLATERAL",
+  similes: ["add collateral", "reduce liquidation risk", "make position safer", "add margin"],
+  description: `Add more of the base token to a position to reduce LTV and move the liquidation price further away.
+
+You must hold the base token in your wallet. For a WBTC/USDC position, you add WBTC.`,
+  examples: [[{
+    input: { positionAddress: "6vMm...", collateralAmount: "5000" },
+    output: { status: "success", signature: "3aPH..." },
+    explanation: "Add 5000 satoshis of WBTC to reduce liquidation risk.",
+  }]],
+  schema: z.object({
+    positionAddress: z.string().describe("Position address (base58)"),
+    collateralAmount: z.string().describe("Amount of base token in smallest units"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const sig = await lavarageAddCollateral(agent, input.positionAddress, input.collateralAmount);
+      return { status: "success", signature: sig };
+    } catch (e: any) {
+      return { status: "error", message: e.message };
+    }
+  },
+};

--- a/packages/plugin-defi/src/lavarage/actions/borrow.ts
+++ b/packages/plugin-defi/src/lavarage/actions/borrow.ts
@@ -1,0 +1,88 @@
+import type { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { lavarageOpenPosition } from "../tools";
+
+export const lavarageBorrowAction: Action = {
+  name: "LAVARAGE_BORROW",
+  similes: [
+    "borrow tokens",
+    "borrow against collateral",
+    "take a loan",
+    "borrow USDC",
+    "borrow SOL",
+    "get a loan on solana",
+    "borrow crypto",
+    "lend and borrow",
+  ],
+  description: `Borrow any Solana token against collateral on Lavarage. No directional bet — just access to liquidity.
+
+Examples:
+- "Borrow USDC against my SOL" — keep SOL exposure, get liquid USDC
+- "Borrow SOL against USDC" — get SOL without selling USDC
+- "Take a 2x loan on my SOL" — borrow equal to your deposit
+
+The leverage parameter controls your loan-to-value:
+- 2x = borrow equal to your collateral (50% LTV)
+- 3x = borrow 2x your collateral (67% LTV)
+
+Repay anytime with LAVARAGE_REPAY. No fixed term, no lockup.
+
+First call LAVARAGE_LIST_TOKENS to find the borrow offer, then use the offerPublicKey.`,
+  examples: [
+    [
+      {
+        input: {
+          offerPublicKey: "CfiYMFbjugNMf2SXibqLHW7JPevWQnGzHrxmspwcuXHi",
+          collateralAmount: "10000000",
+          leverage: 2,
+        },
+        output: {
+          status: "success",
+          signature: "2AYJ924L...",
+          message: "Borrowed tokens against 10M lamports collateral",
+        },
+        explanation: "Borrow USDC against 0.01 SOL collateral at 2x (50% LTV).",
+      },
+    ],
+  ],
+  schema: z.object({
+    offerPublicKey: z
+      .string()
+      .describe("Borrow offer public key — get from LAVARAGE_LIST_TOKENS"),
+    collateralAmount: z
+      .string()
+      .describe("Collateral in quote token smallest units (lamports for SOL, 1e6 for USDC)"),
+    leverage: z
+      .number()
+      .min(1.1)
+      .max(10)
+      .describe("Borrow ratio — 2x = borrow equal to collateral, 3x = borrow 2x collateral"),
+    slippageBps: z
+      .number()
+      .optional()
+      .default(50)
+      .describe("Slippage in bps (default: 50)"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      // Borrow uses the same open position flow — the offer type determines it's a borrow
+      const signature = await lavarageOpenPosition(
+        agent,
+        input.offerPublicKey,
+        input.collateralAmount,
+        input.leverage,
+        input.slippageBps,
+      );
+      return {
+        status: "success",
+        signature,
+        message: `Borrow complete! Tokens in your wallet. TX: ${signature}. Repay with LAVARAGE_REPAY.`,
+      };
+    } catch (error: any) {
+      return {
+        status: "error",
+        message: `Borrow failed: ${error.message}`,
+      };
+    }
+  },
+};

--- a/packages/plugin-defi/src/lavarage/actions/closePosition.ts
+++ b/packages/plugin-defi/src/lavarage/actions/closePosition.ts
@@ -1,0 +1,62 @@
+import type { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { lavarageClosePosition } from "../tools";
+
+export const lavarageClosePositionAction: Action = {
+  name: "LAVARAGE_CLOSE_POSITION",
+  similes: [
+    "close leverage position",
+    "close leveraged position",
+    "close margin position",
+    "close lavarage position",
+    "sell leveraged position",
+    "exit leverage trade",
+  ],
+  description: `Close a leveraged position on Lavarage. Sells the tokens, repays the borrow, returns collateral + profit (or minus loss).
+
+Get the positionAddress from LAVARAGE_GET_POSITIONS first.`,
+  examples: [
+    [
+      {
+        input: {
+          positionAddress: "6vMmSiMi6hSPJPUrkQ6fQKhCBvKnBi7P4BmSXYQ7brHm",
+        },
+        output: {
+          status: "success",
+          signature: "4RQjfHW6jEbKxzYM...",
+          message: "Position closed",
+        },
+        explanation: "Close a leveraged position and receive remaining collateral.",
+      },
+    ],
+  ],
+  schema: z.object({
+    positionAddress: z
+      .string()
+      .describe("Position account address (base58) — get from LAVARAGE_GET_POSITIONS"),
+    slippageBps: z
+      .number()
+      .optional()
+      .default(50)
+      .describe("Slippage tolerance in basis points (default: 50)"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const signature = await lavarageClosePosition(
+        agent,
+        input.positionAddress,
+        input.slippageBps,
+      );
+      return {
+        status: "success",
+        signature,
+        message: `Position closed. TX: ${signature}`,
+      };
+    } catch (error: any) {
+      return {
+        status: "error",
+        message: `Failed to close position: ${error.message}`,
+      };
+    }
+  },
+};

--- a/packages/plugin-defi/src/lavarage/actions/getMaxLeverage.ts
+++ b/packages/plugin-defi/src/lavarage/actions/getMaxLeverage.ts
@@ -1,0 +1,62 @@
+import type { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { lavarageGetMaxLeverage } from "../tools";
+
+export const lavarageGetMaxLeverageAction: Action = {
+  name: "LAVARAGE_GET_MAX_LEVERAGE",
+  similes: [
+    "max leverage",
+    "what leverage available",
+    "leverage rates",
+    "lending rates",
+    "borrowing rates for leverage",
+    "available liquidity for leverage",
+  ],
+  description: `Get max leverage, borrow APR, and available liquidity for tokens on Lavarage. Useful for finding the best offer before opening a position.
+
+Optionally filter by quote currency (SOL or USDC).`,
+  examples: [
+    [
+      {
+        input: { search: "SOL", quoteCurrency: "USDC" },
+        output: {
+          status: "success",
+          offers: [
+            {
+              symbol: "cbBTC",
+              maxLeverage: "12.610",
+              apr: "5.00",
+              quoteSymbol: "USDC",
+            },
+          ],
+        },
+        explanation: "Find max leverage and rates for BTC tokens quoted in USDC.",
+      },
+    ],
+  ],
+  schema: z.object({
+    search: z
+      .string()
+      .describe("Search by token name or symbol (e.g. 'BTC', 'SOL')"),
+    quoteCurrency: z
+      .enum(["SOL", "USDC", "all"])
+      .optional()
+      .default("all")
+      .describe("Filter by quote currency (default: all)"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const offers = await lavarageGetMaxLeverage(
+        agent,
+        input.search,
+        input.quoteCurrency,
+      );
+      return { status: "success", offers, count: offers.length };
+    } catch (error: any) {
+      return {
+        status: "error",
+        message: `Failed to get leverage info: ${error.message}`,
+      };
+    }
+  },
+};

--- a/packages/plugin-defi/src/lavarage/actions/getPositionStatus.ts
+++ b/packages/plugin-defi/src/lavarage/actions/getPositionStatus.ts
@@ -1,0 +1,57 @@
+import type { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { lavarageGetPositionStatus } from "../tools";
+
+export const lavarageGetPositionStatusAction: Action = {
+  name: "LAVARAGE_GET_POSITION_STATUS",
+  similes: [
+    "get position status",
+    "check position health",
+    "position details",
+    "position pnl",
+    "is my position safe",
+    "liquidation risk",
+  ],
+  description: `Get detailed status of a specific leveraged position — PnL, liquidation price, LTV, interest accrued, and current health.
+
+Get the positionAddress from LAVARAGE_GET_POSITIONS first.`,
+  examples: [
+    [
+      {
+        input: {
+          positionAddress: "6vMmSiMi6hSPJPUrkQ6fQKhCBvKnBi7P4BmSXYQ7brHm",
+        },
+        output: {
+          status: "success",
+          position: {
+            baseTokenSymbol: "WBTC",
+            quoteTokenSymbol: "USDC",
+            unrealizedPnlUsd: 0.42,
+            liquidationPrice: 50146.6,
+            currentLtv: 0.76,
+          },
+        },
+        explanation: "Check PnL and liquidation risk of a specific position.",
+      },
+    ],
+  ],
+  schema: z.object({
+    positionAddress: z
+      .string()
+      .describe("Position account address (base58) — get from LAVARAGE_GET_POSITIONS"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const position = await lavarageGetPositionStatus(
+        agent,
+        input.positionAddress,
+      );
+      return { status: "success", position };
+    } catch (error: any) {
+      return {
+        status: "error",
+        message: `Failed to get position: ${error.message}`,
+      };
+    }
+  },
+};

--- a/packages/plugin-defi/src/lavarage/actions/getPositions.ts
+++ b/packages/plugin-defi/src/lavarage/actions/getPositions.ts
@@ -1,0 +1,61 @@
+import type { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { lavarageGetPositions } from "../tools";
+
+export const lavarageGetPositionsAction: Action = {
+  name: "LAVARAGE_GET_POSITIONS",
+  similes: [
+    "get leverage positions",
+    "list leveraged positions",
+    "show margin positions",
+    "my lavarage positions",
+    "check open positions",
+    "show leverage trades",
+  ],
+  description: `List all leveraged positions for your wallet on Lavarage. Shows token pair, leverage, entry price, PnL, liquidation price, and more.
+
+Positions can be LONG (profit when price goes up), SHORT (profit when price goes down), or BORROW (no directional bet).`,
+  examples: [
+    [
+      {
+        input: { status: "OPEN" },
+        output: {
+          status: "success",
+          positions: [
+            {
+              address: "6vMm...",
+              side: "LONG",
+              baseTokenSymbol: "WBTC",
+              quoteTokenSymbol: "USDC",
+              leverage: "3.000",
+              unrealizedPnlUsd: 0.42,
+            },
+          ],
+        },
+        explanation: "List all open leveraged positions.",
+      },
+    ],
+  ],
+  schema: z.object({
+    status: z
+      .enum(["OPEN", "CLOSED", "ALL"])
+      .optional()
+      .default("OPEN")
+      .describe("Filter by status (default: OPEN)"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const positions = await lavarageGetPositions(agent, input.status);
+      return {
+        status: "success",
+        positions,
+        count: Array.isArray(positions) ? positions.length : 0,
+      };
+    } catch (error: any) {
+      return {
+        status: "error",
+        message: `Failed to get positions: ${error.message}`,
+      };
+    }
+  },
+};

--- a/packages/plugin-defi/src/lavarage/actions/getQuote.ts
+++ b/packages/plugin-defi/src/lavarage/actions/getQuote.ts
@@ -1,0 +1,30 @@
+import type { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { lavarageGetQuote } from "../tools";
+
+export const lavarageGetQuoteAction: Action = {
+  name: "LAVARAGE_GET_QUOTE",
+  similes: ["get leverage quote", "preview trade", "check trade cost", "estimate leverage trade"],
+  description: `Preview a leverage trade before executing. Shows expected output, price impact, and fees. Does NOT execute anything.
+
+Use the same params (offerPublicKey, collateralAmount, leverage) for LAVARAGE_OPEN_POSITION to execute.`,
+  examples: [[{
+    input: { offerPublicKey: "CfiY...", collateralAmount: "5000000", leverage: 3 },
+    output: { status: "success", quote: { outAmount: "15038", priceImpactPct: "0" } },
+    explanation: "Preview a 3x trade with 5 USDC collateral.",
+  }]],
+  schema: z.object({
+    offerPublicKey: z.string().describe("Offer public key from LAVARAGE_LIST_TOKENS"),
+    collateralAmount: z.string().describe("Collateral in quote token smallest units"),
+    leverage: z.number().min(1.1).max(12).describe("Leverage multiplier"),
+    slippageBps: z.number().optional().default(50).describe("Slippage in bps"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const quote = await lavarageGetQuote(agent, input.offerPublicKey, input.collateralAmount, input.leverage, input.slippageBps);
+      return { status: "success", quote };
+    } catch (e: any) {
+      return { status: "error", message: e.message };
+    }
+  },
+};

--- a/packages/plugin-defi/src/lavarage/actions/increaseBorrow.ts
+++ b/packages/plugin-defi/src/lavarage/actions/increaseBorrow.ts
@@ -1,0 +1,31 @@
+import type { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { lavarageIncreaseBorrow } from "../tools";
+
+export const lavarageIncreaseBorrowAction: Action = {
+  name: "LAVARAGE_INCREASE_BORROW",
+  similes: ["increase borrow", "borrow more", "increase leverage", "compound position", "add leverage"],
+  description: `Increase the borrowed amount on a Lavarage position. Two modes:
+
+- "withdraw": Borrow more quote tokens and receive them in your wallet.
+- "compound": Borrow more and swap into the base token, increasing your position size (like adding leverage).`,
+  examples: [[{
+    input: { positionAddress: "6vMm...", additionalBorrowAmount: "1000000", mode: "withdraw" },
+    output: { status: "success", signature: "2AYJ..." },
+    explanation: "Borrow 1 USDC more from the lending pool.",
+  }]],
+  schema: z.object({
+    positionAddress: z.string().describe("Position address (base58)"),
+    additionalBorrowAmount: z.string().describe("Amount to borrow in quote token smallest units"),
+    mode: z.enum(["withdraw", "compound"]).describe('"withdraw" = receive tokens, "compound" = swap into more base token'),
+    slippageBps: z.number().optional().default(50).describe("Slippage (compound mode only)"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const sig = await lavarageIncreaseBorrow(agent, input.positionAddress, input.additionalBorrowAmount, input.mode, input.slippageBps);
+      return { status: "success", signature: sig };
+    } catch (e: any) {
+      return { status: "error", message: e.message };
+    }
+  },
+};

--- a/packages/plugin-defi/src/lavarage/actions/index.ts
+++ b/packages/plugin-defi/src/lavarage/actions/index.ts
@@ -1,0 +1,6 @@
+export { lavarageOpenPositionAction } from "./openPosition";
+export { lavarageClosePositionAction } from "./closePosition";
+export { lavarageGetPositionsAction } from "./getPositions";
+export { lavarageGetPositionStatusAction } from "./getPositionStatus";
+export { lavarageListTokensAction } from "./listTokens";
+export { lavarageGetMaxLeverageAction } from "./getMaxLeverage";

--- a/packages/plugin-defi/src/lavarage/actions/index.ts
+++ b/packages/plugin-defi/src/lavarage/actions/index.ts
@@ -4,3 +4,8 @@ export { lavarageGetPositionsAction } from "./getPositions";
 export { lavarageGetPositionStatusAction } from "./getPositionStatus";
 export { lavarageListTokensAction } from "./listTokens";
 export { lavarageGetMaxLeverageAction } from "./getMaxLeverage";
+export { lavarageRepayAction } from "./repay";
+export { lavarageIncreaseBorrowAction } from "./increaseBorrow";
+export { lavarageAddCollateralAction } from "./addCollateral";
+export { lavarageGetQuoteAction } from "./getQuote";
+export { lavarageTradeHistoryAction } from "./tradeHistory";

--- a/packages/plugin-defi/src/lavarage/actions/index.ts
+++ b/packages/plugin-defi/src/lavarage/actions/index.ts
@@ -9,3 +9,4 @@ export { lavarageIncreaseBorrowAction } from "./increaseBorrow";
 export { lavarageAddCollateralAction } from "./addCollateral";
 export { lavarageGetQuoteAction } from "./getQuote";
 export { lavarageTradeHistoryAction } from "./tradeHistory";
+export { lavarageBorrowAction } from "./borrow";

--- a/packages/plugin-defi/src/lavarage/actions/listTokens.ts
+++ b/packages/plugin-defi/src/lavarage/actions/listTokens.ts
@@ -1,0 +1,54 @@
+import type { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { lavarageListTokens } from "../tools";
+
+export const lavarageListTokensAction: Action = {
+  name: "LAVARAGE_LIST_TOKENS",
+  similes: [
+    "list leverage tokens",
+    "search lavarage tokens",
+    "what tokens can I leverage",
+    "available leverage tokens",
+    "show tradeable tokens",
+    "find token for leverage",
+  ],
+  description: `Search for tokens available for leverage trading on Lavarage. Returns tokens with their best offer, current price, max leverage, and available liquidity.
+
+The offerPublicKey from the results is needed to open a position via LAVARAGE_OPEN_POSITION.`,
+  examples: [
+    [
+      {
+        input: { search: "BTC" },
+        output: {
+          status: "success",
+          tokens: [
+            {
+              symbol: "WBTC",
+              offerPublicKey: "CfiY...",
+              maxLeverage: "12.610",
+              quoteSymbol: "USDC",
+            },
+          ],
+        },
+        explanation: "Search for BTC tokens available for leverage trading.",
+      },
+    ],
+  ],
+  schema: z.object({
+    search: z
+      .string()
+      .min(1)
+      .describe("Search by token name or symbol (e.g. 'BTC', 'SOL', 'BONK')"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const tokens = await lavarageListTokens(agent, input.search);
+      return { status: "success", tokens, count: tokens.length };
+    } catch (error: any) {
+      return {
+        status: "error",
+        message: `Failed to list tokens: ${error.message}`,
+      };
+    }
+  },
+};

--- a/packages/plugin-defi/src/lavarage/actions/openPosition.ts
+++ b/packages/plugin-defi/src/lavarage/actions/openPosition.ts
@@ -1,0 +1,87 @@
+import type { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { lavarageOpenPosition } from "../tools";
+
+export const lavarageOpenPositionAction: Action = {
+  name: "LAVARAGE_OPEN_POSITION",
+  similes: [
+    "open leverage position",
+    "open leveraged long",
+    "long with leverage",
+    "open margin position",
+    "leverage trade",
+    "open lavarage position",
+    "go long with leverage",
+    "open spot margin long",
+  ],
+  description: `Open a leveraged spot margin position on Lavarage — leverage trade ANY Solana token (not just perps on major pairs).
+
+Unlike perpetual protocols (Drift, Adrena) that only support ~20 pairs, Lavarage supports 2000+ tokens including memecoins, DeFi tokens, and LSTs. Up to 12x leverage on majors, 2-5x on long-tail tokens.
+
+Deposit SOL or USDC as collateral, borrow more from lending pools, and buy the token with leverage. Your position is a real spot holding — you own the actual tokens, not a derivative.
+
+Workflow: LAVARAGE_LIST_TOKENS("BTC") → get offerPublicKey → LAVARAGE_OPEN_POSITION(offer, collateral, leverage).
+
+Collateral is in the quote token's smallest units (lamports for SOL, 1e6 for USDC).`,
+  examples: [
+    [
+      {
+        input: {
+          offerPublicKey: "CfiYMFbjugNMf2SXibqLHW7JPevWQnGzHrxmspwcuXHi",
+          collateralAmount: "5000000",
+          leverage: 3,
+        },
+        output: {
+          status: "success",
+          signature: "5z1EofNxkwitMnXK...",
+          message: "Opened 3x long position with 5 USDC collateral",
+        },
+        explanation:
+          "Open a 3x leveraged long position on WBTC with $5 USDC collateral.",
+      },
+    ],
+  ],
+  schema: z.object({
+    offerPublicKey: z
+      .string()
+      .describe(
+        "The offer/pool public key — get from LAVARAGE_LIST_TOKENS or LAVARAGE_GET_MAX_LEVERAGE",
+      ),
+    collateralAmount: z
+      .string()
+      .describe(
+        "Collateral in quote token smallest units (lamports for SOL, 1e6 units for USDC)",
+      ),
+    leverage: z
+      .number()
+      .min(1.1)
+      .max(12)
+      .describe("Leverage multiplier (e.g. 3 for 3x)"),
+    slippageBps: z
+      .number()
+      .optional()
+      .default(50)
+      .describe("Slippage tolerance in basis points (default: 50 = 0.5%)"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const signature = await lavarageOpenPosition(
+        agent,
+        input.offerPublicKey,
+        input.collateralAmount,
+        input.leverage,
+        input.slippageBps,
+      );
+      return {
+        status: "success",
+        signature,
+        message: `Opened ${input.leverage}x position. TX: ${signature}`,
+      };
+    } catch (error: any) {
+      return {
+        status: "error",
+        message: `Failed to open position: ${error.message}`,
+      };
+    }
+  },
+};

--- a/packages/plugin-defi/src/lavarage/actions/repay.ts
+++ b/packages/plugin-defi/src/lavarage/actions/repay.ts
@@ -1,0 +1,27 @@
+import type { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { lavarageRepay } from "../tools";
+
+export const lavarageRepayAction: Action = {
+  name: "LAVARAGE_REPAY",
+  similes: ["repay borrow", "repay loan", "close borrow position", "pay back loan"],
+  description: `Fully repay a borrow position on Lavarage — return borrowed tokens to the lender and reclaim collateral.
+
+Get positionAddress from LAVARAGE_GET_POSITIONS (filter for BORROW positions).`,
+  examples: [[{
+    input: { positionAddress: "GGps6Y..." },
+    output: { status: "success", signature: "268wtn..." },
+    explanation: "Repay a borrow position and reclaim collateral.",
+  }]],
+  schema: z.object({
+    positionAddress: z.string().describe("Borrow position address (base58)"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const sig = await lavarageRepay(agent, input.positionAddress);
+      return { status: "success", signature: sig };
+    } catch (e: any) {
+      return { status: "error", message: e.message };
+    }
+  },
+};

--- a/packages/plugin-defi/src/lavarage/actions/tradeHistory.ts
+++ b/packages/plugin-defi/src/lavarage/actions/tradeHistory.ts
@@ -1,0 +1,25 @@
+import type { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { lavarageTradeHistory } from "../tools";
+
+export const lavarageTradeHistoryAction: Action = {
+  name: "LAVARAGE_TRADE_HISTORY",
+  similes: ["trade history", "past trades", "trading history", "show my trades"],
+  description: `Get your trade history — every open, close, liquidation, and repay event with PnL, fees, and TX signatures.`,
+  examples: [[{
+    input: { limit: 5 },
+    output: { status: "success", total: 100, events: [] },
+    explanation: "Get last 5 trade events.",
+  }]],
+  schema: z.object({
+    limit: z.number().optional().default(20).describe("Max events to return"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const result = await lavarageTradeHistory(agent, input.limit);
+      return { status: "success", ...result };
+    } catch (e: any) {
+      return { status: "error", message: e.message };
+    }
+  },
+};

--- a/packages/plugin-defi/src/lavarage/index.ts
+++ b/packages/plugin-defi/src/lavarage/index.ts
@@ -1,0 +1,17 @@
+export {
+  lavarageOpenPositionAction,
+  lavarageClosePositionAction,
+  lavarageGetPositionsAction,
+  lavarageGetPositionStatusAction,
+  lavarageListTokensAction,
+  lavarageGetMaxLeverageAction,
+} from "./actions";
+
+export {
+  lavarageOpenPosition,
+  lavarageClosePosition,
+  lavarageGetPositions,
+  lavarageGetPositionStatus,
+  lavarageListTokens,
+  lavarageGetMaxLeverage,
+} from "./tools";

--- a/packages/plugin-defi/src/lavarage/index.ts
+++ b/packages/plugin-defi/src/lavarage/index.ts
@@ -5,6 +5,11 @@ export {
   lavarageGetPositionStatusAction,
   lavarageListTokensAction,
   lavarageGetMaxLeverageAction,
+  lavarageRepayAction,
+  lavarageIncreaseBorrowAction,
+  lavarageAddCollateralAction,
+  lavarageGetQuoteAction,
+  lavarageTradeHistoryAction,
 } from "./actions";
 
 export {
@@ -14,4 +19,13 @@ export {
   lavarageGetPositionStatus,
   lavarageListTokens,
   lavarageGetMaxLeverage,
+  lavarageRepay,
+  lavaragePartialRepay,
+  lavarageIncreaseBorrow,
+  lavarageAddCollateral,
+  lavarageSplitPosition,
+  lavarageMergePositions,
+  lavarageGetQuote,
+  lavarageCloseQuote,
+  lavarageTradeHistory,
 } from "./tools";

--- a/packages/plugin-defi/src/lavarage/index.ts
+++ b/packages/plugin-defi/src/lavarage/index.ts
@@ -10,6 +10,7 @@ export {
   lavarageAddCollateralAction,
   lavarageGetQuoteAction,
   lavarageTradeHistoryAction,
+  lavarageBorrowAction,
 } from "./actions";
 
 export {

--- a/packages/plugin-defi/src/lavarage/tools/index.ts
+++ b/packages/plugin-defi/src/lavarage/tools/index.ts
@@ -1,8 +1,23 @@
 export {
+  // Market data
   lavarageListTokens,
   lavarageGetMaxLeverage,
+  lavarageGetQuote,
+  lavarageCloseQuote,
+  // Trading
   lavarageOpenPosition,
   lavarageClosePosition,
+  // Positions
   lavarageGetPositions,
   lavarageGetPositionStatus,
+  // Borrow
+  lavarageRepay,
+  lavaragePartialRepay,
+  lavarageIncreaseBorrow,
+  // Position management
+  lavarageAddCollateral,
+  lavarageSplitPosition,
+  lavarageMergePositions,
+  // History
+  lavarageTradeHistory,
 } from "./lavarage";

--- a/packages/plugin-defi/src/lavarage/tools/index.ts
+++ b/packages/plugin-defi/src/lavarage/tools/index.ts
@@ -1,0 +1,8 @@
+export {
+  lavarageListTokens,
+  lavarageGetMaxLeverage,
+  lavarageOpenPosition,
+  lavarageClosePosition,
+  lavarageGetPositions,
+  lavarageGetPositionStatus,
+} from "./lavarage";

--- a/packages/plugin-defi/src/lavarage/tools/lavarage.ts
+++ b/packages/plugin-defi/src/lavarage/tools/lavarage.ts
@@ -1,5 +1,5 @@
 import { type SolanaAgentKit, signOrSendTX } from "solana-agent-kit";
-import { VersionedTransaction, PublicKey } from "@solana/web3.js";
+import { VersionedTransaction } from "@solana/web3.js";
 import bs58 from "bs58";
 
 const API_BASE = "https://api.lavarage.xyz/api/v1";
@@ -26,9 +26,30 @@ async function lavaApi(
   return data;
 }
 
-/**
- * List available tokens for leverage trading with best offers.
- */
+async function buildSignAndSend(
+  agent: SolanaAgentKit,
+  txBase58: string,
+): Promise<string> {
+  const txBuffer = Buffer.from(bs58.decode(txBase58));
+  const tx = VersionedTransaction.deserialize(txBuffer);
+  return await signOrSendTX(agent, tx);
+}
+
+async function getTipAndBuild(
+  agent: SolanaAgentKit,
+  path: string,
+  body: any,
+): Promise<string> {
+  const { tipLamports } = await lavaApi("/bundle/tip");
+  const result = await lavaApi(path, {
+    method: "POST",
+    body: { ...body, astralaneTipLamports: tipLamports },
+  });
+  return await buildSignAndSend(agent, result.transaction);
+}
+
+// ── Market Data ──
+
 export async function lavarageListTokens(
   _agent: SolanaAgentKit,
   search: string,
@@ -44,9 +65,8 @@ export async function lavarageListTokens(
     if (
       !existing ||
       Number(o.availableForOpen ?? 0) > Number(existing.availableForOpen ?? 0)
-    ) {
+    )
       seen.set(mint, o);
-    }
   }
   return Array.from(seen.values())
     .slice(0, 20)
@@ -63,19 +83,12 @@ export async function lavarageListTokens(
     }));
 }
 
-/**
- * Get max leverage and available liquidity for a token.
- */
 export async function lavarageGetMaxLeverage(
   _agent: SolanaAgentKit,
   search: string,
   quoteCurrency?: string,
 ): Promise<any[]> {
-  const params = new URLSearchParams({
-    includeTokens: "true",
-    search,
-    limit: "10",
-  });
+  const params = new URLSearchParams({ includeTokens: "true", search, limit: "10" });
   if (quoteCurrency && quoteCurrency !== "all") {
     const quoteMap: Record<string, string> = {
       SOL: "So11111111111111111111111111111111111111112",
@@ -95,9 +108,8 @@ export async function lavarageGetMaxLeverage(
   }));
 }
 
-/**
- * Open a leveraged position. Builds TX via API, signs with agent wallet, submits.
- */
+// ── Trading ──
+
 export async function lavarageOpenPosition(
   agent: SolanaAgentKit,
   offerPublicKey: string,
@@ -105,61 +117,29 @@ export async function lavarageOpenPosition(
   leverage: number,
   slippageBps = 50,
 ): Promise<string> {
-  const wallet = agent.wallet.publicKey.toBase58();
-
-  // Get tip for MEV protection
-  const { tipLamports } = await lavaApi("/bundle/tip");
-
-  // Build the transaction
-  const result = await lavaApi("/positions/open", {
-    method: "POST",
-    body: {
-      offerPublicKey,
-      userPublicKey: wallet,
-      collateralAmount,
-      leverage,
-      slippageBps,
-      astralaneTipLamports: tipLamports,
-    },
+  return getTipAndBuild(agent, "/positions/open", {
+    offerPublicKey,
+    userPublicKey: agent.wallet.publicKey.toBase58(),
+    collateralAmount,
+    leverage,
+    slippageBps,
   });
-
-  // Deserialize (API returns base58)
-  const txBuffer = Buffer.from(bs58.decode(result.transaction));
-  const tx = VersionedTransaction.deserialize(txBuffer);
-
-  // Sign and send via agent's wallet
-  return await signOrSendTX(agent, tx);
 }
 
-/**
- * Close a leveraged position.
- */
 export async function lavarageClosePosition(
   agent: SolanaAgentKit,
   positionAddress: string,
   slippageBps = 50,
 ): Promise<string> {
-  const wallet = agent.wallet.publicKey.toBase58();
-  const { tipLamports } = await lavaApi("/bundle/tip");
-
-  const result = await lavaApi("/positions/close", {
-    method: "POST",
-    body: {
-      positionAddress,
-      userPublicKey: wallet,
-      slippageBps,
-      astralaneTipLamports: tipLamports,
-    },
+  return getTipAndBuild(agent, "/positions/close", {
+    positionAddress,
+    userPublicKey: agent.wallet.publicKey.toBase58(),
+    slippageBps,
   });
-
-  const txBuffer = Buffer.from(bs58.decode(result.transaction));
-  const tx = VersionedTransaction.deserialize(txBuffer);
-  return await signOrSendTX(agent, tx);
 }
 
-/**
- * List positions for the agent's wallet.
- */
+// ── Positions ──
+
 export async function lavarageGetPositions(
   agent: SolanaAgentKit,
   status = "OPEN",
@@ -168,20 +148,139 @@ export async function lavarageGetPositions(
   return lavaApi(`/positions?owner=${wallet}&status=${status}`);
 }
 
-/**
- * Get details for a specific position.
- */
 export async function lavarageGetPositionStatus(
   agent: SolanaAgentKit,
   positionAddress: string,
 ): Promise<any> {
   const wallet = agent.wallet.publicKey.toBase58();
-  const positions = await lavaApi(
-    `/positions?owner=${wallet}&limit=250`,
-  );
+  const positions = await lavaApi(`/positions?owner=${wallet}&limit=250`);
   const match = (Array.isArray(positions) ? positions : []).find(
     (p: any) => p.address === positionAddress,
   );
   if (!match) throw new Error(`Position ${positionAddress} not found`);
   return match;
+}
+
+// ── Borrow ──
+
+export async function lavarageRepay(
+  agent: SolanaAgentKit,
+  positionAddress: string,
+): Promise<string> {
+  return getTipAndBuild(agent, "/positions/repay", {
+    positionAddress,
+    userPublicKey: agent.wallet.publicKey.toBase58(),
+  });
+}
+
+export async function lavaragePartialRepay(
+  agent: SolanaAgentKit,
+  positionAddress: string,
+  repaymentBps: number,
+): Promise<string> {
+  return getTipAndBuild(agent, "/positions/partial-repay", {
+    positionAddress,
+    userPublicKey: agent.wallet.publicKey.toBase58(),
+    repaymentBps,
+  });
+}
+
+export async function lavarageIncreaseBorrow(
+  agent: SolanaAgentKit,
+  positionAddress: string,
+  additionalBorrowAmount: string,
+  mode: "withdraw" | "compound",
+  slippageBps = 50,
+): Promise<string> {
+  return getTipAndBuild(agent, "/positions/increase-borrow", {
+    positionAddress,
+    userPublicKey: agent.wallet.publicKey.toBase58(),
+    additionalBorrowAmount,
+    mode,
+    slippageBps,
+  });
+}
+
+// ── Position Management ──
+
+export async function lavarageAddCollateral(
+  agent: SolanaAgentKit,
+  positionAddress: string,
+  collateralAmount: string,
+): Promise<string> {
+  return getTipAndBuild(agent, "/positions/add-collateral", {
+    positionAddress,
+    userPublicKey: agent.wallet.publicKey.toBase58(),
+    collateralAmount,
+  });
+}
+
+export async function lavarageSplitPosition(
+  agent: SolanaAgentKit,
+  positionAddress: string,
+  splitRatioBps: number,
+): Promise<string> {
+  return getTipAndBuild(agent, "/positions/split", {
+    positionAddress,
+    userPublicKey: agent.wallet.publicKey.toBase58(),
+    splitRatioBps,
+  });
+}
+
+export async function lavarageMergePositions(
+  agent: SolanaAgentKit,
+  firstPositionAddress: string,
+  secondPositionAddress: string,
+): Promise<string> {
+  return getTipAndBuild(agent, "/positions/merge", {
+    firstPositionAddress,
+    secondPositionAddress,
+    userPublicKey: agent.wallet.publicKey.toBase58(),
+  });
+}
+
+// ── Quotes ──
+
+export async function lavarageGetQuote(
+  agent: SolanaAgentKit,
+  offerPublicKey: string,
+  collateralAmount: string,
+  leverage: number,
+  slippageBps = 50,
+): Promise<any> {
+  return lavaApi("/positions/quote", {
+    method: "POST",
+    body: {
+      offerPublicKey,
+      userPublicKey: agent.wallet.publicKey.toBase58(),
+      collateralAmount,
+      leverage,
+      slippageBps,
+    },
+  });
+}
+
+export async function lavarageCloseQuote(
+  agent: SolanaAgentKit,
+  positionAddress: string,
+  slippageBps = 50,
+): Promise<any> {
+  return lavaApi("/positions/close-quote", {
+    method: "POST",
+    body: {
+      positionAddress,
+      userPublicKey: agent.wallet.publicKey.toBase58(),
+      slippageBps,
+    },
+  });
+}
+
+// ── History ──
+
+export async function lavarageTradeHistory(
+  agent: SolanaAgentKit,
+  limit = 20,
+): Promise<any> {
+  const wallet = agent.wallet.publicKey.toBase58();
+  return lavaApi(`/positions/trade-history?owner=${wallet}&limit=${limit}`);
 }

--- a/packages/plugin-defi/src/lavarage/tools/lavarage.ts
+++ b/packages/plugin-defi/src/lavarage/tools/lavarage.ts
@@ -32,7 +32,13 @@ async function buildSignAndSend(
 ): Promise<string> {
   const txBuffer = Buffer.from(bs58.decode(txBase58));
   const tx = VersionedTransaction.deserialize(txBuffer);
-  return await signOrSendTX(agent, tx);
+  const result = await signOrSendTX(agent, tx);
+  if (typeof result === "string") return result;
+  // If signOrSendTX returned a Transaction/VersionedTransaction (sign-only mode),
+  // we need to send it ourselves
+  const signed = result as VersionedTransaction;
+  const sig = await agent.connection.sendRawTransaction(signed.serialize());
+  return sig;
 }
 
 async function getTipAndBuild(

--- a/packages/plugin-defi/src/lavarage/tools/lavarage.ts
+++ b/packages/plugin-defi/src/lavarage/tools/lavarage.ts
@@ -1,4 +1,4 @@
-import { type SolanaAgentKit, signOrSendTX } from "solana-agent-kit";
+import type { SolanaAgentKit } from "solana-agent-kit";
 import { VersionedTransaction } from "@solana/web3.js";
 import bs58 from "bs58";
 
@@ -32,13 +32,21 @@ async function buildSignAndSend(
 ): Promise<string> {
   const txBuffer = Buffer.from(bs58.decode(txBase58));
   const tx = VersionedTransaction.deserialize(txBuffer);
-  const result = await signOrSendTX(agent, tx);
-  if (typeof result === "string") return result;
-  // If signOrSendTX returned a Transaction/VersionedTransaction (sign-only mode),
-  // we need to send it ourselves
-  const signed = result as VersionedTransaction;
-  const sig = await agent.connection.sendRawTransaction(signed.serialize());
-  return sig;
+
+  // Sign and send directly — can't use signOrSendTX because its instanceof
+  // check fails when @solana/web3.js versions differ between plugin and core.
+  // This is the same pattern other plugins use for pre-built transactions.
+  if (agent.wallet.signAndSendTransaction) {
+    const { signature } = await agent.wallet.signAndSendTransaction(tx);
+    return signature;
+  }
+
+  // Fallback: sign then send separately
+  const signed = await agent.wallet.signTransaction(tx);
+  return await agent.connection.sendRawTransaction(
+    (signed as VersionedTransaction).serialize(),
+    { skipPreflight: true, maxRetries: 3 },
+  );
 }
 
 async function getTipAndBuild(

--- a/packages/plugin-defi/src/lavarage/tools/lavarage.ts
+++ b/packages/plugin-defi/src/lavarage/tools/lavarage.ts
@@ -1,0 +1,187 @@
+import { type SolanaAgentKit, signOrSendTX } from "solana-agent-kit";
+import { VersionedTransaction, PublicKey } from "@solana/web3.js";
+import bs58 from "bs58";
+
+const API_BASE = "https://api.lavarage.xyz/api/v1";
+const API_KEY =
+  "lv2_prod_f10d28b9ef5694e38b61eb614556ed85ab480585ef03c39c";
+
+async function lavaApi(
+  path: string,
+  opts?: { method?: string; body?: any },
+): Promise<any> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: opts?.method ?? "GET",
+    headers: {
+      "x-api-key": API_KEY,
+      "Content-Type": "application/json",
+    },
+    body: opts?.body ? JSON.stringify(opts.body) : undefined,
+  });
+  const data = await res.json();
+  if (!res.ok)
+    throw new Error(
+      `Lavarage API ${res.status}: ${data?.message ?? JSON.stringify(data)}`,
+    );
+  return data;
+}
+
+/**
+ * List available tokens for leverage trading with best offers.
+ */
+export async function lavarageListTokens(
+  _agent: SolanaAgentKit,
+  search: string,
+): Promise<any[]> {
+  const offers = await lavaApi(
+    `/offers?includeTokens=true&search=${encodeURIComponent(search)}&limit=20`,
+  );
+  const seen = new Map<string, any>();
+  for (const o of offers) {
+    const mint = o.tradedTokenAddress ?? o.tokenMint;
+    if (!mint) continue;
+    const existing = seen.get(mint);
+    if (
+      !existing ||
+      Number(o.availableForOpen ?? 0) > Number(existing.availableForOpen ?? 0)
+    ) {
+      seen.set(mint, o);
+    }
+  }
+  return Array.from(seen.values())
+    .slice(0, 20)
+    .map((o) => ({
+      offerPublicKey: o.publicKey,
+      symbol: o.baseToken?.symbol ?? "unknown",
+      name: o.baseToken?.name ?? null,
+      mint: o.tradedTokenAddress ?? o.tokenMint,
+      price: o.baseToken?.price ?? null,
+      quoteSymbol: o.quoteToken?.symbol ?? "unknown",
+      maxLeverage: o.maxLeverage,
+      apr: o.apr,
+      side: o.side,
+    }));
+}
+
+/**
+ * Get max leverage and available liquidity for a token.
+ */
+export async function lavarageGetMaxLeverage(
+  _agent: SolanaAgentKit,
+  search: string,
+  quoteCurrency?: string,
+): Promise<any[]> {
+  const params = new URLSearchParams({
+    includeTokens: "true",
+    search,
+    limit: "10",
+  });
+  if (quoteCurrency && quoteCurrency !== "all") {
+    const quoteMap: Record<string, string> = {
+      SOL: "So11111111111111111111111111111111111111112",
+      USDC: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    };
+    if (quoteMap[quoteCurrency]) params.set("quoteToken", quoteMap[quoteCurrency]);
+  }
+  const offers = await lavaApi(`/offers?${params}`);
+  return (Array.isArray(offers) ? offers : []).map((o: any) => ({
+    offerPublicKey: o.publicKey,
+    symbol: o.baseToken?.symbol ?? "unknown",
+    quoteSymbol: o.quoteToken?.symbol ?? "unknown",
+    maxLeverage: o.maxLeverage,
+    apr: o.apr,
+    availableLiquidity: o.availableForOpen ?? o.availableLiquidity,
+    side: o.side,
+  }));
+}
+
+/**
+ * Open a leveraged position. Builds TX via API, signs with agent wallet, submits.
+ */
+export async function lavarageOpenPosition(
+  agent: SolanaAgentKit,
+  offerPublicKey: string,
+  collateralAmount: string,
+  leverage: number,
+  slippageBps = 50,
+): Promise<string> {
+  const wallet = agent.wallet.publicKey.toBase58();
+
+  // Get tip for MEV protection
+  const { tipLamports } = await lavaApi("/bundle/tip");
+
+  // Build the transaction
+  const result = await lavaApi("/positions/open", {
+    method: "POST",
+    body: {
+      offerPublicKey,
+      userPublicKey: wallet,
+      collateralAmount,
+      leverage,
+      slippageBps,
+      astralaneTipLamports: tipLamports,
+    },
+  });
+
+  // Deserialize (API returns base58)
+  const txBuffer = Buffer.from(bs58.decode(result.transaction));
+  const tx = VersionedTransaction.deserialize(txBuffer);
+
+  // Sign and send via agent's wallet
+  return await signOrSendTX(agent, tx);
+}
+
+/**
+ * Close a leveraged position.
+ */
+export async function lavarageClosePosition(
+  agent: SolanaAgentKit,
+  positionAddress: string,
+  slippageBps = 50,
+): Promise<string> {
+  const wallet = agent.wallet.publicKey.toBase58();
+  const { tipLamports } = await lavaApi("/bundle/tip");
+
+  const result = await lavaApi("/positions/close", {
+    method: "POST",
+    body: {
+      positionAddress,
+      userPublicKey: wallet,
+      slippageBps,
+      astralaneTipLamports: tipLamports,
+    },
+  });
+
+  const txBuffer = Buffer.from(bs58.decode(result.transaction));
+  const tx = VersionedTransaction.deserialize(txBuffer);
+  return await signOrSendTX(agent, tx);
+}
+
+/**
+ * List positions for the agent's wallet.
+ */
+export async function lavarageGetPositions(
+  agent: SolanaAgentKit,
+  status = "OPEN",
+): Promise<any[]> {
+  const wallet = agent.wallet.publicKey.toBase58();
+  return lavaApi(`/positions?owner=${wallet}&status=${status}`);
+}
+
+/**
+ * Get details for a specific position.
+ */
+export async function lavarageGetPositionStatus(
+  agent: SolanaAgentKit,
+  positionAddress: string,
+): Promise<any> {
+  const wallet = agent.wallet.publicKey.toBase58();
+  const positions = await lavaApi(
+    `/positions?owner=${wallet}&limit=250`,
+  );
+  const match = (Array.isArray(positions) ? positions : []).find(
+    (p: any) => p.address === positionAddress,
+  );
+  if (!match) throw new Error(`Position ${positionAddress} not found`);
+  return match;
+}

--- a/packages/plugin-defi/test-lavarage.mjs
+++ b/packages/plugin-defi/test-lavarage.mjs
@@ -1,0 +1,123 @@
+import { readFileSync } from "fs";
+import { Keypair, Connection, LAMPORTS_PER_SOL } from "@solana/web3.js";
+
+const { default: DefiPlugin } = await import("./dist/index.js");
+
+const keyData = JSON.parse(readFileSync("/tmp/test-sak-wallet.json", "utf-8"));
+const keypair = Keypair.fromSecretKey(Uint8Array.from(keyData));
+const wallet = keypair.publicKey.toBase58();
+const connection = new Connection("https://api.mainnet-beta.solana.com");
+
+console.log(`Wallet: ${wallet}`);
+const balance = await connection.getBalance(keypair.publicKey);
+console.log(`SOL Balance: ${(balance / LAMPORTS_PER_SOL).toFixed(4)} SOL\n`);
+
+// Proper agent mock with signAndSendTransaction (what SAK's signOrSendTX expects)
+const agent = {
+  wallet: {
+    publicKey: keypair.publicKey,
+    signTransaction: async (tx) => { tx.sign([keypair]); return tx; },
+    signAllTransactions: async (txs) => { txs.forEach(tx => tx.sign([keypair])); return txs; },
+    signAndSendTransaction: async (tx) => {
+      tx.sign([keypair]);
+      const sig = await connection.sendRawTransaction(tx.serialize(), { skipPreflight: true, maxRetries: 3 });
+      return { signature: sig };
+    },
+  },
+  connection,
+  config: {},
+};
+
+const actions = DefiPlugin.actions.filter((a) => a.name.startsWith("LAVARAGE"));
+console.log(`${actions.length} Lavarage actions loaded\n`);
+
+const getAction = (name) => actions.find((a) => a.name === name);
+let passed = 0, failed = 0;
+
+async function test(name, fn) {
+  process.stdout.write(`${name}... `);
+  try {
+    const result = await fn();
+    if (result.status === "error") {
+      console.log(`FAIL: ${result.message}`);
+      failed++;
+    } else {
+      console.log("PASS");
+      passed++;
+    }
+    return result;
+  } catch (e) {
+    console.log(`FAIL: ${e.message}`);
+    failed++;
+    return null;
+  }
+}
+
+// === READ TESTS ===
+const tokenResult = await test("LIST_TOKENS (BTC)", () =>
+  getAction("LAVARAGE_LIST_TOKENS").handler(agent, { search: "BTC" })
+);
+if (tokenResult?.tokens?.length > 0)
+  console.log(`  → Found: ${tokenResult.tokens.map(t => `${t.symbol}/${t.quoteSymbol}`).join(", ")}\n`);
+
+await test("GET_MAX_LEVERAGE (SOL/USDC)", () =>
+  getAction("LAVARAGE_GET_MAX_LEVERAGE").handler(agent, { search: "SOL", quoteCurrency: "USDC" })
+);
+
+let offerKey = tokenResult?.tokens?.find(t => t.quoteSymbol === "USDC")?.offerPublicKey;
+if (offerKey)
+  console.log(`  → Using offer: ${offerKey.slice(0,12)}...\n`);
+
+if (offerKey) {
+  const quoteResult = await test("GET_QUOTE (2x, $2 USDC)", () =>
+    getAction("LAVARAGE_GET_QUOTE").handler(agent, { offerPublicKey: offerKey, collateralAmount: "2000000", leverage: 2 })
+  );
+  if (quoteResult?.quote)
+    console.log(`  → In: ${quoteResult.quote.inAmount} → Out: ${quoteResult.quote.outAmount}\n`);
+}
+
+await test("GET_POSITIONS", () =>
+  getAction("LAVARAGE_GET_POSITIONS").handler(agent, { status: "ALL" })
+);
+
+await test("TRADE_HISTORY", () =>
+  getAction("LAVARAGE_TRADE_HISTORY").handler(agent, { limit: 3 })
+);
+
+// === LIVE TRADE TEST ===
+if (offerKey) {
+  console.log("\n=== LIVE TRADE TEST ===");
+
+  const openResult = await test("OPEN_POSITION (2x long cbBTC/USDC, $2)", () =>
+    getAction("LAVARAGE_OPEN_POSITION").handler(agent, {
+      offerPublicKey: offerKey,
+      collateralAmount: "2000000",
+      leverage: 2,
+      slippageBps: 100,
+    })
+  );
+
+  if (openResult?.signature) {
+    console.log(`  → TX: ${openResult.signature}\n`);
+    console.log("  Waiting 8s for position to appear...");
+    await new Promise(r => setTimeout(r, 8000));
+
+    const posResult = await test("GET_POSITIONS (verify)", () =>
+      getAction("LAVARAGE_GET_POSITIONS").handler(agent, { status: "OPEN" })
+    );
+
+    if (posResult?.positions?.length > 0) {
+      const p = posResult.positions[0];
+      console.log(`  → ${p.side} ${p.baseTokenSymbol ?? "?"}/${p.quoteTokenSymbol ?? "?"} ${p.leverage}x\n`);
+
+      const closeResult = await test("CLOSE_POSITION", () =>
+        getAction("LAVARAGE_CLOSE_POSITION").handler(agent, { positionAddress: p.address, slippageBps: 100 })
+      );
+      if (closeResult?.signature)
+        console.log(`  → Close TX: ${closeResult.signature}\n`);
+    }
+  }
+}
+
+console.log(`\n=== RESULTS: ${passed} passed, ${failed} failed ===`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Adds [Lavarage](https://lavarage.xyz) integration to the DeFi plugin — spot margin leverage trading on Solana tokens.

### Tools added

| Tool | Description |
|------|-------------|
| `LAVARAGE_OPEN_POSITION` | Open a leveraged position (SOL/USDC collateral) |
| `LAVARAGE_CLOSE_POSITION` | Close a position |
| `LAVARAGE_GET_POSITIONS` | List positions with PnL and liquidation data |
| `LAVARAGE_GET_POSITION_STATUS` | Position health — LTV, liquidation price, interest |
| `LAVARAGE_LIST_TOKENS` | Search available tokens |
| `LAVARAGE_GET_MAX_LEVERAGE` | Max leverage, APR, and liquidity per token |

### How it works

- Calls Lavarage V2 REST API to build transactions
- Agent signs with wallet keypair via signOrSendTX
- No additional SDK dependency — pure HTTP
- MEV protection included

### Files

- packages/plugin-defi/src/lavarage/ — tools + actions
- packages/plugin-defi/src/index.ts — register in plugin

## Test plan

- [x] Build passes
- [x] Actions have Zod schemas + examples
- [x] Open/close position tested with agent wallet