### PR TITLE
feat: add plugin-moonpay for fiat on/off-ramp

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:plugin-defi": "turbo run build --filter=@solana-agent-kit/plugin-defi",
     "build:plugin-misc": "turbo run build --filter=@solana-agent-kit/plugin-misc",
     "build:plugin-blinks": "turbo run build --filter=@solana-agent-kit/plugin-blinks",
+    "build:plugin-moonpay": "turbo run build --filter=@solana-agent-kit/plugin-moonpay",
     "build:adapter-mcp": "turbo run build --filter=@solana-agent-kit/adapter-mcp",
     "test": "npx tsx test/index.ts",
     "docs": "typedoc",

--- a/packages/plugin-moonpay/package.json
+++ b/packages/plugin-moonpay/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@solana-agent-kit/plugin-moonpay",
+  "version": "1.0.0",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "scripts": {
+    "clean": "rm -rf dist .turbo node_modules",
+    "build": "tsup src/index.ts --dts --clean --format cjs,esm --out-dir dist",
+    "test": "jest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sendaifun/solana-agent-kit.git"
+  },
+  "homepage": "https://github.com/sendaifun/solana-agent-kit/tree/v2/packages/plugin-moonpay",
+  "dependencies": {
+    "solana-agent-kit": "workspace:*",
+    "zod": "^3.24.1"
+  },
+  "peerDependencies": {
+    "@solana/web3.js": "^1.98.2",
+    "solana-agent-kit": "2.0.7"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/plugin-moonpay/src/index.ts
+++ b/packages/plugin-moonpay/src/index.ts
@@ -1,0 +1,50 @@
+import { Plugin, SolanaAgentKit } from "solana-agent-kit";
+
+// Import MoonPay actions
+import moonpayGetBuyQuoteAction from "./moonpay/actions/getBuyQuote";
+import moonpayGetSellQuoteAction from "./moonpay/actions/getSellQuote";
+import moonpayGetTransactionAction from "./moonpay/actions/getTransaction";
+import moonpayGenerateOnRampUrlAction from "./moonpay/actions/generateOnRampUrl";
+import moonpayGenerateOffRampUrlAction from "./moonpay/actions/generateOffRampUrl";
+
+// Import MoonPay tools
+import {
+  moonpayGetBuyQuote,
+  moonpayGetSellQuote,
+  moonpayGetTransaction,
+  moonpayGenerateOnRampUrl,
+  moonpayGenerateOffRampUrl,
+} from "./moonpay/tools";
+
+export * from "./moonpay/tools";
+export * from "./moonpay/types";
+
+const MoonPayPlugin = {
+  name: "moonpay",
+
+  methods: {
+    moonpayGetBuyQuote,
+    moonpayGetSellQuote,
+    moonpayGetTransaction,
+    moonpayGenerateOnRampUrl,
+    moonpayGenerateOffRampUrl,
+  },
+
+  actions: [
+    moonpayGetBuyQuoteAction,
+    moonpayGetSellQuoteAction,
+    moonpayGetTransactionAction,
+    moonpayGenerateOnRampUrlAction,
+    moonpayGenerateOffRampUrlAction,
+  ],
+
+  initialize: function (): void {
+    Object.entries(this.methods).forEach(([methodName, method]) => {
+      if (typeof method === "function") {
+        this.methods[methodName] = method;
+      }
+    });
+  },
+} satisfies Plugin;
+
+export default MoonPayPlugin;

--- a/packages/plugin-moonpay/src/moonpay/actions/generateOffRampUrl.ts
+++ b/packages/plugin-moonpay/src/moonpay/actions/generateOffRampUrl.ts
@@ -1,0 +1,63 @@
+import type { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { moonpayGenerateOffRampUrl } from "../tools/generateOffRampUrl";
+
+const moonpayGenerateOffRampUrlAction: Action = {
+  name: "MOONPAY_GENERATE_OFF_RAMP_URL",
+  similes: [
+    "generate moonpay sell link",
+    "create moonpay off-ramp url",
+    "get moonpay widget url to sell crypto",
+    "moonpay sell crypto link",
+    "create crypto to fiat sell url",
+  ],
+  description:
+    "Generate a MoonPay off-ramp widget URL that can be opened in a browser to sell crypto for fiat currency.",
+  examples: [
+    [
+      {
+        input: {
+          cryptoCode: "sol",
+          amount: 1,
+          fiatCode: "usd",
+        },
+        output: {
+          status: "success",
+          url: "https://sell.moonpay.com?apiKey=...&baseCurrencyCode=sol&baseCurrencyAmount=1&quoteCurrencyCode=usd",
+        },
+        explanation: "Generate a MoonPay URL to sell 1 SOL for USD",
+      },
+    ],
+  ],
+  schema: z.object({
+    cryptoCode: z
+      .string()
+      .min(1)
+      .describe("Crypto currency code to sell, e.g. 'sol', 'eth', 'usdc'"),
+    amount: z
+      .number()
+      .positive()
+      .optional()
+      .describe("Amount of crypto to pre-fill in the widget"),
+    fiatCode: z
+      .string()
+      .optional()
+      .default("usd")
+      .describe("Target fiat currency code (default: 'usd')"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const url = await moonpayGenerateOffRampUrl(
+        agent,
+        input.cryptoCode,
+        input.amount,
+        input.fiatCode,
+      );
+      return { status: "success", url };
+    } catch (e: any) {
+      return { status: "error", message: e.message };
+    }
+  },
+};
+
+export default moonpayGenerateOffRampUrlAction;

--- a/packages/plugin-moonpay/src/moonpay/actions/generateOnRampUrl.ts
+++ b/packages/plugin-moonpay/src/moonpay/actions/generateOnRampUrl.ts
@@ -1,0 +1,70 @@
+import type { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { moonpayGenerateOnRampUrl } from "../tools/generateOnRampUrl";
+
+const moonpayGenerateOnRampUrlAction: Action = {
+  name: "MOONPAY_GENERATE_ON_RAMP_URL",
+  similes: [
+    "generate moonpay buy link",
+    "create moonpay on-ramp url",
+    "get moonpay widget url to buy crypto",
+    "moonpay buy crypto link",
+    "create fiat to crypto purchase url",
+  ],
+  description:
+    "Generate a MoonPay on-ramp widget URL that can be opened in a browser to buy crypto with fiat currency. The agent's wallet address is used by default.",
+  examples: [
+    [
+      {
+        input: {
+          cryptoCode: "sol",
+          amount: 100,
+          fiatCode: "usd",
+        },
+        output: {
+          status: "success",
+          url: "https://buy.moonpay.com?apiKey=...&currencyCode=sol&walletAddress=...&baseCurrencyAmount=100&baseCurrencyCode=usd",
+        },
+        explanation: "Generate a MoonPay URL to buy SOL with 100 USD",
+      },
+    ],
+  ],
+  schema: z.object({
+    cryptoCode: z
+      .string()
+      .min(1)
+      .describe("Crypto currency code to buy, e.g. 'sol', 'eth', 'usdc'"),
+    walletAddress: z
+      .string()
+      .optional()
+      .describe(
+        "Destination wallet address. Defaults to the agent's wallet address.",
+      ),
+    amount: z
+      .number()
+      .positive()
+      .optional()
+      .describe("Fiat amount to pre-fill in the widget"),
+    fiatCode: z
+      .string()
+      .optional()
+      .default("usd")
+      .describe("Fiat currency code (default: 'usd')"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const url = await moonpayGenerateOnRampUrl(
+        agent,
+        input.cryptoCode,
+        input.walletAddress,
+        input.amount,
+        input.fiatCode,
+      );
+      return { status: "success", url };
+    } catch (e: any) {
+      return { status: "error", message: e.message };
+    }
+  },
+};
+
+export default moonpayGenerateOnRampUrlAction;

--- a/packages/plugin-moonpay/src/moonpay/actions/getBuyQuote.ts
+++ b/packages/plugin-moonpay/src/moonpay/actions/getBuyQuote.ts
@@ -1,0 +1,65 @@
+import type { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { moonpayGetBuyQuote } from "../tools/getBuyQuote";
+
+const moonpayGetBuyQuoteAction: Action = {
+  name: "MOONPAY_GET_BUY_QUOTE",
+  similes: [
+    "get moonpay buy quote",
+    "moonpay on-ramp quote",
+    "how much crypto can I buy with fiat",
+    "get price to buy sol with usd on moonpay",
+    "moonpay fiat to crypto quote",
+  ],
+  description:
+    "Get a quote from MoonPay for purchasing crypto with fiat currency. Returns fee breakdown and exchange rate.",
+  examples: [
+    [
+      {
+        input: {
+          cryptoCode: "sol",
+          fiatCode: "usd",
+          amount: 100,
+        },
+        output: {
+          status: "success",
+          baseCurrencyAmount: 100,
+          quoteCurrencyAmount: 0.89,
+          feeAmount: 4.99,
+          networkFeeAmount: 0.5,
+          totalAmount: 100,
+        },
+        explanation: "Get a quote to buy SOL with 100 USD on MoonPay",
+      },
+    ],
+  ],
+  schema: z.object({
+    cryptoCode: z
+      .string()
+      .min(1)
+      .describe("Crypto currency code to buy, e.g. 'sol', 'eth', 'usdc'"),
+    fiatCode: z
+      .string()
+      .min(1)
+      .describe("Fiat currency code to spend, e.g. 'usd', 'eur', 'gbp'"),
+    amount: z
+      .number()
+      .positive()
+      .describe("Amount of fiat currency to spend"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const quote = await moonpayGetBuyQuote(
+        agent,
+        input.cryptoCode,
+        input.fiatCode,
+        input.amount,
+      );
+      return { status: "success", ...quote };
+    } catch (e: any) {
+      return { status: "error", message: e.message };
+    }
+  },
+};
+
+export default moonpayGetBuyQuoteAction;

--- a/packages/plugin-moonpay/src/moonpay/actions/getSellQuote.ts
+++ b/packages/plugin-moonpay/src/moonpay/actions/getSellQuote.ts
@@ -1,0 +1,65 @@
+import type { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { moonpayGetSellQuote } from "../tools/getSellQuote";
+
+const moonpayGetSellQuoteAction: Action = {
+  name: "MOONPAY_GET_SELL_QUOTE",
+  similes: [
+    "get moonpay sell quote",
+    "moonpay off-ramp quote",
+    "how much fiat will I get for crypto on moonpay",
+    "sell sol for usd on moonpay quote",
+    "moonpay crypto to fiat quote",
+  ],
+  description:
+    "Get a quote from MoonPay for selling crypto to fiat currency. Returns fee breakdown and exchange rate.",
+  examples: [
+    [
+      {
+        input: {
+          cryptoCode: "sol",
+          fiatCode: "usd",
+          amount: 1,
+        },
+        output: {
+          status: "success",
+          baseCurrencyAmount: 1,
+          quoteCurrencyAmount: 108.5,
+          feeAmount: 2.5,
+          networkFeeAmount: 0.3,
+          totalAmount: 1,
+        },
+        explanation: "Get a quote to sell 1 SOL for USD on MoonPay",
+      },
+    ],
+  ],
+  schema: z.object({
+    cryptoCode: z
+      .string()
+      .min(1)
+      .describe("Crypto currency code to sell, e.g. 'sol', 'eth', 'usdc'"),
+    fiatCode: z
+      .string()
+      .min(1)
+      .describe("Fiat currency code to receive, e.g. 'usd', 'eur', 'gbp'"),
+    amount: z
+      .number()
+      .positive()
+      .describe("Amount of crypto to sell"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const quote = await moonpayGetSellQuote(
+        agent,
+        input.cryptoCode,
+        input.fiatCode,
+        input.amount,
+      );
+      return { status: "success", ...quote };
+    } catch (e: any) {
+      return { status: "error", message: e.message };
+    }
+  },
+};
+
+export default moonpayGetSellQuoteAction;

--- a/packages/plugin-moonpay/src/moonpay/actions/getTransaction.ts
+++ b/packages/plugin-moonpay/src/moonpay/actions/getTransaction.ts
@@ -1,0 +1,55 @@
+import type { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { moonpayGetTransaction } from "../tools/getTransaction";
+
+const moonpayGetTransactionAction: Action = {
+  name: "MOONPAY_GET_TRANSACTION",
+  similes: [
+    "check moonpay transaction",
+    "moonpay transaction status",
+    "get moonpay transaction details",
+    "look up moonpay purchase",
+  ],
+  description:
+    "Retrieve a MoonPay transaction by ID to check its status and details.",
+  examples: [
+    [
+      {
+        input: {
+          transactionId: "f1e2d3c4-a5b6-7890-abcd-ef1234567890",
+        },
+        output: {
+          status: "success",
+          transaction: {
+            id: "f1e2d3c4-a5b6-7890-abcd-ef1234567890",
+            status: "completed",
+            walletAddress: "...",
+            baseCurrencyAmount: 100,
+            quoteCurrencyAmount: 0.89,
+            createdAt: "2024-01-01T00:00:00Z",
+          },
+        },
+        explanation: "Retrieve a completed MoonPay transaction",
+      },
+    ],
+  ],
+  schema: z.object({
+    transactionId: z
+      .string()
+      .min(1)
+      .describe("MoonPay transaction ID (UUID format)"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const transaction = await moonpayGetTransaction(
+        agent,
+        input.transactionId,
+      );
+      return { status: "success", transaction };
+    } catch (e: any) {
+      return { status: "error", message: e.message };
+    }
+  },
+};
+
+export default moonpayGetTransactionAction;

--- a/packages/plugin-moonpay/src/moonpay/tools/generateOffRampUrl.ts
+++ b/packages/plugin-moonpay/src/moonpay/tools/generateOffRampUrl.ts
@@ -1,0 +1,34 @@
+import { SolanaAgentKit } from "solana-agent-kit";
+
+/**
+ * Generate a MoonPay off-ramp widget URL for selling crypto to fiat.
+ *
+ * @param agent         SolanaAgentKit instance
+ * @param cryptoCode    Crypto currency code to sell, e.g. "sol"
+ * @param amount        Amount of crypto to sell
+ * @param fiatCode      Target fiat currency code (default: "usd")
+ * @returns             Widget URL string
+ */
+export async function moonpayGenerateOffRampUrl(
+  agent: SolanaAgentKit,
+  cryptoCode: string,
+  amount?: number,
+  fiatCode = "usd",
+): Promise<string> {
+  const apiKey = agent.config?.OTHER_API_KEYS?.MOONPAY_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "MOONPAY_API_KEY is required in agent config OTHER_API_KEYS",
+    );
+  }
+
+  const url = new URL("https://sell.moonpay.com");
+  url.searchParams.set("apiKey", apiKey);
+  url.searchParams.set("baseCurrencyCode", cryptoCode.toLowerCase());
+  if (amount !== undefined) {
+    url.searchParams.set("baseCurrencyAmount", amount.toString());
+  }
+  url.searchParams.set("quoteCurrencyCode", fiatCode.toLowerCase());
+
+  return url.toString();
+}

--- a/packages/plugin-moonpay/src/moonpay/tools/generateOnRampUrl.ts
+++ b/packages/plugin-moonpay/src/moonpay/tools/generateOnRampUrl.ts
@@ -1,0 +1,42 @@
+import { SolanaAgentKit } from "solana-agent-kit";
+
+/**
+ * Generate a MoonPay on-ramp widget URL for buying crypto with fiat.
+ * The URL can be opened in a browser to complete the purchase.
+ *
+ * @param agent         SolanaAgentKit instance
+ * @param cryptoCode    Crypto currency code, e.g. "sol"
+ * @param walletAddress Destination wallet address (defaults to agent's wallet)
+ * @param amount        Optional fiat amount to pre-fill
+ * @param fiatCode      Optional fiat currency code (default: "usd")
+ * @returns             Widget URL string
+ */
+export async function moonpayGenerateOnRampUrl(
+  agent: SolanaAgentKit,
+  cryptoCode: string,
+  walletAddress?: string,
+  amount?: number,
+  fiatCode = "usd",
+): Promise<string> {
+  const apiKey = agent.config?.OTHER_API_KEYS?.MOONPAY_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "MOONPAY_API_KEY is required in agent config OTHER_API_KEYS",
+    );
+  }
+
+  const wallet = walletAddress ?? agent.wallet_address.toBase58();
+
+  const url = new URL("https://buy.moonpay.com");
+  url.searchParams.set("apiKey", apiKey);
+  url.searchParams.set("currencyCode", cryptoCode.toLowerCase());
+  url.searchParams.set("walletAddress", wallet);
+  if (amount !== undefined) {
+    url.searchParams.set("baseCurrencyAmount", amount.toString());
+  }
+  if (fiatCode) {
+    url.searchParams.set("baseCurrencyCode", fiatCode.toLowerCase());
+  }
+
+  return url.toString();
+}

--- a/packages/plugin-moonpay/src/moonpay/tools/getBuyQuote.ts
+++ b/packages/plugin-moonpay/src/moonpay/tools/getBuyQuote.ts
@@ -1,0 +1,40 @@
+import { SolanaAgentKit } from "solana-agent-kit";
+import type { MoonPayBuyQuote } from "../types";
+
+/**
+ * Get a buy quote from MoonPay for purchasing crypto with fiat.
+ *
+ * @param agent      SolanaAgentKit instance (provides MOONPAY_API_KEY from config)
+ * @param cryptoCode Crypto currency code, e.g. "sol"
+ * @param fiatCode   Fiat currency code, e.g. "usd"
+ * @param amount     Amount of fiat to spend
+ * @returns          MoonPay buy quote
+ */
+export async function moonpayGetBuyQuote(
+  agent: SolanaAgentKit,
+  cryptoCode: string,
+  fiatCode: string,
+  amount: number,
+): Promise<MoonPayBuyQuote> {
+  const apiKey = agent.config?.OTHER_API_KEYS?.MOONPAY_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "MOONPAY_API_KEY is required in agent config OTHER_API_KEYS",
+    );
+  }
+
+  const url = new URL(
+    `https://api.moonpay.com/v3/currencies/${cryptoCode.toLowerCase()}/buy_quote`,
+  );
+  url.searchParams.set("apiKey", apiKey);
+  url.searchParams.set("baseCurrencyCode", fiatCode.toLowerCase());
+  url.searchParams.set("baseCurrencyAmount", amount.toString());
+
+  const res = await fetch(url.toString());
+  if (!res.ok) {
+    const err = await res.text();
+    throw new Error(`MoonPay buy quote failed: ${err}`);
+  }
+
+  return res.json() as Promise<MoonPayBuyQuote>;
+}

--- a/packages/plugin-moonpay/src/moonpay/tools/getSellQuote.ts
+++ b/packages/plugin-moonpay/src/moonpay/tools/getSellQuote.ts
@@ -1,0 +1,40 @@
+import { SolanaAgentKit } from "solana-agent-kit";
+import type { MoonPaySellQuote } from "../types";
+
+/**
+ * Get a sell quote from MoonPay for selling crypto to fiat.
+ *
+ * @param agent      SolanaAgentKit instance
+ * @param cryptoCode Crypto currency code, e.g. "sol"
+ * @param fiatCode   Fiat currency code, e.g. "usd"
+ * @param amount     Amount of crypto to sell
+ * @returns          MoonPay sell quote
+ */
+export async function moonpayGetSellQuote(
+  agent: SolanaAgentKit,
+  cryptoCode: string,
+  fiatCode: string,
+  amount: number,
+): Promise<MoonPaySellQuote> {
+  const apiKey = agent.config?.OTHER_API_KEYS?.MOONPAY_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "MOONPAY_API_KEY is required in agent config OTHER_API_KEYS",
+    );
+  }
+
+  const url = new URL(
+    `https://api.moonpay.com/v3/currencies/${cryptoCode.toLowerCase()}/sell_quote`,
+  );
+  url.searchParams.set("apiKey", apiKey);
+  url.searchParams.set("quoteCurrencyCode", fiatCode.toLowerCase());
+  url.searchParams.set("baseCurrencyAmount", amount.toString());
+
+  const res = await fetch(url.toString());
+  if (!res.ok) {
+    const err = await res.text();
+    throw new Error(`MoonPay sell quote failed: ${err}`);
+  }
+
+  return res.json() as Promise<MoonPaySellQuote>;
+}

--- a/packages/plugin-moonpay/src/moonpay/tools/getTransaction.ts
+++ b/packages/plugin-moonpay/src/moonpay/tools/getTransaction.ts
@@ -1,0 +1,31 @@
+import { SolanaAgentKit } from "solana-agent-kit";
+import type { MoonPayTransaction } from "../types";
+
+/**
+ * Retrieve a MoonPay transaction by ID.
+ *
+ * @param agent         SolanaAgentKit instance
+ * @param transactionId MoonPay transaction ID
+ * @returns             Transaction details
+ */
+export async function moonpayGetTransaction(
+  agent: SolanaAgentKit,
+  transactionId: string,
+): Promise<MoonPayTransaction> {
+  const apiKey = agent.config?.OTHER_API_KEYS?.MOONPAY_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "MOONPAY_API_KEY is required in agent config OTHER_API_KEYS",
+    );
+  }
+
+  const url = `https://api.moonpay.com/v1/transactions/${transactionId}?apiKey=${apiKey}`;
+
+  const res = await fetch(url);
+  if (!res.ok) {
+    const err = await res.text();
+    throw new Error(`MoonPay get transaction failed: ${err}`);
+  }
+
+  return res.json() as Promise<MoonPayTransaction>;
+}

--- a/packages/plugin-moonpay/src/moonpay/tools/index.ts
+++ b/packages/plugin-moonpay/src/moonpay/tools/index.ts
@@ -1,0 +1,5 @@
+export * from "./getBuyQuote";
+export * from "./getSellQuote";
+export * from "./getTransaction";
+export * from "./generateOnRampUrl";
+export * from "./generateOffRampUrl";

--- a/packages/plugin-moonpay/src/moonpay/types/index.ts
+++ b/packages/plugin-moonpay/src/moonpay/types/index.ts
@@ -1,0 +1,31 @@
+export interface MoonPayBuyQuote {
+  baseCurrencyAmount: number;
+  quoteCurrencyAmount: number;
+  feeAmount: number;
+  extraFeeAmount: number;
+  networkFeeAmount: number;
+  totalAmount: number;
+}
+
+export interface MoonPayTransaction {
+  id: string;
+  status: string;
+  cryptoTransactionId?: string;
+  walletAddress: string;
+  baseCurrencyAmount: number;
+  quoteCurrencyAmount: number;
+  currency: { code: string };
+  baseCurrency: { code: string };
+  createdAt: string;
+  updatedAt: string;
+  redirectUrl?: string;
+}
+
+export interface MoonPaySellQuote {
+  baseCurrencyAmount: number;
+  quoteCurrencyAmount: number;
+  feeAmount: number;
+  extraFeeAmount: number;
+  networkFeeAmount: number;
+  totalAmount: number;
+}

--- a/packages/plugin-moonpay/tsconfig.cjs.json
+++ b/packages/plugin-moonpay/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "module": "CommonJS"
+  }
+}

--- a/packages/plugin-moonpay/tsconfig.json
+++ b/packages/plugin-moonpay/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Adds a new `@solana-agent-kit/plugin-moonpay` package integrating [MoonPay](https://moonpay.com)'s fiat on-ramp and off-ramp APIs into the Solana Agent Kit plugin system
- Follows the same actions/tools architecture as existing plugins (plugin-defi, plugin-misc, etc.)
- No external SDK dependency — uses MoonPay's REST API directly via `fetch`

## Tools & Actions

| Method | Action Name | Description |
|--------|-------------|-------------|
| `moonpayGetBuyQuote` | `MOONPAY_GET_BUY_QUOTE` | Get a quote to buy crypto with fiat |
| `moonpayGetSellQuote` | `MOONPAY_GET_SELL_QUOTE` | Get a quote to sell crypto for fiat |
| `moonpayGetTransaction` | `MOONPAY_GET_TRANSACTION` | Retrieve a transaction by ID |
| `moonpayGenerateOnRampUrl` | `MOONPAY_GENERATE_ON_RAMP_URL` | Generate a MoonPay widget URL for buying |
| `moonpayGenerateOffRampUrl` | `MOONPAY_GENERATE_OFF_RAMP_URL` | Generate a MoonPay widget URL for selling |

## Usage

```typescript
import { SolanaAgentKit } from "solana-agent-kit";
import MoonPayPlugin from "@solana-agent-kit/plugin-moonpay";

const agent = new SolanaAgentKit(wallet, rpcUrl, {
  OTHER_API_KEYS: {
    MOONPAY_API_KEY: "your_moonpay_api_key",
  },
}).use(MoonPayPlugin);

// Get a buy quote
const quote = await agent.methods.moonpayGetBuyQuote("sol", "usd", 100);

// Generate an on-ramp URL
const url = await agent.methods.moonpayGenerateOnRampUrl("sol");
```

## Configuration

Requires `MOONPAY_API_KEY` set under `OTHER_API_KEYS` in the agent config. Get a key at [moonpay.com/dashboard](https://moonpay.com/dashboard).

## Test plan

- [ ] `pnpm build --filter=@solana-agent-kit/plugin-moonpay` builds without errors
- [ ] Buy/sell quote actions return correct fee breakdowns from MoonPay sandbox API
- [ ] On-ramp and off-ramp URL generation produces valid widget URLs
- [ ] Transaction lookup returns expected status fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)