### PR TITLE
feat: add QuantOracle — 9 quant finance actions for composite workflows

### DIFF
--- a/packages/plugin-misc/src/index.ts
+++ b/packages/plugin-misc/src/index.ts
@@ -178,6 +178,28 @@ import getVerificationJobStatusAction from "./ottersec/actions/getVerificationJo
 import getVerifiedProgramsAction from "./ottersec/actions/getVerifiedPrograms";
 import verifyProgramAction from "./ottersec/actions/verifyProgram";
 
+// quantoracle
+import priceOptionAction from "./quantoracle/actions/priceOption";
+import runFullRiskAnalysisAction from "./quantoracle/actions/runFullRiskAnalysis";
+import backtestStrategyAction from "./quantoracle/actions/backtestStrategy";
+import optimizeOptionsStrategyAction from "./quantoracle/actions/optimizeOptionsStrategy";
+import recommendHedgeAction from "./quantoracle/actions/recommendHedge";
+import planRebalanceAction from "./quantoracle/actions/planRebalance";
+import runMonteCarloAction from "./quantoracle/actions/runMonteCarlo";
+import computeImpermanentLossAction from "./quantoracle/actions/computeImpermanentLoss";
+import computeLiquidationPriceAction from "./quantoracle/actions/computeLiquidationPrice";
+import {
+  priceOption,
+  runFullRiskAnalysis,
+  backtestStrategy,
+  optimizeOptionsStrategy,
+  recommendHedge,
+  planRebalance,
+  runMonteCarlo,
+  computeImpermanentLoss,
+  computeLiquidationPrice,
+} from "./quantoracle/tools";
+
 // Define and export the plugin
 const MiscPlugin = {
   name: "misc",
@@ -248,6 +270,16 @@ const MiscPlugin = {
     get_verification_job_status,
     get_verified_programs,
     verify_program,
+    // QuantOracle
+    priceOption,
+    runFullRiskAnalysis,
+    backtestStrategy,
+    optimizeOptionsStrategy,
+    recommendHedge,
+    planRebalance,
+    runMonteCarlo,
+    computeImpermanentLoss,
+    computeLiquidationPrice,
   },
 
   // Combine all actions

--- a/packages/plugin-misc/src/index.ts
+++ b/packages/plugin-misc/src/index.ts
@@ -188,6 +188,8 @@ import planRebalanceAction from "./quantoracle/actions/planRebalance";
 import runMonteCarloAction from "./quantoracle/actions/runMonteCarlo";
 import computeImpermanentLossAction from "./quantoracle/actions/computeImpermanentLoss";
 import computeLiquidationPriceAction from "./quantoracle/actions/computeLiquidationPrice";
+import getLiveVolatilityAction from "./quantoracle/actions/getLiveVolatility";
+import getLiveFundingRateAction from "./quantoracle/actions/getLiveFundingRate";
 import {
   priceOption,
   runFullRiskAnalysis,
@@ -198,6 +200,8 @@ import {
   runMonteCarlo,
   computeImpermanentLoss,
   computeLiquidationPrice,
+  getLiveVolatility,
+  getLiveFundingRate,
 } from "./quantoracle/tools";
 
 // Define and export the plugin
@@ -280,6 +284,8 @@ const MiscPlugin = {
     runMonteCarlo,
     computeImpermanentLoss,
     computeLiquidationPrice,
+    getLiveVolatility,
+    getLiveFundingRate,
   },
 
   // Combine all actions
@@ -347,6 +353,18 @@ const MiscPlugin = {
     getVerificationJobStatusAction,
     getVerifiedProgramsAction,
     verifyProgramAction,
+    // QuantOracle
+    priceOptionAction,
+    runFullRiskAnalysisAction,
+    backtestStrategyAction,
+    optimizeOptionsStrategyAction,
+    recommendHedgeAction,
+    planRebalanceAction,
+    runMonteCarloAction,
+    computeImpermanentLossAction,
+    computeLiquidationPriceAction,
+    getLiveVolatilityAction,
+    getLiveFundingRateAction,
   ],
 
   // Initialize function

--- a/packages/plugin-misc/src/quantoracle/actions/backtestStrategy.ts
+++ b/packages/plugin-misc/src/quantoracle/actions/backtestStrategy.ts
@@ -1,0 +1,63 @@
+import { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { backtestStrategy } from "../tools";
+
+const backtestStrategyAction: Action = {
+  name: "QUANTORACLE_BACKTEST_STRATEGY",
+  description:
+    "Run a deterministic backtest of a trading strategy on a price history. Supports sma_crossover, rsi_mean_reversion, momentum, and bollinger_breakout. Returns Sharpe, Calmar, max drawdown, number of trades, win rate, equity curve, and vs buy-and-hold comparison. PAID-ONLY — $0.10 per call via x402.",
+  similes: [
+    "backtest an sma crossover strategy",
+    "test rsi mean reversion on prices",
+    "run a momentum backtest",
+    "evaluate a bollinger breakout strategy",
+    "deterministic strategy backtest",
+  ],
+  examples: [
+    [
+      {
+        input: {
+          prices: [100, 101, 102, 103, 104, 105, 106, 105, 104, 103, 102, 101, 100, 99, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115],
+          strategy: "sma_crossover",
+          params: { fast: 5, slow: 15 },
+        },
+        output: {
+          strategy: "sma_crossover",
+          performance: { sharpe: 1.85, total_return: 0.12, max_drawdown: -0.05 },
+          trades_summary: { total: 3, win_rate: 0.67 },
+          vs_buy_hold: { excess_return: 0.03 },
+        },
+        explanation: "5/15 SMA crossover on 32 bars returns 12% with 3 trades, +3% vs buy&hold.",
+      },
+    ],
+  ],
+  schema: z.object({
+    prices: z.array(z.number()).min(30).describe("Price history (daily closes, oldest first). Min 30 bars."),
+    strategy: z
+      .enum(["sma_crossover", "rsi_mean_reversion", "momentum", "bollinger_breakout"])
+      .describe("Strategy type"),
+    params: z
+      .record(z.union([z.number(), z.string()]))
+      .optional()
+      .describe(
+        "Strategy-specific params. SMA: {fast, slow}. RSI: {period, oversold, overbought}. Momentum: {lookback}. Bollinger: {period, std}."
+      ),
+    initial_capital: z.number().positive().optional().describe("Default 10000"),
+    commission_bps: z.number().min(0).optional().describe("Round-trip commission in basis points. Default 5"),
+    slippage_bps: z.number().min(0).optional().describe("One-way slippage in basis points. Default 5"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const result = await backtestStrategy(agent, input as any);
+      return { status: "success", result };
+    } catch (e) {
+      return {
+        status: "error",
+        // @ts-expect-error - error is not a property of unknown
+        message: e.message,
+      };
+    }
+  },
+};
+
+export default backtestStrategyAction;

--- a/packages/plugin-misc/src/quantoracle/actions/computeImpermanentLoss.ts
+++ b/packages/plugin-misc/src/quantoracle/actions/computeImpermanentLoss.ts
@@ -1,0 +1,46 @@
+import { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { computeImpermanentLoss } from "../tools";
+
+const computeImpermanentLossAction: Action = {
+  name: "QUANTORACLE_IMPERMANENT_LOSS",
+  description:
+    "Calculate impermanent loss for a Uniswap v2 or v3 LP position given a price ratio change. For v3, provide the concentrated range. $0.005 per call via x402 past the free tier.",
+  similes: [
+    "calculate impermanent loss",
+    "il for my uniswap position",
+    "amm liquidity provider loss",
+    "lp divergence loss",
+    "how much did i lose as an lp",
+  ],
+  examples: [
+    [
+      {
+        input: { current_price_ratio: 2.0, initial_value: 10000, pool_type: "v2" },
+        output: { il_pct: -5.72, final_value: 9428 },
+        explanation: "If the price of one token doubles, a Uniswap v2 LP loses 5.72% vs HODL.",
+      },
+    ],
+  ],
+  schema: z.object({
+    current_price_ratio: z.number().positive().describe("current_price / initial_price"),
+    initial_value: z.number().positive().optional().describe("Default 10000"),
+    pool_type: z.enum(["v2", "v3"]).optional().describe("Default v2"),
+    range_low: z.number().optional().describe("v3 only: lower price bound"),
+    range_high: z.number().optional().describe("v3 only: upper price bound"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const result = await computeImpermanentLoss(agent, input as any);
+      return { status: "success", result };
+    } catch (e) {
+      return {
+        status: "error",
+        // @ts-expect-error - error is not a property of unknown
+        message: e.message,
+      };
+    }
+  },
+};
+
+export default computeImpermanentLossAction;

--- a/packages/plugin-misc/src/quantoracle/actions/computeLiquidationPrice.ts
+++ b/packages/plugin-misc/src/quantoracle/actions/computeLiquidationPrice.ts
@@ -1,0 +1,53 @@
+import { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { computeLiquidationPrice } from "../tools";
+
+const computeLiquidationPriceAction: Action = {
+  name: "QUANTORACLE_LIQUIDATION_PRICE",
+  description:
+    "Calculate the liquidation price of a leveraged position (long or short) given entry, collateral, leverage, and maintenance margin. Supports perpetuals, futures, and margin accounts. $0.002 per call via x402 past the free tier.",
+  similes: [
+    "liquidation price for my leveraged position",
+    "where would i get liquidated",
+    "margin call price",
+    "perp liquidation price",
+    "distance to liquidation",
+  ],
+  examples: [
+    [
+      {
+        input: {
+          entry_price: 50000,
+          collateral: 1000,
+          position_size: 5000,
+          leverage: 5,
+          direction: "long",
+        },
+        output: { liquidation_price: 40000, distance_pct: 20 },
+        explanation: "5x long BTC at $50k with $1k collateral liquidates at $40k (20% drop).",
+      },
+    ],
+  ],
+  schema: z.object({
+    entry_price: z.number().positive(),
+    collateral: z.number().positive(),
+    position_size: z.number().positive(),
+    leverage: z.number().positive(),
+    direction: z.enum(["long", "short"]),
+    maintenance_margin: z.number().optional().describe("Maintenance margin as fraction. Default 0.005"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const result = await computeLiquidationPrice(agent, input as any);
+      return { status: "success", result };
+    } catch (e) {
+      return {
+        status: "error",
+        // @ts-expect-error - error is not a property of unknown
+        message: e.message,
+      };
+    }
+  },
+};
+
+export default computeLiquidationPriceAction;

--- a/packages/plugin-misc/src/quantoracle/actions/getLiveFundingRate.ts
+++ b/packages/plugin-misc/src/quantoracle/actions/getLiveFundingRate.ts
@@ -1,0 +1,51 @@
+import { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { getLiveFundingRate } from "../tools";
+
+const getLiveFundingRateAction: Action = {
+  name: "QUANTORACLE_LIVE_FUNDING_RATE",
+  description:
+    "Get the LIVE perpetual funding rate + annualized carry for a crypto asset, from a fresh exchange feed. Pass only the ticker. Use this for current funding instead of estimating it — funding erodes collateral on perps and shifts liquidation prices. $0.005 per call via x402 past 20 free calls/IP/day.",
+  similes: [
+    "current funding rate",
+    "live perp funding",
+    "what is the funding rate",
+    "perpetual funding now",
+    "annualized carry",
+  ],
+  examples: [
+    [
+      {
+        input: { asset: "ETH" },
+        output: {
+          status: "success",
+          result: {
+            asset: "ETH",
+            funding_rate: -0.000104,
+            annualized_rate: -0.1137,
+            regime: "BACKWARDATION",
+            source: "okx",
+          },
+        },
+        explanation: "ETH perp funding is negative (-11.4% annualized) — shorts pay longs.",
+      },
+    ],
+  ],
+  schema: z.object({
+    asset: z.string().describe("Crypto asset symbol, e.g. BTC, ETH, SOL (USD pair)"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const result = await getLiveFundingRate(agent, input as any);
+      return { status: "success", result };
+    } catch (e) {
+      return {
+        status: "error",
+        // @ts-expect-error - error is not a property of unknown
+        message: e.message,
+      };
+    }
+  },
+};
+
+export default getLiveFundingRateAction;

--- a/packages/plugin-misc/src/quantoracle/actions/getLiveVolatility.ts
+++ b/packages/plugin-misc/src/quantoracle/actions/getLiveVolatility.ts
@@ -1,0 +1,51 @@
+import { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { getLiveVolatility } from "../tools";
+
+const getLiveVolatilityAction: Action = {
+  name: "QUANTORACLE_LIVE_VOLATILITY",
+  description:
+    "Get LIVE realized volatility (7d/30d/90d) + regime for a crypto asset, computed from fresh market data. Pass only the ticker — QuantOracle fetches the candles and runs the math. Use this for current volatility instead of estimating it. $0.01 per call via x402 past 20 free calls/IP/day.",
+  similes: [
+    "current volatility",
+    "live realized vol",
+    "how volatile is bitcoin right now",
+    "crypto volatility now",
+    "fresh volatility data",
+  ],
+  examples: [
+    [
+      {
+        input: { asset: "BTC" },
+        output: {
+          status: "success",
+          result: {
+            asset: "BTC",
+            spot: 61728.7,
+            realized_vol_30d: 0.31,
+            regime: "NORMAL",
+            source: "kraken",
+          },
+        },
+        explanation: "Fresh BTC realized vol: 31% annualized over 30 days, normal regime.",
+      },
+    ],
+  ],
+  schema: z.object({
+    asset: z.string().describe("Crypto asset symbol, e.g. BTC, ETH, SOL (USD pair)"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const result = await getLiveVolatility(agent, input as any);
+      return { status: "success", result };
+    } catch (e) {
+      return {
+        status: "error",
+        // @ts-expect-error - error is not a property of unknown
+        message: e.message,
+      };
+    }
+  },
+};
+
+export default getLiveVolatilityAction;

--- a/packages/plugin-misc/src/quantoracle/actions/optimizeOptionsStrategy.ts
+++ b/packages/plugin-misc/src/quantoracle/actions/optimizeOptionsStrategy.ts
@@ -1,0 +1,55 @@
+import { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { optimizeOptionsStrategy } from "../tools";
+
+const optimizeOptionsStrategyAction: Action = {
+  name: "QUANTORACLE_OPTIONS_STRATEGY_OPTIMIZER",
+  description:
+    "Rank the top options strategies given a market outlook (bullish/bearish/neutral) and volatility view (rising/falling/stable). Returns ranked list of Long Call, Bull Call Spread, Iron Condor, Long Straddle, etc. — each with legs, max profit/loss, breakevens, and score. PAID-ONLY — $0.08 per call via x402.",
+  similes: [
+    "suggest the best options strategy",
+    "what options play is best for a bullish outlook",
+    "rank options strategies for rising vol",
+    "recommend iron condor or straddle",
+    "best options trade for my view",
+  ],
+  examples: [
+    [
+      {
+        input: { S: 100, outlook: "bullish", vol_view: "rising", T: 0.25, sigma: 0.25 },
+        output: {
+          top_pick: "Long Call (ATM)",
+          strategies: [
+            { name: "Long Call (ATM)", net_debit: 5.6, max_loss: 5.6, breakeven: [105.6] },
+            { name: "Bull Call Spread", net_debit: 2.16, max_profit: 2.84 },
+          ],
+        },
+        explanation: "For a bullish/rising-vol view on a $100 stock, top pick is Long Call.",
+      },
+    ],
+  ],
+  schema: z.object({
+    S: z.number().positive().describe("Spot price"),
+    outlook: z.enum(["bullish", "bearish", "neutral"]),
+    vol_view: z.enum(["rising", "falling", "stable"]).optional().describe("Default stable"),
+    T: z.number().positive().describe("Time to expiration in years"),
+    sigma: z.number().positive().describe("Current implied volatility"),
+    r: z.number().optional().describe("Default 0.05"),
+    q: z.number().optional().describe("Default 0"),
+    capital: z.number().positive().optional().describe("Default 10000"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const result = await optimizeOptionsStrategy(agent, input as any);
+      return { status: "success", result };
+    } catch (e) {
+      return {
+        status: "error",
+        // @ts-expect-error - error is not a property of unknown
+        message: e.message,
+      };
+    }
+  },
+};
+
+export default optimizeOptionsStrategyAction;

--- a/packages/plugin-misc/src/quantoracle/actions/planRebalance.ts
+++ b/packages/plugin-misc/src/quantoracle/actions/planRebalance.ts
@@ -1,0 +1,55 @@
+import { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { planRebalance } from "../tools";
+
+const planRebalanceAction: Action = {
+  name: "QUANTORACLE_REBALANCE_PLAN",
+  description:
+    "Generate the exact trade list to move a portfolio from current holdings to target weights with transaction cost estimate. Returns buy/sell actions, total cost, drift before/after. PAID-ONLY — $0.05 per call via x402.",
+  similes: [
+    "generate rebalance trades",
+    "rebalance my portfolio to target weights",
+    "what trades to hit my target allocation",
+    "drift correction trades",
+    "compute rebalance orders with costs",
+  ],
+  examples: [
+    [
+      {
+        input: {
+          current_holdings: { AAPL: 50000, TSLA: 30000, GLD: 20000 },
+          target_weights: { AAPL: 0.4, TSLA: 0.4, GLD: 0.2 },
+        },
+        output: {
+          num_trades: 2,
+          total_cost_usd: 20,
+          trades: [
+            { asset: "AAPL", action: "sell", amount_usd: 10000 },
+            { asset: "TSLA", action: "buy", amount_usd: 10000 },
+          ],
+        },
+        explanation: "Rebalance 50/30/20 to 40/40/20: sell $10k AAPL, buy $10k TSLA, cost $20.",
+      },
+    ],
+  ],
+  schema: z.object({
+    current_holdings: z.record(z.number()).describe("Asset symbol -> current USD value"),
+    target_weights: z.record(z.number()).describe("Asset symbol -> target weight (must sum to ~1.0)"),
+    transaction_cost_bps: z.number().min(0).optional().describe("One-way cost in bps. Default 10"),
+    min_trade_usd: z.number().min(0).optional().describe("Default 10"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const result = await planRebalance(agent, input as any);
+      return { status: "success", result };
+    } catch (e) {
+      return {
+        status: "error",
+        // @ts-expect-error - error is not a property of unknown
+        message: e.message,
+      };
+    }
+  },
+};
+
+export default planRebalanceAction;

--- a/packages/plugin-misc/src/quantoracle/actions/priceOption.ts
+++ b/packages/plugin-misc/src/quantoracle/actions/priceOption.ts
@@ -1,0 +1,60 @@
+import { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { priceOption } from "../tools";
+
+const priceOptionAction: Action = {
+  name: "QUANTORACLE_PRICE_OPTION",
+  description:
+    "Price a European option using Black-Scholes with all 10 Greeks (delta, gamma, theta, vega, rho, vanna, charm, volga, speed, color). Deterministic — same inputs always produce same outputs. 1000 free calls/IP/day, no API key required.",
+  similes: [
+    "price an option",
+    "black scholes option pricing",
+    "compute option greeks",
+    "get delta gamma theta vega for an option",
+    "european option valuation",
+  ],
+  examples: [
+    [
+      {
+        input: { S: 100, K: 105, T: 0.5, sigma: 0.2, r: 0.05, type: "call" },
+        output: {
+          price: 4.5817,
+          breakeven: 109.5817,
+          prob_itm: 0.4056,
+          greeks: {
+            delta: 0.46116,
+            gamma: 0.028076,
+            theta: -0.021074,
+            vega: 0.280757,
+            rho: 0.207672,
+          },
+        },
+        explanation:
+          "Price a 6-month ATM-ish call with spot=100, strike=105, 20% vol. Returns $4.58 with delta 0.46.",
+      },
+    ],
+  ],
+  schema: z.object({
+    S: z.number().positive().describe("Spot price of underlying"),
+    K: z.number().positive().describe("Strike price"),
+    T: z.number().positive().describe("Time to expiration in years"),
+    sigma: z.number().positive().describe("Annualized implied volatility (e.g. 0.2 = 20%)"),
+    r: z.number().optional().describe("Risk-free rate (annualized). Default 0.05"),
+    q: z.number().optional().describe("Continuous dividend yield. Default 0"),
+    type: z.enum(["call", "put"]).optional().describe("Option type. Default call"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const result = await priceOption(agent, input as any);
+      return { status: "success", result };
+    } catch (e) {
+      return {
+        status: "error",
+        // @ts-expect-error - error is not a property of unknown
+        message: e.message,
+      };
+    }
+  },
+};
+
+export default priceOptionAction;

--- a/packages/plugin-misc/src/quantoracle/actions/recommendHedge.ts
+++ b/packages/plugin-misc/src/quantoracle/actions/recommendHedge.ts
@@ -1,0 +1,60 @@
+import { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { recommendHedge } from "../tools";
+
+const recommendHedgeAction: Action = {
+  name: "QUANTORACLE_RECOMMEND_HEDGE",
+  description:
+    "Rank the cheapest effective hedges for a given position (long stock, long crypto, etc.). Compares protective puts, collars, futures shorts, and partial hedges with cost, protection level, and affordability. PAID-ONLY — $0.04 per call via x402.",
+  similes: [
+    "how should i hedge my long position",
+    "recommend cheapest hedge for my stock",
+    "compare protective put vs collar",
+    "suggest hedge strategy",
+    "protect my portfolio",
+  ],
+  examples: [
+    [
+      {
+        input: {
+          position_type: "long_stock",
+          position_value: 50000,
+          asset_price: 100,
+          volatility: 0.25,
+          time_horizon_days: 30,
+        },
+        output: {
+          recommended: "collar",
+          hedges: [
+            { type: "collar", cost_usd: 258.2, protection: "floor at 95, cap at 110" },
+            { type: "protective_put", cost_usd: 439.15 },
+          ],
+        },
+        explanation: "A collar costing $258 is recommended over a $439 protective put.",
+      },
+    ],
+  ],
+  schema: z.object({
+    position_type: z.enum(["long_stock", "short_stock", "long_crypto", "long_options"]),
+    position_value: z.number().positive(),
+    asset_price: z.number().positive(),
+    volatility: z.number().positive().describe("Annualized volatility"),
+    time_horizon_days: z.number().int().positive().optional().describe("Default 30"),
+    max_hedge_cost_pct: z.number().positive().optional().describe("Default 0.05 (5% of position)"),
+    r: z.number().optional().describe("Default 0.05"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const result = await recommendHedge(agent, input as any);
+      return { status: "success", result };
+    } catch (e) {
+      return {
+        status: "error",
+        // @ts-expect-error - error is not a property of unknown
+        message: e.message,
+      };
+    }
+  },
+};
+
+export default recommendHedgeAction;

--- a/packages/plugin-misc/src/quantoracle/actions/runFullRiskAnalysis.ts
+++ b/packages/plugin-misc/src/quantoracle/actions/runFullRiskAnalysis.ts
@@ -1,0 +1,51 @@
+import { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { runFullRiskAnalysis } from "../tools";
+
+const runFullRiskAnalysisAction: Action = {
+  name: "QUANTORACLE_FULL_RISK_ANALYSIS",
+  description:
+    "Complete risk tearsheet in a single call: Sharpe, Sortino, Calmar, VaR, CVaR, Kelly leverage, max drawdown, Hurst exponent, CAGR. Replaces 7 individual endpoint calls. PAID-ONLY — $0.04 per call via x402 USDC (Base or Solana).",
+  similes: [
+    "full risk analysis on returns",
+    "complete risk tearsheet",
+    "compute sharpe sortino var in one call",
+    "portfolio risk metrics summary",
+    "run a risk report",
+  ],
+  examples: [
+    [
+      {
+        input: {
+          returns: [0.01, -0.02, 0.03, 0.005, -0.01, 0.02, -0.015, 0.025, 0.01, -0.005, 0.015],
+          portfolio_value: 10000,
+        },
+        output: {
+          returns: { annualized: 0.84, vol: 0.28, cagr: 1.23 },
+          risk: { sharpe: 2.83, sortino: 4.59, var_95: -0.03, max_drawdown: -0.03 },
+          kelly: { full_kelly_leverage: 10.65, half_kelly: 5.32 },
+        },
+        explanation: "Analyze 11 return observations: Sharpe 2.83, Kelly suggests 10.6x leverage.",
+      },
+    ],
+  ],
+  schema: z.object({
+    returns: z.array(z.number()).min(10).describe("Periodic returns as decimals (e.g. 0.01 = 1%)"),
+    portfolio_value: z.number().positive().optional().describe("Current portfolio value. Default 100000"),
+    risk_free_rate: z.number().optional().describe("Annual risk-free rate. Default 0.045"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const result = await runFullRiskAnalysis(agent, input as any);
+      return { status: "success", result };
+    } catch (e) {
+      return {
+        status: "error",
+        // @ts-expect-error - error is not a property of unknown
+        message: e.message,
+      };
+    }
+  },
+};
+
+export default runFullRiskAnalysisAction;

--- a/packages/plugin-misc/src/quantoracle/actions/runMonteCarlo.ts
+++ b/packages/plugin-misc/src/quantoracle/actions/runMonteCarlo.ts
@@ -1,0 +1,53 @@
+import { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { runMonteCarlo } from "../tools";
+
+const runMonteCarloAction: Action = {
+  name: "QUANTORACLE_MONTE_CARLO_SIM",
+  description:
+    "Run a Monte Carlo simulation of portfolio value using Geometric Brownian Motion with optional contributions/withdrawals. Returns terminal distribution (p5/p25/p50/p75/p95), probability of loss, probability of doubling, CAGR. $0.015 per call via x402 past the free tier.",
+  similes: [
+    "monte carlo simulation of a portfolio",
+    "retirement projection",
+    "gbm simulation",
+    "probability of doubling my money",
+    "portfolio projection with contributions",
+  ],
+  examples: [
+    [
+      {
+        input: { initial_value: 100000, annual_return: 0.08, annual_vol: 0.15, years: 30, simulations: 1000 },
+        output: {
+          terminal: { mean: 1075981, median: 764033, p5: 203883, p95: 3079865 },
+          prob_loss: 0.003,
+          prob_double: 0.952,
+          cagr: 0.0824,
+        },
+        explanation: "$100k at 8%/15% vol over 30 years: median $764k, 95.2% probability of doubling.",
+      },
+    ],
+  ],
+  schema: z.object({
+    initial_value: z.number().positive().optional().describe("Default 100000"),
+    annual_return: z.number().optional().describe("Default 0.1"),
+    annual_vol: z.number().positive().optional().describe("Default 0.2"),
+    years: z.number().positive().max(100).optional().describe("Default 5"),
+    simulations: z.number().int().min(1).max(5000).optional().describe("Default 1000"),
+    contributions: z.number().optional().describe("Annual contribution amount. Default 0"),
+    withdrawal_rate: z.number().optional().describe("Annual withdrawal as fraction. Default 0"),
+  }),
+  handler: async (agent, input) => {
+    try {
+      const result = await runMonteCarlo(agent, input as any);
+      return { status: "success", result };
+    } catch (e) {
+      return {
+        status: "error",
+        // @ts-expect-error - error is not a property of unknown
+        message: e.message,
+      };
+    }
+  },
+};
+
+export default runMonteCarloAction;

--- a/packages/plugin-misc/src/quantoracle/tools/index.ts
+++ b/packages/plugin-misc/src/quantoracle/tools/index.ts
@@ -152,3 +152,17 @@ export async function computeLiquidationPrice(
 ) {
   return callQuantOracle(agent, "/v1/crypto/liquidation-price", input);
 }
+
+export async function getLiveVolatility(
+  agent: SolanaAgentKit,
+  input: { asset: string }
+) {
+  return callQuantOracle(agent, "/v1/live/volatility", input);
+}
+
+export async function getLiveFundingRate(
+  agent: SolanaAgentKit,
+  input: { asset: string }
+) {
+  return callQuantOracle(agent, "/v1/live/funding-rates", input);
+}

--- a/packages/plugin-misc/src/quantoracle/tools/index.ts
+++ b/packages/plugin-misc/src/quantoracle/tools/index.ts
@@ -1,0 +1,154 @@
+import type { SolanaAgentKit } from "solana-agent-kit";
+
+const QUANTORACLE_BASE_URL = "https://api.quantoracle.dev";
+
+/**
+ * Shared fetch helper for all QuantOracle endpoints.
+ * Free tier: 1000 calls/IP/day. Paid endpoints return 402 with x402 payment
+ * requirements (USDC on Base or Solana). This client does not auto-pay —
+ * callers exhausting the free tier should use an x402-capable HTTP client.
+ */
+export async function callQuantOracle<T = any>(
+  _agent: SolanaAgentKit,
+  endpoint: string,
+  params: Record<string, any>
+): Promise<T> {
+  const path = endpoint.startsWith("/") ? endpoint : `/${endpoint}`;
+  const resp = await fetch(`${QUANTORACLE_BASE_URL}${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "User-Agent": "solana-agent-kit-quantoracle/1.0.0",
+      "X-Source": "solana-agent-kit",
+    },
+    body: JSON.stringify(params),
+  });
+
+  if (resp.status === 402) {
+    const body = await resp.json().catch(() => ({}));
+    throw new Error(
+      `QuantOracle: payment required (${endpoint}). Free tier exhausted. Pay via x402 USDC on Base or Solana. Details: ${JSON.stringify(
+        body
+      ).slice(0, 200)}`
+    );
+  }
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(
+      `QuantOracle ${endpoint} failed (${resp.status}): ${text.slice(0, 300)}`
+    );
+  }
+  return (await resp.json()) as T;
+}
+
+export async function priceOption(
+  agent: SolanaAgentKit,
+  input: { S: number; K: number; T: number; sigma: number; r?: number; q?: number; type?: "call" | "put" }
+) {
+  return callQuantOracle(agent, "/v1/options/price", input);
+}
+
+export async function runFullRiskAnalysis(
+  agent: SolanaAgentKit,
+  input: { returns: number[]; portfolio_value?: number; risk_free_rate?: number }
+) {
+  return callQuantOracle(agent, "/v1/risk/full-analysis", input);
+}
+
+export async function backtestStrategy(
+  agent: SolanaAgentKit,
+  input: {
+    prices: number[];
+    strategy: "sma_crossover" | "rsi_mean_reversion" | "momentum" | "bollinger_breakout";
+    params?: Record<string, number>;
+    initial_capital?: number;
+    commission_bps?: number;
+    slippage_bps?: number;
+  }
+) {
+  return callQuantOracle(agent, "/v1/backtest/strategy", input);
+}
+
+export async function optimizeOptionsStrategy(
+  agent: SolanaAgentKit,
+  input: {
+    S: number;
+    outlook: "bullish" | "bearish" | "neutral";
+    vol_view?: "rising" | "falling" | "stable";
+    T: number;
+    sigma: number;
+    r?: number;
+    q?: number;
+    capital?: number;
+  }
+) {
+  return callQuantOracle(agent, "/v1/options/strategy-optimizer", input);
+}
+
+export async function recommendHedge(
+  agent: SolanaAgentKit,
+  input: {
+    position_type: "long_stock" | "short_stock" | "long_crypto" | "long_options";
+    position_value: number;
+    asset_price: number;
+    volatility: number;
+    time_horizon_days?: number;
+    max_hedge_cost_pct?: number;
+  }
+) {
+  return callQuantOracle(agent, "/v1/hedging/recommend", input);
+}
+
+export async function planRebalance(
+  agent: SolanaAgentKit,
+  input: {
+    current_holdings: Record<string, number>;
+    target_weights: Record<string, number>;
+    transaction_cost_bps?: number;
+    min_trade_usd?: number;
+  }
+) {
+  return callQuantOracle(agent, "/v1/portfolio/rebalance-plan", input);
+}
+
+export async function runMonteCarlo(
+  agent: SolanaAgentKit,
+  input: {
+    initial_value?: number;
+    annual_return?: number;
+    annual_vol?: number;
+    years?: number;
+    simulations?: number;
+    contributions?: number;
+    withdrawal_rate?: number;
+  }
+) {
+  return callQuantOracle(agent, "/v1/simulate/montecarlo", input);
+}
+
+export async function computeImpermanentLoss(
+  agent: SolanaAgentKit,
+  input: {
+    current_price_ratio: number;
+    initial_value?: number;
+    pool_type?: "v2" | "v3";
+    range_low?: number;
+    range_high?: number;
+  }
+) {
+  return callQuantOracle(agent, "/v1/crypto/impermanent-loss", input);
+}
+
+export async function computeLiquidationPrice(
+  agent: SolanaAgentKit,
+  input: {
+    entry_price: number;
+    collateral: number;
+    position_size: number;
+    leverage: number;
+    direction: "long" | "short";
+    maintenance_margin?: number;
+  }
+) {
+  return callQuantOracle(agent, "/v1/crypto/liquidation-price", input);
+}


### PR DESCRIPTION
## Summary

Adds **QuantOracle** to `packages/plugin-misc` — a deterministic quantitative finance API with 63 underlying calculators + 10 composite workflows. This PR surfaces **9 high-value actions** (rather than exposing all 73 endpoints) to keep the scope reviewable.

QuantOracle offers a **1,000 free calls/IP/day** tier (no API key, no signup), so the actions work out-of-the-box. Past the free tier, paid endpoints return HTTP 402 with x402 payment requirements (USDC on Base or Solana) — the plugin surfaces a clear error; downstream x402-capable clients can auto-pay if desired.

## Actions

| Action | Description | Price past free tier |
|--------|-------------|---------------------|
| `QUANTORACLE_PRICE_OPTION` | Black-Scholes + 10 Greeks | \$0.005 |
| `QUANTORACLE_FULL_RISK_ANALYSIS` | Full risk tearsheet (Sharpe, Sortino, VaR, Kelly, DD, Hurst, CAGR) | \$0.04 (paid-only) |
| `QUANTORACLE_BACKTEST_STRATEGY` | SMA / RSI / momentum / Bollinger backtest | \$0.10 (paid-only) |
| `QUANTORACLE_OPTIONS_STRATEGY_OPTIMIZER` | Rank options strategies by outlook + vol view | \$0.08 (paid-only) |
| `QUANTORACLE_RECOMMEND_HEDGE` | Compare protective put / collar / futures / partial hedges | \$0.04 (paid-only) |
| `QUANTORACLE_REBALANCE_PLAN` | Exact rebalance trades + transaction cost estimate | \$0.05 (paid-only) |
| `QUANTORACLE_MONTE_CARLO_SIM` | GBM portfolio projection with contributions/withdrawals | \$0.015 |
| `QUANTORACLE_IMPERMANENT_LOSS` | Uniswap v2/v3 IL calculator | \$0.005 |
| `QUANTORACLE_LIQUIDATION_PRICE` | Leveraged position liquidation price | \$0.002 |

## File layout

Mirrors \`packages/plugin-misc/src/coingecko/\`:

\`\`\`
packages/plugin-misc/src/quantoracle/
├── actions/
│   ├── backtestStrategy.ts
│   ├── computeImpermanentLoss.ts
│   ├── computeLiquidationPrice.ts
│   ├── optimizeOptionsStrategy.ts
│   ├── planRebalance.ts
│   ├── priceOption.ts
│   ├── recommendHedge.ts
│   ├── runFullRiskAnalysis.ts
│   └── runMonteCarlo.ts
└── tools/
    └── index.ts         # shared fetch helper + per-endpoint methods
\`\`\`

Plus wiring in \`packages/plugin-misc/src/index.ts\` (9 action imports + 9 method entries).

## Notes

- No new dependencies — uses native \`fetch\`.
- All actions return \`{ status: 'success', result }\` on success or \`{ status: 'error', message }\` on failure, matching the coingecko pattern.
- Zod schemas use minimal typed field shapes (per contributor guidance from PR #499 about TS OOM).
- Could be the first x402-native integration in the kit — happy to extend to all 73 endpoints in a follow-up.

## Links

- API: https://api.quantoracle.dev
- API docs: https://api.quantoracle.dev/docs
- x402 discovery (Base + Solana): https://api.quantoracle.dev/.well-known/x402
- Repo: https://github.com/QuantOracledev/quantoracle