### PR TITLE
feat: add vybes.fun integration (token launch, predictions, logos)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -50,6 +50,10 @@
               {
                 "group": "Misc",
                 "pages": ["docs/v2/plugins/misc/misc-plugin-intro"]
+              },
+              {
+                "group": "Vybes",
+                "pages": ["docs/v2/plugins/vybes/vybes-plugin-intro"]
               }
             ]
           },

--- a/docs/v2/plugins/vybes/vybes-plugin-intro.mdx
+++ b/docs/v2/plugins/vybes/vybes-plugin-intro.mdx
@@ -1,0 +1,131 @@
+---
+title: 'Vybes Plugin'
+description: 'Launch meme tokens, generate AI logos, and create prediction markets on vybes.fun'
+icon: 'rocket'
+---
+
+# Vybes Plugin
+
+The `@solana-agent-kit/plugin-vybes` plugin integrates [vybes.fun](https://vybes.fun) into the Solana Agent Kit, enabling AI agents to launch meme tokens with bonding curves, generate AI logos, create prediction markets, and check earnings.
+
+## Installation
+
+Install the plugin alongside the core Solana Agent Kit:
+
+```bash
+npm install solana-agent-kit @solana-agent-kit/plugin-vybes
+```
+
+## Integration
+
+Add the Vybes plugin to your agent:
+
+```typescript
+import { SolanaAgentKit } from "solana-agent-kit";
+import VybesPlugin from "@solana-agent-kit/plugin-vybes";
+
+const agent = new SolanaAgentKit(
+  wallet,
+  "YOUR_RPC_URL",
+  {}
+).use(VybesPlugin);
+```
+
+## Actions
+
+### LAUNCH_VYBES_TOKEN
+
+Launch a new Solana meme token on vybes.fun with a bonding curve and AI-generated logo. Free to launch (0 SOL creation fee). Tokens graduate to Meteora DEX at ~85 SOL raised.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| name | string | Yes | Token name (1-32 chars) |
+| symbol | string | Yes | Token ticker symbol (2-10 chars) |
+| description | string | No | Token description |
+| style | string | No | AI logo style: meme, cute, cool, hype, moon, pixel, anime, 3d, logo, degen |
+
+### GENERATE_VYBES_LOGO
+
+Generate an AI logo for a token using Workers AI (FLUX model). Free, no payment required. Returns a public URL to a 1024x1024 PNG. Rate limited to 20/hour.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| name | string | Yes | Token or project name |
+| symbol | string | Yes | Token ticker symbol |
+| style | string | No | Logo style (default: meme) |
+
+### CREATE_VYBES_PREDICTION
+
+Create a YES/NO prediction market on vybes.fun for a Solana token. Free to create. Others can bet with SOL. Markets are auto-resolved by cron.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| tokenMint | string | Yes | Solana token mint address |
+| question | string | Yes | Prediction question (10-200 chars) |
+| templateType | string | Yes | graduation, market_cap_target, multiplier, ath_flip, holder_count, or volume_target |
+| duration | string | No | 24h, 48h, 7d, or 30d (default: 24h) |
+| metadata | object | No | Template-specific metadata |
+
+## Methods
+
+### launchTokenOnVybes
+
+Full launch flow: checks fees, generates AI logo, sends payment (if any), creates token.
+
+```typescript
+const token = await agent.methods.launchTokenOnVybes(agent, {
+  name: "Moon Dog",
+  symbol: "MDOG",
+  description: "The moon-iest dog token",
+  style: "meme",
+});
+// Returns: { tokenAddress, uuid, viewUrl, paymentTx, ... }
+```
+
+### generateVybesLogo
+
+Generate an AI logo with one of 10 styles.
+
+```typescript
+const logo = await agent.methods.generateVybesLogo({
+  name: "Moon Dog",
+  symbol: "MDOG",
+  style: "pixel",
+});
+// Returns: { imageUrl, style, ... }
+```
+
+### createVybesPrediction
+
+Create a prediction market using one of 6 template types.
+
+```typescript
+const prediction = await agent.methods.createVybesPrediction({
+  wallet: agent.wallet.publicKey.toBase58(),
+  tokenMint: "7nxQB...",
+  question: "Will this token graduate in 24h?",
+  templateType: "graduation",
+  duration: "24h",
+});
+// Returns: { marketId, viewUrl, endTime, ... }
+```
+
+### getVybesEarnings
+
+Check tokens launched, prediction bets, payouts, and net profit for any wallet.
+
+```typescript
+const earnings = await agent.methods.getVybesEarnings(
+  agent.wallet.publicKey.toBase58()
+);
+// Returns: { tokensLaunched, totalPredictions, netProfitLamports, ... }
+```
+
+## Links
+
+- [Vybes.fun](https://vybes.fun)
+- [Developer Docs](https://vybes.fun/developers)
+- [Plugin Source (GitHub)](https://github.com/AICre8dev/solana-agent-kit-vybes)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:plugin-defi": "turbo run build --filter=@solana-agent-kit/plugin-defi",
     "build:plugin-misc": "turbo run build --filter=@solana-agent-kit/plugin-misc",
     "build:plugin-blinks": "turbo run build --filter=@solana-agent-kit/plugin-blinks",
+    "build:plugin-vybes": "turbo run build --filter=@solana-agent-kit/plugin-vybes",
     "build:adapter-mcp": "turbo run build --filter=@solana-agent-kit/adapter-mcp",
     "test": "npx tsx test/index.ts",
     "docs": "typedoc",

--- a/packages/plugin-vybes/README.md
+++ b/packages/plugin-vybes/README.md
@@ -1,0 +1,78 @@
+# @solana-agent-kit/plugin-vybes
+
+[Vybes.fun](https://vybes.fun) integration for the Solana Agent Kit. Launch meme tokens, generate AI logos, create prediction markets, and check earnings — all from your AI agent.
+
+## Features
+
+- **Token Launch** — Deploy a Solana meme token with bonding curve and AI-generated logo. Free to launch (0 SOL creation fee). Tokens graduate to Meteora DEX at ~85 SOL raised.
+- **AI Logo Generation** — Generate 1024x1024 PNG logos via Workers AI (FLUX model). 10 styles: meme, cute, cool, hype, moon, pixel, anime, 3d, logo, degen. Free, rate limited to 20/hour.
+- **Prediction Markets** — Create YES/NO prediction markets on any Solana token. 6 template types (graduation, market_cap_target, multiplier, ath_flip, holder_count, volume_target). Auto-resolved by cron.
+- **Earnings** — Check tokens launched, prediction bets, payouts, and net profit for any wallet.
+
+## Installation
+
+```bash
+pnpm add @solana-agent-kit/plugin-vybes
+```
+
+## Usage
+
+```typescript
+import { SolanaAgentKit } from "solana-agent-kit";
+import VybesPlugin from "@solana-agent-kit/plugin-vybes";
+
+const agent = new SolanaAgentKit(wallet, rpcUrl, config)
+  .use(VybesPlugin);
+
+// Launch a token
+const token = await agent.methods.launchTokenOnVybes(agent, {
+  name: "Moon Dog",
+  symbol: "MDOG",
+  description: "The moon-iest dog token",
+  style: "meme",
+});
+
+// Generate a logo
+const logo = await agent.methods.generateVybesLogo({
+  name: "Moon Dog",
+  symbol: "MDOG",
+  style: "pixel",
+});
+
+// Create a prediction market
+const prediction = await agent.methods.createVybesPrediction({
+  wallet: agent.wallet.publicKey.toBase58(),
+  tokenMint: token.tokenAddress,
+  question: "Will MDOG graduate in 24h?",
+  templateType: "graduation",
+  duration: "24h",
+});
+
+// Check earnings
+const earnings = await agent.methods.getVybesEarnings(
+  agent.wallet.publicKey.toBase58(),
+);
+```
+
+## Actions (AI Agent Tools)
+
+| Action | Name | Description |
+|--------|------|-------------|
+| Launch Token | `LAUNCH_VYBES_TOKEN` | Launch a meme token with bonding curve + AI logo |
+| Generate Logo | `GENERATE_VYBES_LOGO` | Generate AI logo (10 styles, free) |
+| Create Prediction | `CREATE_VYBES_PREDICTION` | Create YES/NO prediction market |
+
+## Methods (Programmatic API)
+
+| Method | Description |
+|--------|-------------|
+| `launchTokenOnVybes` | Full launch flow: fee check, logo gen, payment, token creation |
+| `generateVybesLogo` | Generate AI logo via FLUX model |
+| `createVybesPrediction` | Create prediction market with template |
+| `getVybesEarnings` | Get earnings summary for a wallet |
+
+## Links
+
+- [Vybes.fun](https://vybes.fun)
+- [Developer Docs](https://vybes.fun/developers)
+- [Plugin Source](https://github.com/AICre8dev/solana-agent-kit-vybes)

--- a/packages/plugin-vybes/package.json
+++ b/packages/plugin-vybes/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@solana-agent-kit/plugin-vybes",
+  "version": "2.0.0",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "scripts": {
+    "clean": "rm -rf dist .turbo node_modules",
+    "build": "tsup src/index.ts --dts --clean --format cjs,esm --out-dir dist",
+    "test": "jest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sendaifun/solana-agent-kit.git"
+  },
+  "homepage": "https://github.com/sendaifun/solana-agent-kit/tree/v2/packages/plugin-vybes",
+  "dependencies": {
+    "@solana/spl-token": "^0.4.9",
+    "bs58": "^6.0.0",
+    "redaxios": "^0.5.1",
+    "solana-agent-kit": "workspace:*",
+    "zod": "^3.24.1"
+  },
+  "peerDependencies": {
+    "@solana/web3.js": "^1.98.2",
+    "solana-agent-kit": "2.0.7"
+  }
+}

--- a/packages/plugin-vybes/src/index.ts
+++ b/packages/plugin-vybes/src/index.ts
@@ -1,0 +1,71 @@
+import type { Plugin, SolanaAgentKit } from "solana-agent-kit";
+
+// Import Vybes tools
+import {
+  launchTokenOnVybes,
+  generateVybesLogo,
+  createVybesPrediction,
+  getVybesEarnings,
+} from "./vybes/tools";
+
+// Import Vybes actions
+import vybesLaunchAction from "./vybes/actions/launchToken";
+import vybesLogoAction from "./vybes/actions/generateLogo";
+import vybesPredictionAction from "./vybes/actions/createPrediction";
+
+// Define and export the plugin
+const VybesPlugin = {
+  name: "vybes",
+
+  // Combine all tools
+  methods: {
+    launchTokenOnVybes,
+    generateVybesLogo,
+    createVybesPrediction,
+    getVybesEarnings,
+  },
+
+  // Combine all actions
+  actions: [
+    vybesLaunchAction,
+    vybesLogoAction,
+    vybesPredictionAction,
+  ],
+
+  // Initialize function
+  initialize: function (): void {
+    Object.entries(this.methods).forEach(([methodName, method]) => {
+      if (typeof method === "function") {
+        this.methods[methodName] = method;
+      }
+    });
+  },
+} satisfies Plugin;
+
+// Default export for convenience
+export default VybesPlugin;
+
+// Re-export tools and types
+export {
+  launchTokenOnVybes,
+  generateVybesLogo,
+  createVybesPrediction,
+  getVybesEarnings,
+} from "./vybes/tools";
+
+export type {
+  LaunchTokenParams,
+  LaunchTokenResult,
+  GenerateLogoParams,
+  GenerateLogoResult,
+  VybesLogoStyle,
+  CreatePredictionParams,
+  CreatePredictionResult,
+  VybesTemplateType,
+  VybesDuration,
+  VybesEarnings,
+} from "./vybes/tools";
+
+export { vybesLaunchAction } from "./vybes/actions/launchToken";
+export { vybesLogoAction } from "./vybes/actions/generateLogo";
+export { vybesPredictionAction } from "./vybes/actions/createPrediction";

--- a/packages/plugin-vybes/src/vybes/actions/createPrediction.ts
+++ b/packages/plugin-vybes/src/vybes/actions/createPrediction.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+import type { Action, SolanaAgentKit } from "solana-agent-kit";
+import { createVybesPrediction } from "../tools/createPrediction";
+
+const schema = z.object({
+  tokenMint: z.string().describe("Solana token mint address"),
+  question: z
+    .string()
+    .min(10)
+    .max(200)
+    .describe("Prediction question"),
+  templateType: z
+    .enum([
+      "graduation",
+      "market_cap_target",
+      "multiplier",
+      "ath_flip",
+      "holder_count",
+      "volume_target",
+    ])
+    .describe("Prediction template type"),
+  duration: z
+    .enum(["24h", "48h", "7d", "30d"])
+    .optional()
+    .describe("Duration (default: 24h)"),
+  metadata: z
+    .record(z.any())
+    .optional()
+    .describe("Template-specific metadata"),
+});
+
+const vybesPredictionAction: Action = {
+  name: "CREATE_VYBES_PREDICTION",
+  similes: [
+    "create vybes prediction",
+    "make prediction market",
+    "start a bet on vybes",
+    "create prediction on vybes.fun",
+    "prediction market vybes",
+  ],
+  description:
+    "Create a prediction market on vybes.fun for a Solana token. " +
+    "Free to create. Others can bet YES/NO with SOL. Auto-resolved by cron. " +
+    "Templates: graduation, market_cap_target, multiplier, ath_flip, holder_count, volume_target.",
+  examples: [
+    [
+      {
+        input: {
+          tokenMint: "7nxQB...",
+          question: "Will this token hit 100 SOL volume in 24h?",
+          templateType: "volume_target",
+          duration: "24h",
+          metadata: { target_volume: 100 },
+        },
+        output: {
+          status: "success",
+          marketId: "market-123",
+          viewUrl: "https://vybes.fun/predictions/market-123",
+        },
+        explanation:
+          "Create a volume target prediction market with 24h duration",
+      },
+    ],
+  ],
+  schema,
+  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+    try {
+      const wallet = agent.wallet.publicKey.toBase58();
+      const result = await createVybesPrediction({
+        wallet,
+        tokenMint: input.tokenMint,
+        question: input.question,
+        templateType: input.templateType as any,
+        duration: input.duration,
+        metadata: input.metadata,
+      });
+      return {
+        status: "success",
+        marketId: result.marketId,
+        viewUrl: result.viewUrl,
+        message: `Created prediction: ${input.question}`,
+      };
+    } catch (error: any) {
+      return {
+        status: "error",
+        message: `Prediction creation failed: ${error.message}`,
+      };
+    }
+  },
+};
+
+export default vybesPredictionAction;
+export { vybesPredictionAction };

--- a/packages/plugin-vybes/src/vybes/actions/generateLogo.ts
+++ b/packages/plugin-vybes/src/vybes/actions/generateLogo.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+import type { Action, SolanaAgentKit } from "solana-agent-kit";
+import { generateVybesLogo } from "../tools/generateLogo";
+
+const schema = z.object({
+  name: z.string().min(1).describe("Token or project name"),
+  symbol: z.string().min(1).max(10).describe("Token ticker symbol"),
+  style: z
+    .enum([
+      "meme",
+      "cute",
+      "cool",
+      "hype",
+      "moon",
+      "pixel",
+      "anime",
+      "3d",
+      "logo",
+      "degen",
+    ])
+    .optional()
+    .describe("Logo style (default: meme)"),
+});
+
+const vybesLogoAction: Action = {
+  name: "GENERATE_VYBES_LOGO",
+  similes: [
+    "generate vybes logo",
+    "create token logo on vybes",
+    "make ai logo",
+    "generate token art",
+    "vybes logo",
+  ],
+  description:
+    "Generate an AI logo for a token using vybes.fun Workers AI (FLUX model). " +
+    "Free, no payment required. Returns public URL to 1024x1024 PNG. " +
+    "10 styles: meme, cute, cool, hype, moon, pixel, anime, 3d, logo, degen.",
+  examples: [
+    [
+      {
+        input: { name: "Moon Cat", symbol: "MCAT", style: "pixel" },
+        output: {
+          status: "success",
+          imageUrl: "https://...",
+          style: "pixel",
+        },
+        explanation: "Generate a pixel art logo for Moon Cat token",
+      },
+    ],
+  ],
+  schema,
+  handler: async (_agent: SolanaAgentKit, input: Record<string, any>) => {
+    try {
+      const result = await generateVybesLogo({
+        name: input.name,
+        symbol: input.symbol,
+        style: input.style,
+      });
+      return {
+        status: "success",
+        imageUrl: result.imageUrl,
+        style: result.style,
+        message: `Generated ${result.style} logo for ${input.name}`,
+      };
+    } catch (error: any) {
+      return {
+        status: "error",
+        message: `Logo generation failed: ${error.message}`,
+      };
+    }
+  },
+};
+
+export default vybesLogoAction;
+export { vybesLogoAction };

--- a/packages/plugin-vybes/src/vybes/actions/launchToken.ts
+++ b/packages/plugin-vybes/src/vybes/actions/launchToken.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+import type { Action, SolanaAgentKit } from "solana-agent-kit";
+import { launchTokenOnVybes } from "../tools/launchToken";
+
+const schema = z.object({
+  name: z.string().min(1).max(32).describe("Token name"),
+  symbol: z.string().min(2).max(10).describe("Token ticker symbol"),
+  description: z.string().optional().describe("Token description"),
+  style: z
+    .enum([
+      "meme",
+      "cute",
+      "cool",
+      "hype",
+      "moon",
+      "pixel",
+      "anime",
+      "3d",
+      "logo",
+      "degen",
+    ])
+    .optional()
+    .describe("AI logo style (default: meme)"),
+});
+
+const vybesLaunchAction: Action = {
+  name: "LAUNCH_VYBES_TOKEN",
+  similes: [
+    "launch token on vybes",
+    "create vybes token",
+    "deploy meme coin on vybes",
+    "launch on vybes.fun",
+    "create solana token on vybes",
+  ],
+  description:
+    "Launch a new Solana meme token on vybes.fun with bonding curve and AI-generated logo. " +
+    "Free to launch. The token gets a bonding curve for trading and graduates to Meteora DEX at ~85 SOL.",
+  examples: [
+    [
+      {
+        input: {
+          name: "Moon Dog",
+          symbol: "MDOG",
+          description: "A meme token for dog lovers",
+          style: "meme",
+        },
+        output: {
+          status: "success",
+          tokenAddress: "7nxQB...",
+          uuid: "abc-123",
+          viewUrl: "https://vybes.fun/launch/abc-123",
+        },
+        explanation:
+          "Launch a meme token with auto-generated logo on vybes.fun",
+      },
+    ],
+  ],
+  schema,
+  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+    try {
+      const result = await launchTokenOnVybes(agent, {
+        name: input.name,
+        symbol: input.symbol,
+        description: input.description,
+        style: input.style,
+      });
+      return {
+        status: "success",
+        tokenAddress: result.tokenAddress,
+        uuid: result.uuid,
+        viewUrl: result.viewUrl,
+        paymentTx: result.paymentTx,
+        message: `Launched ${input.name} ($${input.symbol}) on vybes.fun`,
+      };
+    } catch (error: any) {
+      return { status: "error", message: `Launch failed: ${error.message}` };
+    }
+  },
+};
+
+export default vybesLaunchAction;
+export { vybesLaunchAction };

--- a/packages/plugin-vybes/src/vybes/index.ts
+++ b/packages/plugin-vybes/src/vybes/index.ts
@@ -1,0 +1,23 @@
+export {
+  launchTokenOnVybes,
+  generateVybesLogo,
+  createVybesPrediction,
+  getVybesEarnings,
+} from "./tools";
+
+export type {
+  LaunchTokenParams,
+  LaunchTokenResult,
+  GenerateLogoParams,
+  GenerateLogoResult,
+  VybesLogoStyle,
+  CreatePredictionParams,
+  CreatePredictionResult,
+  VybesTemplateType,
+  VybesDuration,
+  VybesEarnings,
+} from "./tools";
+
+export { default as vybesLaunchAction } from "./actions/launchToken";
+export { default as vybesLogoAction } from "./actions/generateLogo";
+export { default as vybesPredictionAction } from "./actions/createPrediction";

--- a/packages/plugin-vybes/src/vybes/tools/createPrediction.ts
+++ b/packages/plugin-vybes/src/vybes/tools/createPrediction.ts
@@ -1,0 +1,67 @@
+const VYBES_API_URL = "https://vybes.fun";
+
+export type VybesTemplateType =
+  | "graduation" | "market_cap_target" | "multiplier"
+  | "ath_flip" | "holder_count" | "volume_target";
+
+export type VybesDuration = "24h" | "48h" | "7d" | "30d";
+
+export interface CreatePredictionParams {
+  wallet: string;
+  tokenMint: string;
+  question: string;
+  templateType: VybesTemplateType;
+  duration?: VybesDuration;
+  metadata?: Record<string, any>;
+}
+
+export interface CreatePredictionResult {
+  success: boolean;
+  marketId: string;
+  question: string;
+  templateType: string;
+  endTime: string;
+  viewUrl: string;
+}
+
+/**
+ * Create a prediction market on vybes.fun for a Solana token.
+ * Free to create. Others can bet YES/NO with SOL. Auto-resolved by cron.
+ *
+ * Templates: graduation, market_cap_target, multiplier, ath_flip,
+ * holder_count, volume_target.
+ *
+ * @param params - Wallet, token mint, question, template type, duration, metadata
+ */
+export async function createVybesPrediction(
+  params: CreatePredictionParams,
+): Promise<CreatePredictionResult> {
+  const res = await fetch(`${VYBES_API_URL}/api/agent/predict`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      action: "create",
+      wallet: params.wallet,
+      tokenMint: params.tokenMint,
+      question: params.question,
+      templateType: params.templateType,
+      duration: params.duration || "24h",
+      metadata: params.metadata || {},
+    }),
+  });
+
+  const data = await res.json();
+
+  if (!data.success) {
+    throw new Error(data.error || "Prediction creation failed");
+  }
+
+  return {
+    success: true,
+    marketId: data.data.marketId,
+    question: params.question,
+    templateType: params.templateType,
+    endTime: data.data.endTime,
+    viewUrl: `${VYBES_API_URL}/predictions/${data.data.marketId}`,
+  };
+}

--- a/packages/plugin-vybes/src/vybes/tools/generateLogo.ts
+++ b/packages/plugin-vybes/src/vybes/tools/generateLogo.ts
@@ -1,0 +1,56 @@
+const VYBES_API_URL = "https://vybes.fun";
+
+export type VybesLogoStyle =
+  | "meme" | "cute" | "cool" | "hype" | "moon"
+  | "pixel" | "anime" | "3d" | "logo" | "degen";
+
+export interface GenerateLogoParams {
+  name: string;
+  symbol: string;
+  style?: VybesLogoStyle;
+}
+
+export interface GenerateLogoResult {
+  success: boolean;
+  imageUrl: string;
+  name: string;
+  symbol: string;
+  style: string;
+}
+
+/**
+ * Generate an AI logo for a token via vybes.fun Workers AI (FLUX model).
+ * Free, no payment required. Rate limited to 20/hour.
+ * Returns a public URL to a 1024x1024 PNG.
+ *
+ * @param params - Token name, symbol, and optional style
+ */
+export async function generateVybesLogo(
+  params: GenerateLogoParams,
+): Promise<GenerateLogoResult> {
+  const style = params.style || "meme";
+
+  const res = await fetch(`${VYBES_API_URL}/api/agent/logo`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      name: params.name,
+      symbol: params.symbol,
+      style,
+    }),
+  });
+
+  const data = await res.json();
+
+  if (!data.success) {
+    throw new Error(data.error || "Logo generation failed");
+  }
+
+  return {
+    success: true,
+    imageUrl: data.data.imageUrl,
+    name: params.name,
+    symbol: params.symbol,
+    style,
+  };
+}

--- a/packages/plugin-vybes/src/vybes/tools/getEarnings.ts
+++ b/packages/plugin-vybes/src/vybes/tools/getEarnings.ts
@@ -1,0 +1,31 @@
+const VYBES_API_URL = "https://vybes.fun";
+
+export interface VybesEarnings {
+  tokensLaunched: number;
+  totalPredictions: number;
+  totalBetLamports: number;
+  totalPayoutLamports: number;
+  netProfitLamports: number;
+  tokens: any[];
+  predictions: any[];
+}
+
+/**
+ * Get earnings summary for a wallet from vybes.fun.
+ * Free, read-only endpoint. Returns tokens launched, prediction bets,
+ * payouts, and net profit.
+ *
+ * @param wallet - Solana wallet address
+ */
+export async function getVybesEarnings(
+  wallet: string,
+): Promise<VybesEarnings> {
+  const res = await fetch(`${VYBES_API_URL}/api/agent/earnings?wallet=${wallet}`);
+  const data = await res.json();
+
+  if (!data.success) {
+    throw new Error(data.error || "Failed to get earnings");
+  }
+
+  return data.data;
+}

--- a/packages/plugin-vybes/src/vybes/tools/index.ts
+++ b/packages/plugin-vybes/src/vybes/tools/index.ts
@@ -1,0 +1,20 @@
+export { launchTokenOnVybes } from "./launchToken";
+export type { LaunchTokenParams, LaunchTokenResult } from "./launchToken";
+
+export { generateVybesLogo } from "./generateLogo";
+export type {
+  GenerateLogoParams,
+  GenerateLogoResult,
+  VybesLogoStyle,
+} from "./generateLogo";
+
+export { createVybesPrediction } from "./createPrediction";
+export type {
+  CreatePredictionParams,
+  CreatePredictionResult,
+  VybesTemplateType,
+  VybesDuration,
+} from "./createPrediction";
+
+export { getVybesEarnings } from "./getEarnings";
+export type { VybesEarnings } from "./getEarnings";

--- a/packages/plugin-vybes/src/vybes/tools/launchToken.ts
+++ b/packages/plugin-vybes/src/vybes/tools/launchToken.ts
@@ -1,0 +1,116 @@
+import {
+  PublicKey,
+  SystemProgram,
+  Transaction,
+} from "@solana/web3.js";
+import { type SolanaAgentKit, signOrSendTX } from "solana-agent-kit";
+
+const VYBES_API_URL = "https://vybes.fun";
+
+export interface LaunchTokenParams {
+  name: string;
+  symbol: string;
+  description?: string;
+  imageUrl?: string;
+  style?: string;
+}
+
+export interface LaunchTokenResult {
+  success: boolean;
+  tokenAddress: string;
+  uuid: string;
+  name: string;
+  symbol: string;
+  imageUrl?: string;
+  viewUrl: string;
+  paymentTx: string;
+}
+
+/**
+ * Launch a token on vybes.fun with bonding curve.
+ * Handles the full flow: get fee info -> generate logo (optional) -> send payment -> create token.
+ *
+ * Free to launch (0 SOL creation fee). Token gets a bonding curve for trading
+ * and graduates to Meteora DEX at ~85 SOL raised.
+ *
+ * @param agent - SolanaAgentKit instance
+ * @param params - Token name, symbol, description, and optional imageUrl/style
+ */
+export async function launchTokenOnVybes(
+  agent: SolanaAgentKit,
+  params: LaunchTokenParams,
+): Promise<LaunchTokenResult> {
+  const walletAddress = agent.wallet.publicKey.toBase58();
+
+  // 1. Get fee info
+  const infoRes = await fetch(`${VYBES_API_URL}/api/agent/launch?action=info`);
+  const infoData = await infoRes.json();
+  if (!infoData.success) throw new Error("Failed to get vybes launch info");
+  const { feeLamports, revenueWallet } = infoData.data;
+
+  // 2. Generate logo if no imageUrl provided
+  let imageUrl = params.imageUrl;
+  if (!imageUrl) {
+    const logoRes = await fetch(`${VYBES_API_URL}/api/agent/logo`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: params.name,
+        symbol: params.symbol,
+        style: params.style || "meme",
+      }),
+    });
+    const logoData = await logoRes.json();
+    if (logoData.success) {
+      imageUrl = logoData.data.imageUrl;
+    }
+  }
+
+  // 3. Send payment (only if fee > 0)
+  let paymentTx = "";
+  if (feeLamports > 0) {
+    const tx = new Transaction().add(
+      SystemProgram.transfer({
+        fromPubkey: agent.wallet.publicKey,
+        toPubkey: new PublicKey(revenueWallet),
+        lamports: feeLamports,
+      }),
+    );
+    const { blockhash } = await agent.connection.getLatestBlockhash();
+    tx.recentBlockhash = blockhash;
+    tx.feePayer = agent.wallet.publicKey;
+
+    const result = await signOrSendTX(agent, tx);
+    paymentTx = typeof result === "string" ? result : "";
+  }
+
+  // 4. Launch token
+  const launchRes = await fetch(`${VYBES_API_URL}/api/agent/launch`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      agentWallet: walletAddress,
+      ...(paymentTx && { paymentTxSignature: paymentTx }),
+      name: params.name,
+      symbol: params.symbol.toUpperCase(),
+      description: params.description || "",
+      imageUrl,
+    }),
+  });
+  const result = await launchRes.json();
+
+  if (!result.success) {
+    throw new Error(result.error || "Token launch failed");
+  }
+
+  return {
+    success: true,
+    tokenAddress: result.data.tokenAddress,
+    uuid: result.data.uuid,
+    name: params.name,
+    symbol: params.symbol.toUpperCase(),
+    imageUrl,
+    viewUrl: `${VYBES_API_URL}/launch/${result.data.uuid}`,
+    paymentTx,
+  };
+}

--- a/packages/plugin-vybes/tsconfig.json
+++ b/packages/plugin-vybes/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,10 +109,10 @@ importers:
         version: 0.2.7(zod@3.24.1)
       '@langchain/core':
         specifier: ^0.3.44
-        version: 0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1))
+        version: 0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1))
       '@openai/agents':
         specifier: ^0.0.7
-        version: 0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
+        version: 0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
       '@solana/spl-token':
         specifier: ^0.4.13
         version: 0.4.13(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.7.2)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)(utf-8-validate@5.0.10)
@@ -464,26 +464,47 @@ importers:
         specifier: ^8.4.0
         version: 8.4.0(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
 
+  packages/plugin-vybes:
+    dependencies:
+      '@solana/spl-token':
+        specifier: ^0.4.9
+        version: 0.4.13(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js':
+        specifier: ^1.98.2
+        version: 1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      bs58:
+        specifier: ^6.0.0
+        version: 6.0.0
+      redaxios:
+        specifier: ^0.5.1
+        version: 0.5.1
+      solana-agent-kit:
+        specifier: workspace:*
+        version: link:../core
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.63
+
   test:
     dependencies:
       '@ai-sdk/openai':
         specifier: ^1.3.10
-        version: 1.3.20(zod@3.24.4)
+        version: 1.3.20(zod@3.25.63)
       '@anthropic-ai/sdk':
         specifier: ^0.39.0
         version: 0.39.0(encoding@0.1.13)
       '@langchain/core':
         specifier: ^0.3.44
-        version: 0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4))
+        version: 0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63))
       '@langchain/langgraph':
         specifier: ^0.2.63
-        version: 0.2.67(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))(react@19.0.0)(zod-to-json-schema@3.24.1(zod@3.24.4))
+        version: 0.2.67(@langchain/core@0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))(react@19.0.0)(zod-to-json-schema@3.24.1(zod@3.25.63))
       '@langchain/openai':
         specifier: ^0.5.5
-        version: 0.5.7(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))(encoding@0.1.13)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 0.5.7(@langchain/core@0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))(encoding@0.1.13)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@openai/agents':
         specifier: ^0.0.7
-        version: 0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+        version: 0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
       '@solana-agent-kit/plugin-blinks':
         specifier: workspace:*
         version: link:../packages/plugin-blinks
@@ -504,7 +525,7 @@ importers:
         version: 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
       ai:
         specifier: ^4.1.5
-        version: 4.1.5(react@19.0.0)(zod@3.24.4)
+        version: 4.1.5(react@19.0.0)(zod@3.25.63)
       bs58:
         specifier: ^6.0.0
         version: 6.0.0
@@ -513,13 +534,13 @@ importers:
         version: 16.4.7
       openai:
         specifier: ^5.3.0
-        version: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+        version: 5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
       solana-agent-kit:
         specifier: workspace:*
         version: link:../packages/core
       zod-to-json-schema:
         specifier: ^3.24.1
-        version: 3.24.1(zod@3.24.4)
+        version: 3.24.1(zod@3.25.63)
     devDependencies:
       tsx:
         specifier: ^4.19.2
@@ -6900,11 +6921,11 @@ snapshots:
 
   '@adraffy/ens-normalize@1.10.1': {}
 
-  '@ai-sdk/openai@1.3.20(zod@3.24.4)':
+  '@ai-sdk/openai@1.3.20(zod@3.25.63)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.4)
-      zod: 3.24.4
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.63)
+      zod: 3.25.63
 
   '@ai-sdk/provider-utils@2.1.2(zod@3.24.1)':
     dependencies:
@@ -6915,15 +6936,6 @@ snapshots:
     optionalDependencies:
       zod: 3.24.1
 
-  '@ai-sdk/provider-utils@2.1.2(zod@3.24.4)':
-    dependencies:
-      '@ai-sdk/provider': 1.0.6
-      eventsource-parser: 3.0.0
-      nanoid: 3.3.8
-      secure-json-parse: 2.7.0
-    optionalDependencies:
-      zod: 3.24.4
-
   '@ai-sdk/provider-utils@2.1.2(zod@3.25.63)':
     dependencies:
       '@ai-sdk/provider': 1.0.6
@@ -6933,12 +6945,12 @@ snapshots:
     optionalDependencies:
       zod: 3.25.63
 
-  '@ai-sdk/provider-utils@2.2.7(zod@3.24.4)':
+  '@ai-sdk/provider-utils@2.2.7(zod@3.25.63)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       nanoid: 3.3.8
       secure-json-parse: 2.7.0
-      zod: 3.24.4
+      zod: 3.25.63
 
   '@ai-sdk/provider@1.0.6':
     dependencies:
@@ -6958,16 +6970,6 @@ snapshots:
       react: 19.0.0
       zod: 3.24.1
 
-  '@ai-sdk/react@1.1.3(react@19.0.0)(zod@3.24.4)':
-    dependencies:
-      '@ai-sdk/provider-utils': 2.1.2(zod@3.24.4)
-      '@ai-sdk/ui-utils': 1.1.3(zod@3.24.4)
-      swr: 2.3.3(react@19.0.0)
-      throttleit: 2.1.0
-    optionalDependencies:
-      react: 19.0.0
-      zod: 3.24.4
-
   '@ai-sdk/react@1.1.3(react@19.0.0)(zod@3.25.63)':
     dependencies:
       '@ai-sdk/provider-utils': 2.1.2(zod@3.25.63)
@@ -6985,14 +6987,6 @@ snapshots:
       zod-to-json-schema: 3.24.1(zod@3.24.1)
     optionalDependencies:
       zod: 3.24.1
-
-  '@ai-sdk/ui-utils@1.1.3(zod@3.24.4)':
-    dependencies:
-      '@ai-sdk/provider': 1.0.6
-      '@ai-sdk/provider-utils': 2.1.2(zod@3.24.4)
-      zod-to-json-schema: 3.24.1(zod@3.24.4)
-    optionalDependencies:
-      zod: 3.24.4
 
   '@ai-sdk/ui-utils@1.1.3(zod@3.25.63)':
     dependencies:
@@ -7053,7 +7047,7 @@ snapshots:
       '@aptos-labs/aptos-cli': 1.0.2
       '@aptos-labs/aptos-client': 0.1.1
       '@noble/curves': 1.8.2
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.7.2
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
       eventemitter3: 5.0.1
@@ -8554,14 +8548,14 @@ snapshots:
 
   '@jup-ag/api@6.0.39': {}
 
-  '@langchain/core@0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1))':
+  '@langchain/core@0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.19
-      langsmith: 0.3.15(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1))
+      langsmith: 0.3.15(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -8571,14 +8565,14 @@ snapshots:
     transitivePeerDependencies:
       - openai
 
-  '@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4))':
+  '@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.19
-      langsmith: 0.3.15(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4))
+      langsmith: 0.3.15(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -8588,40 +8582,40 @@ snapshots:
     transitivePeerDependencies:
       - openai
 
-  '@langchain/langgraph-checkpoint@0.0.17(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))':
+  '@langchain/langgraph-checkpoint@0.0.17(@langchain/core@0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))':
     dependencies:
-      '@langchain/core': 0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4))
+      '@langchain/core': 0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63))
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@0.0.70(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))(react@19.0.0)':
+  '@langchain/langgraph-sdk@0.0.70(@langchain/core@0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))(react@19.0.0)':
     dependencies:
       '@types/json-schema': 7.0.15
       p-queue: 6.6.2
       p-retry: 4.6.2
       uuid: 9.0.1
     optionalDependencies:
-      '@langchain/core': 0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4))
+      '@langchain/core': 0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63))
       react: 19.0.0
 
-  '@langchain/langgraph@0.2.67(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))(react@19.0.0)(zod-to-json-schema@3.24.1(zod@3.24.4))':
+  '@langchain/langgraph@0.2.67(@langchain/core@0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))(react@19.0.0)(zod-to-json-schema@3.24.1(zod@3.25.63))':
     dependencies:
-      '@langchain/core': 0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4))
-      '@langchain/langgraph-checkpoint': 0.0.17(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))
-      '@langchain/langgraph-sdk': 0.0.70(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))(react@19.0.0)
+      '@langchain/core': 0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63))
+      '@langchain/langgraph-checkpoint': 0.0.17(@langchain/core@0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))
+      '@langchain/langgraph-sdk': 0.0.70(@langchain/core@0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))(react@19.0.0)
       uuid: 10.0.0
-      zod: 3.24.4
+      zod: 3.25.63
     optionalDependencies:
-      zod-to-json-schema: 3.24.1(zod@3.24.4)
+      zod-to-json-schema: 3.24.1(zod@3.25.63)
     transitivePeerDependencies:
       - react
 
-  '@langchain/openai@0.5.7(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))(encoding@0.1.13)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@langchain/openai@0.5.7(@langchain/core@0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))(encoding@0.1.13)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4))
+      '@langchain/core': 0.3.44(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63))
       js-tiktoken: 1.0.19
-      openai: 4.93.0(encoding@0.1.13)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
-      zod: 3.24.4
-      zod-to-json-schema: 3.24.1(zod@3.24.4)
+      openai: 4.93.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
+      zod: 3.25.63
+      zod-to-json-schema: 3.24.1(zod@3.25.63)
     transitivePeerDependencies:
       - encoding
       - ws
@@ -8901,7 +8895,7 @@ snapshots:
     dependencies:
       ansicolors: 0.3.2
       assert: 2.1.0
-      bn.js: 5.2.1
+      bn.js: 5.2.2
       debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
@@ -8924,7 +8918,7 @@ snapshots:
       '@metaplex-foundation/mpl-candy-machine-core': 0.1.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.6.3)(utf-8-validate@5.0.10)
       '@metaplex-foundation/mpl-token-metadata': 2.13.0(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)
       '@noble/ed25519': 1.7.3
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.7.2
       '@solana/spl-account-compression': 0.1.10(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.6.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.6.3)(utf-8-validate@5.0.10)
       '@solana/spl-token': 0.3.11(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.6.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.6.3)(utf-8-validate@5.0.10)
@@ -9605,14 +9599,14 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@openai/agents-core@0.0.7(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)':
+  '@openai/agents-core@0.0.7(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)':
     dependencies:
       '@openai/zod': zod@3.25.63
       debug: 4.4.0
-      openai: 5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
+      openai: 5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.12.1
-      zod: 3.24.1
+      zod: 3.25.63
     transitivePeerDependencies:
       - supports-color
       - ws
@@ -9629,35 +9623,35 @@ snapshots:
       - supports-color
       - ws
 
-  '@openai/agents-core@0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)':
+  '@openai/agents-core@0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)':
     dependencies:
       '@openai/zod': zod@3.25.63
       debug: 4.4.0
-      openai: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+      openai: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.12.1
-      zod: 3.24.4
+      zod: 3.25.63
     transitivePeerDependencies:
       - supports-color
       - ws
 
-  '@openai/agents-openai@0.0.7(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)':
+  '@openai/agents-openai@0.0.7(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)':
     dependencies:
-      '@openai/agents-core': 0.0.7(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
+      '@openai/agents-core': 0.0.7(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
       '@openai/zod': zod@3.25.63
       debug: 4.4.0
-      openai: 5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
+      openai: 5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
     transitivePeerDependencies:
       - supports-color
       - ws
       - zod
 
-  '@openai/agents-openai@0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)':
+  '@openai/agents-openai@0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)':
     dependencies:
-      '@openai/agents-core': 0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+      '@openai/agents-core': 0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
       '@openai/zod': zod@3.25.63
       debug: 4.4.0
-      openai: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+      openai: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
     transitivePeerDependencies:
       - supports-color
       - ws
@@ -9676,9 +9670,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@openai/agents-realtime@0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(zod@3.24.4)':
+  '@openai/agents-realtime@0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(zod@3.25.63)':
     dependencies:
-      '@openai/agents-core': 0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+      '@openai/agents-core': 0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
       '@openai/zod': zod@3.25.63
       '@types/ws': 8.18.1
       debug: 4.4.0
@@ -9689,13 +9683,13 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@openai/agents@0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)':
+  '@openai/agents@0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)':
     dependencies:
-      '@openai/agents-core': 0.0.7(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
-      '@openai/agents-openai': 0.0.7(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
-      '@openai/agents-realtime': 0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(zod@3.24.1)
+      '@openai/agents-core': 0.0.7(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
+      '@openai/agents-openai': 0.0.7(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
+      '@openai/agents-realtime': 0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(zod@3.25.63)
       debug: 4.4.0
-      openai: 5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
+      openai: 5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -9703,13 +9697,13 @@ snapshots:
       - ws
       - zod
 
-  '@openai/agents@0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)':
+  '@openai/agents@0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)':
     dependencies:
-      '@openai/agents-core': 0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
-      '@openai/agents-openai': 0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
-      '@openai/agents-realtime': 0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(zod@3.24.4)
+      '@openai/agents-core': 0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
+      '@openai/agents-openai': 0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
+      '@openai/agents-realtime': 0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(zod@3.24.1)
       debug: 4.4.0
-      openai: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+      openai: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -10024,7 +10018,7 @@ snapshots:
   '@pythnetwork/pyth-solana-receiver@0.7.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.6.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@coral-xyz/anchor': 0.29.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.6.3)(utf-8-validate@5.0.10)
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.7.2
       '@pythnetwork/price-service-sdk': 1.7.1
       '@pythnetwork/solana-utils': 0.4.3(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.6.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.6.3)(utf-8-validate@5.0.10)
@@ -10037,7 +10031,7 @@ snapshots:
   '@pythnetwork/pyth-solana-receiver@0.7.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@coral-xyz/anchor': 0.29.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.7.2
       '@pythnetwork/price-service-sdk': 1.7.1
       '@pythnetwork/solana-utils': 0.4.3(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
@@ -11150,7 +11144,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.27.1
       '@noble/curves': 1.8.2
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.7.2
       '@solana/buffer-layout': 4.0.1
       agentkeepalive: 4.6.0
       bigint-buffer: 1.1.5
@@ -11855,18 +11849,6 @@ snapshots:
       react: 19.0.0
       zod: 3.24.1
 
-  ai@4.1.5(react@19.0.0)(zod@3.24.4):
-    dependencies:
-      '@ai-sdk/provider': 1.0.6
-      '@ai-sdk/provider-utils': 2.1.2(zod@3.24.4)
-      '@ai-sdk/react': 1.1.3(react@19.0.0)(zod@3.24.4)
-      '@ai-sdk/ui-utils': 1.1.3(zod@3.24.4)
-      '@opentelemetry/api': 1.9.0
-      jsondiffpatch: 0.6.0
-    optionalDependencies:
-      react: 19.0.0
-      zod: 3.24.4
-
   ai@4.1.5(react@19.0.0)(zod@3.25.63):
     dependencies:
       '@ai-sdk/provider': 1.0.6
@@ -12257,7 +12239,7 @@ snapshots:
 
   borsh@0.7.0:
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 5.2.2
       bs58: 4.0.1
       text-encoding-utf-8: 1.0.2
 
@@ -13996,7 +13978,7 @@ snapshots:
 
   keccak256@1.0.6:
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 5.2.2
       buffer: 6.0.3
       keccak: 3.0.4
 
@@ -14010,7 +13992,7 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  langsmith@0.3.15(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)):
+  langsmith@0.3.15(openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -14020,9 +14002,9 @@ snapshots:
       semver: 7.7.1
       uuid: 10.0.0
     optionalDependencies:
-      openai: 5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
+      openai: 5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
 
-  langsmith@0.3.15(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)):
+  langsmith@0.3.15(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -14032,7 +14014,7 @@ snapshots:
       semver: 7.7.1
       uuid: 10.0.0
     optionalDependencies:
-      openai: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+      openai: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
 
   lazy-ass@1.6.0: {}
 
@@ -14456,7 +14438,7 @@ snapshots:
       regex: 5.1.1
       regex-recursion: 5.1.1
 
-  openai@4.93.0(encoding@0.1.13)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4):
+  openai@4.93.0(encoding@0.1.13)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63):
     dependencies:
       '@types/node': 18.19.74
       '@types/node-fetch': 2.6.12
@@ -14466,25 +14448,25 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0(encoding@0.1.13)
     optionalDependencies:
-      ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      zod: 3.24.4
+      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      zod: 3.25.63
     transitivePeerDependencies:
       - encoding
 
-  openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1):
+  openai@5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63):
     optionalDependencies:
       ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      zod: 3.24.1
+      zod: 3.25.63
 
   openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1):
     optionalDependencies:
       ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       zod: 3.24.1
 
-  openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4):
+  openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63):
     optionalDependencies:
       ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      zod: 3.24.4
+      zod: 3.25.63
 
   optionator@0.9.4:
     dependencies:
@@ -15010,7 +14992,7 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.15
       '@types/uuid': 8.3.4
-      '@types/ws': 8.5.13
+      '@types/ws': 8.18.1
       buffer: 6.0.3
       eventemitter3: 5.0.1
       uuid: 8.3.2
@@ -16136,7 +16118,7 @@ snapshots:
       util: 0.12.5
       web3-errors: 1.3.1
       web3-types: 1.10.0
-      zod: 3.24.4
+      zod: 3.25.63
 
   web3@4.16.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.1):
     dependencies:


### PR DESCRIPTION
## Summary

- Add `@solana-agent-kit/plugin-vybes` — a new plugin that integrates [vybes.fun](https://vybes.fun) into the Solana Agent Kit
- **4 tools** (programmatic API): `launchTokenOnVybes`, `generateVybesLogo`, `createVybesPrediction`, `getVybesEarnings`
- **3 actions** (AI agent tools with Zod schemas): `LAUNCH_VYBES_TOKEN`, `GENERATE_VYBES_LOGO`, `CREATE_VYBES_PREDICTION`
- All operations are free (0 SOL creation fee). Tokens get a bonding curve and graduate to Meteora DEX at ~85 SOL raised. Predictions auto-resolve via cron.
- Follows the existing plugin architecture: `packages/plugin-vybes/src/vybes/{tools,actions}/`
- Includes docs page at `docs/v2/plugins/vybes/`, build script in root `package.json`, and nav entry in `docs.json`

### What vybes.fun does

Vybes.fun is a Solana meme token launchpad with:
- **Token launch** with bonding curve + AI-generated logos (10 styles via FLUX model)
- **Prediction markets** — 6 auto-resolvable template types (graduation, market cap, multiplier, ATH flip, holder count, volume target)
- **Earnings tracking** — tokens launched, bets placed, payouts received

### Links

- Developer docs: https://vybes.fun/developers
- Plugin source: https://github.com/AICre8dev/solana-agent-kit-vybes
- skill.md (OpenClaw): https://vybes.fun/skill.md

## Test plan

- [ ] `pnpm install` succeeds with new package
- [ ] `pnpm run build:plugin-vybes` compiles CJS + ESM
- [ ] Plugin registers correctly via `.use(VybesPlugin)`
- [ ] Actions have valid Zod schemas and examples
- [ ] Docs page renders at `/docs/v2/plugins/vybes/vybes-plugin-intro`

🤖 Generated with [Claude Code](https://claude.com/claude-code)