### PR TITLE
fix(plugin-misc): add missing await in CoinGecko price handler

### DIFF
--- a/packages/plugin-misc/src/coingecko/actions/getCoingeckoTokenPriceData.ts
+++ b/packages/plugin-misc/src/coingecko/actions/getCoingeckoTokenPriceData.ts
@@ -36,7 +36,7 @@ const getCoingeckoTokenPriceDataAction: Action = {
     try {
       return {
         status: "success",
-        result: getTokenPriceData(agent, input.tokenAddresses),
+        result: await getTokenPriceData(agent, input.tokenAddresses),
       };
     } catch (e) {
       return {


### PR DESCRIPTION
## Summary

`GET_COINGECKO_TOKEN_PRICE_DATA_ACTION`'s handler wraps `getTokenPriceData(...)` without awaiting it. Since the inner function is `async`, the handler returns `{ status: "success", result: Promise{...} }`. `JSON.stringify` serializes a Promise to `{}` (Promises have no enumerable own properties), so every caller sees an empty `result` despite the underlying fetch succeeding.

This is the only non-awaited async call inside a `result:` field across the entire monorepo — I grepped all `packages/*/src/**/actions/*.ts` to confirm.

## Fix

One line in `packages/plugin-misc/src/coingecko/actions/getCoingeckoTokenPriceData.ts`:

```diff
         status: "success",
-        result: getTokenPriceData(agent, input.tokenAddresses),
+        result: await getTokenPriceData(agent, input.tokenAddresses),
```
## Reproduction
> Full reproducer script (runnable standalone, requires only a CoinGecko demo API key):
https://github.com/xpriment626/solana-coralised/blob/master/scripts/reproduce-coingecko-missing-await.sh

Handler called two ways against the same SolanaAgentKit instance, same Demo key, same URL:
Before the fix (as shipped in @solana-agent-kit/plugin-misc@2.0.6):
```sh
===== Call B: handler as shipped (buggy) =====
typeof b.result:              object
b.result instanceof Promise:  true
JSON.stringify(b):            {"status":"success","result":{}}

===== Call A: same handler + manually-awaited inner Promise =====
JSON.stringify(resolved):     {"status":"success","result":{"So111...":{"usd":84.32,...}}}
```
**After the fix (patch applied to the installed dist)**:
```sh
===== Call B: handler as shipped =====
typeof b.result:              object
b.result instanceof Promise:  false
JSON.stringify(b):            {"status":"success","result":{"So111...":{"usd":83.99,"usd_market_cap":1039828370.126999,...}}}

===== Call A: same handler + manually-awaited inner Promise =====
JSON.stringify(resolved):     {"status":"success","result":{"So111...":{"usd":83.99,...}}}
```
Call B now matches Call A.

## Notes
* PR targets v2. CONTRIBUTING.md says to target main, but all recent activity lands on v2 and it's the remote's default branch — happy to retarget if maintainers prefer.
* pnpm run build currently fails on the core package with pre-existing errors (missing @open-wallet-standard/core dep in src/utils/owsWallet.ts, and a Type 'OpenAIToolParameters' is not assignable to type 'never' in src/openai/index.ts). These fail on clean v2 HEAD without this change applied — unrelated to this PR, happy to file separate issues.
* Biome lint passes on the changed file.
* No test added: plugin-misc has "test": "jest" in package.json but no jest config, no dev-dep, and no existing test files. Setting that up felt like scope creep for a single-token fix; happy to follow up with a separate PR for test infra if desired.
* contact on telegram if needed: @e_ssshadow

## Version at discovery
* solana-agent-kit@2.0.10
* @solana-agent-kit/plugin-misc@2.0.6
* Node v24.10.0