### PR TITLE
feat: add MadeOnSol Solana KOL intelligence integration

### DIFF
--- a/packages/plugin-misc/src/index.ts
+++ b/packages/plugin-misc/src/index.ts
@@ -178,6 +178,18 @@ import getVerificationJobStatusAction from "./ottersec/actions/getVerificationJo
 import getVerifiedProgramsAction from "./ottersec/actions/getVerifiedPrograms";
 import verifyProgramAction from "./ottersec/actions/verifyProgram";
 
+// madeonsol
+import madeonsolKolFeedAction from "./madeonsol/actions/kolFeed";
+import madeonsolKolCoordinationAction from "./madeonsol/actions/kolCoordination";
+import madeonsolKolLeaderboardAction from "./madeonsol/actions/kolLeaderboard";
+import madeonsolDeployerAlertsAction from "./madeonsol/actions/deployerAlerts";
+import {
+  madeonsol_kol_feed,
+  madeonsol_kol_coordination,
+  madeonsol_kol_leaderboard,
+  madeonsol_deployer_alerts,
+} from "./madeonsol/tools";
+
 // Define and export the plugin
 const MiscPlugin = {
   name: "misc",
@@ -248,6 +260,10 @@ const MiscPlugin = {
     get_verification_job_status,
     get_verified_programs,
     verify_program,
+    madeonsol_kol_feed,
+    madeonsol_kol_coordination,
+    madeonsol_kol_leaderboard,
+    madeonsol_deployer_alerts,
   },
 
   // Combine all actions
@@ -315,6 +331,10 @@ const MiscPlugin = {
     getVerificationJobStatusAction,
     getVerifiedProgramsAction,
     verifyProgramAction,
+    madeonsolKolFeedAction,
+    madeonsolKolCoordinationAction,
+    madeonsolKolLeaderboardAction,
+    madeonsolDeployerAlertsAction,
   ],
 
   // Initialize function

--- a/packages/plugin-misc/src/madeonsol/actions/deployerAlerts.ts
+++ b/packages/plugin-misc/src/madeonsol/actions/deployerAlerts.ts
@@ -1,0 +1,65 @@
+import { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { madeonsol_deployer_alerts } from "../tools";
+
+const madeonsolDeployerAlertsAction: Action = {
+  name: "MADEONSOL_DEPLOYER_ALERTS_ACTION",
+  similes: [
+    "deployer alerts",
+    "new token launches",
+    "deployer activity",
+    "pump fun deployers",
+    "serial deployer alerts",
+    "new solana tokens",
+  ],
+  description:
+    "Get alerts for suspicious or notable Solana token deployers via MadeOnSol. Tracks serial deployers, rug patterns, and new token launches on Pump.fun and Raydium.",
+  examples: [
+    [
+      {
+        input: { limit: 10 },
+        output: {
+          status: "success",
+          result: {
+            alerts: [
+              {
+                deployer: "5xYz...",
+                token_count: 12,
+                risk_score: 0.85,
+                latest_token: "SCAM",
+              },
+            ],
+          },
+        },
+        explanation: "Get the 10 most recent deployer alerts",
+      },
+    ],
+  ],
+  schema: z.object({
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .default(10)
+      .describe("Number of alerts to return"),
+    since: z
+      .string()
+      .optional()
+      .describe("ISO timestamp to filter alerts after"),
+    offset: z.number().optional().describe("Pagination offset"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const data = await madeonsol_deployer_alerts(agent, input);
+      return { status: "success", result: data };
+    } catch (e) {
+      return {
+        status: "error",
+        // @ts-expect-error - error is not a property of unknown
+        message: e.message,
+      };
+    }
+  },
+};
+
+export default madeonsolDeployerAlertsAction;

--- a/packages/plugin-misc/src/madeonsol/actions/kolCoordination.ts
+++ b/packages/plugin-misc/src/madeonsol/actions/kolCoordination.ts
@@ -1,0 +1,69 @@
+import { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { madeonsol_kol_coordination } from "../tools";
+
+const madeonsolKolCoordinationAction: Action = {
+  name: "MADEONSOL_KOL_COORDINATION_ACTION",
+  similes: [
+    "kol coordination",
+    "tokens multiple kols are buying",
+    "coordinated kol trades",
+    "kol convergence",
+    "smart money consensus",
+  ],
+  description:
+    "Detect tokens that multiple Solana KOLs are trading simultaneously via MadeOnSol. Surfaces potential coordinated moves or organic convergence on the same token.",
+  examples: [
+    [
+      {
+        input: { period: "1h", min_kols: 3, limit: 5 },
+        output: {
+          status: "success",
+          result: {
+            tokens: [
+              {
+                token: "BONK",
+                kol_count: 5,
+                total_volume_usd: 250000,
+              },
+            ],
+          },
+        },
+        explanation:
+          "Find tokens that at least 3 KOLs traded in the last hour",
+      },
+    ],
+  ],
+  schema: z.object({
+    period: z
+      .string()
+      .default("1h")
+      .describe("Time period to check (e.g. 1h, 4h, 24h)"),
+    min_kols: z
+      .number()
+      .min(2)
+      .max(50)
+      .default(3)
+      .describe("Minimum number of KOLs that must have traded the token"),
+    limit: z
+      .number()
+      .min(1)
+      .max(50)
+      .default(10)
+      .describe("Number of results to return"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const data = await madeonsol_kol_coordination(agent, input);
+      return { status: "success", result: data };
+    } catch (e) {
+      return {
+        status: "error",
+        // @ts-expect-error - error is not a property of unknown
+        message: e.message,
+      };
+    }
+  },
+};
+
+export default madeonsolKolCoordinationAction;

--- a/packages/plugin-misc/src/madeonsol/actions/kolFeed.ts
+++ b/packages/plugin-misc/src/madeonsol/actions/kolFeed.ts
@@ -1,0 +1,64 @@
+import { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { madeonsol_kol_feed } from "../tools";
+
+const madeonsolKolFeedAction: Action = {
+  name: "MADEONSOL_KOL_FEED_ACTION",
+  similes: [
+    "kol trades",
+    "what are kols buying",
+    "kol feed",
+    "smart money trades",
+    "kol wallet activity",
+  ],
+  description:
+    "Get real-time Solana KOL (Key Opinion Leader) trades from 946 tracked wallets via MadeOnSol. Returns recent buys and sells with token, amount, and KOL identity.",
+  examples: [
+    [
+      {
+        input: { limit: 10, action: "buy" },
+        output: {
+          status: "success",
+          result: {
+            trades: [
+              {
+                kol: "ansem",
+                action: "buy",
+                token: "BONK",
+                amount_usd: 50000,
+              },
+            ],
+          },
+        },
+        explanation: "Fetch the 10 most recent KOL buy trades",
+      },
+    ],
+  ],
+  schema: z.object({
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .default(10)
+      .describe("Number of trades to return"),
+    action: z
+      .enum(["buy", "sell"])
+      .optional()
+      .describe("Filter by trade type"),
+    kol: z.string().optional().describe("Filter by KOL name"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const data = await madeonsol_kol_feed(agent, input);
+      return { status: "success", result: data };
+    } catch (e) {
+      return {
+        status: "error",
+        // @ts-expect-error - error is not a property of unknown
+        message: e.message,
+      };
+    }
+  },
+};
+
+export default madeonsolKolFeedAction;

--- a/packages/plugin-misc/src/madeonsol/actions/kolLeaderboard.ts
+++ b/packages/plugin-misc/src/madeonsol/actions/kolLeaderboard.ts
@@ -1,0 +1,63 @@
+import { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { madeonsol_kol_leaderboard } from "../tools";
+
+const madeonsolKolLeaderboardAction: Action = {
+  name: "MADEONSOL_KOL_LEADERBOARD_ACTION",
+  similes: [
+    "kol leaderboard",
+    "best performing kols",
+    "top kol traders",
+    "kol rankings",
+    "who are the best solana kols",
+  ],
+  description:
+    "Get the top-performing Solana KOL traders ranked by PnL via MadeOnSol. Shows win rate, total volume, and realized profit for each tracked KOL wallet.",
+  examples: [
+    [
+      {
+        input: { period: "7d", limit: 10 },
+        output: {
+          status: "success",
+          result: {
+            leaderboard: [
+              {
+                kol: "ansem",
+                pnl_usd: 120000,
+                win_rate: 0.72,
+                trade_count: 45,
+              },
+            ],
+          },
+        },
+        explanation: "Get the top 10 KOLs by PnL over the last 7 days",
+      },
+    ],
+  ],
+  schema: z.object({
+    period: z
+      .string()
+      .default("7d")
+      .describe("Time period (e.g. 24h, 7d, 30d)"),
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .default(10)
+      .describe("Number of KOLs to return"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const data = await madeonsol_kol_leaderboard(agent, input);
+      return { status: "success", result: data };
+    } catch (e) {
+      return {
+        status: "error",
+        // @ts-expect-error - error is not a property of unknown
+        message: e.message,
+      };
+    }
+  },
+};
+
+export default madeonsolKolLeaderboardAction;

--- a/packages/plugin-misc/src/madeonsol/tools/deployer_alerts.ts
+++ b/packages/plugin-misc/src/madeonsol/tools/deployer_alerts.ts
@@ -1,0 +1,31 @@
+import { SolanaAgentKit } from "solana-agent-kit";
+
+const BASE_URL = "https://madeonsol.com";
+
+async function query(
+  path: string,
+  params?: Record<string, string | number>,
+) {
+  const url = new URL(path, BASE_URL);
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      if (v !== undefined) url.searchParams.set(k, String(v));
+    }
+  }
+  const res = await fetch(url.toString());
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`MadeOnSol API error ${res.status}: ${body}`);
+  }
+  return res.json();
+}
+
+export async function madeonsol_deployer_alerts(
+  agent: SolanaAgentKit,
+  params: { limit?: number; since?: string; offset?: number } = {},
+) {
+  return query(
+    "/api/x402/deployer-hunter/alerts",
+    params as Record<string, string | number>,
+  );
+}

--- a/packages/plugin-misc/src/madeonsol/tools/index.ts
+++ b/packages/plugin-misc/src/madeonsol/tools/index.ts
@@ -1,0 +1,4 @@
+export * from "./kol_feed";
+export * from "./kol_coordination";
+export * from "./kol_leaderboard";
+export * from "./deployer_alerts";

--- a/packages/plugin-misc/src/madeonsol/tools/kol_coordination.ts
+++ b/packages/plugin-misc/src/madeonsol/tools/kol_coordination.ts
@@ -1,0 +1,31 @@
+import { SolanaAgentKit } from "solana-agent-kit";
+
+const BASE_URL = "https://madeonsol.com";
+
+async function query(
+  path: string,
+  params?: Record<string, string | number>,
+) {
+  const url = new URL(path, BASE_URL);
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      if (v !== undefined) url.searchParams.set(k, String(v));
+    }
+  }
+  const res = await fetch(url.toString());
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`MadeOnSol API error ${res.status}: ${body}`);
+  }
+  return res.json();
+}
+
+export async function madeonsol_kol_coordination(
+  agent: SolanaAgentKit,
+  params: { period?: string; min_kols?: number; limit?: number } = {},
+) {
+  return query(
+    "/api/x402/kol/coordination",
+    params as Record<string, string | number>,
+  );
+}

--- a/packages/plugin-misc/src/madeonsol/tools/kol_feed.ts
+++ b/packages/plugin-misc/src/madeonsol/tools/kol_feed.ts
@@ -1,0 +1,28 @@
+import { SolanaAgentKit } from "solana-agent-kit";
+
+const BASE_URL = "https://madeonsol.com";
+
+async function query(
+  path: string,
+  params?: Record<string, string | number>,
+) {
+  const url = new URL(path, BASE_URL);
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      if (v !== undefined) url.searchParams.set(k, String(v));
+    }
+  }
+  const res = await fetch(url.toString());
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`MadeOnSol API error ${res.status}: ${body}`);
+  }
+  return res.json();
+}
+
+export async function madeonsol_kol_feed(
+  agent: SolanaAgentKit,
+  params: { limit?: number; action?: string; kol?: string } = {},
+) {
+  return query("/api/x402/kol/feed", params as Record<string, string | number>);
+}

--- a/packages/plugin-misc/src/madeonsol/tools/kol_leaderboard.ts
+++ b/packages/plugin-misc/src/madeonsol/tools/kol_leaderboard.ts
@@ -1,0 +1,31 @@
+import { SolanaAgentKit } from "solana-agent-kit";
+
+const BASE_URL = "https://madeonsol.com";
+
+async function query(
+  path: string,
+  params?: Record<string, string | number>,
+) {
+  const url = new URL(path, BASE_URL);
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      if (v !== undefined) url.searchParams.set(k, String(v));
+    }
+  }
+  const res = await fetch(url.toString());
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`MadeOnSol API error ${res.status}: ${body}`);
+  }
+  return res.json();
+}
+
+export async function madeonsol_kol_leaderboard(
+  agent: SolanaAgentKit,
+  params: { period?: string; limit?: number } = {},
+) {
+  return query(
+    "/api/x402/kol/leaderboard",
+    params as Record<string, string | number>,
+  );
+}


### PR DESCRIPTION
## Summary

- **MadeOnSol** ([madeonsol.com](https://madeonsol.com)) is a Solana ecosystem intelligence platform that tracks 946+ KOL (Key Opinion Leader) wallets in real-time and monitors serial token deployers across Pump.fun and Raydium.
- Adds 4 new tools and actions to `plugin-misc` that call MadeOnSol's public x402 API endpoints for pay-per-request Solana alpha data.

## Endpoints added

| Action | Endpoint | Description |
|--------|----------|-------------|
| `MADEONSOL_KOL_FEED_ACTION` | `/api/x402/kol/feed` | Real-time KOL buy/sell trades with token, amount, and KOL identity |
| `MADEONSOL_KOL_COORDINATION_ACTION` | `/api/x402/kol/coordination` | Tokens that multiple KOLs are trading simultaneously (convergence detection) |
| `MADEONSOL_KOL_LEADERBOARD_ACTION` | `/api/x402/kol/leaderboard` | Top KOL traders ranked by PnL, win rate, and volume |
| `MADEONSOL_DEPLOYER_ALERTS_ACTION` | `/api/x402/deployer-hunter/alerts` | Alerts for suspicious serial deployers and rug patterns |

## Protocol

Uses the [x402](https://www.x402.org/) HTTP payment protocol for pay-per-request access — agents pay in SOL per API call with no API key required.

## Links

- API docs: [madeonsol.com/solana-api](https://madeonsol.com/solana-api)
- Discovery endpoint: `https://madeonsol.com/.well-known/x402.json`
- Site: [madeonsol.com](https://madeonsol.com)

## Test plan

- [ ] Verify `plugin-misc` builds without TypeScript errors
- [ ] Test each action returns valid JSON from the MadeOnSol API
- [ ] Confirm actions register correctly in the Solana Agent Kit plugin system

🤖 Generated with [Claude Code](https://claude.com/claude-code)