### PR TITLE
feat(plugin-blinks): add AlgoVoi multi-chain payment provider

### DIFF
--- a/packages/plugin-blinks/README.md
+++ b/packages/plugin-blinks/README.md
@@ -1,8 +1,14 @@
 # @solana-agent-kit/plugin-blinks
 
-This plugin provides a set of tools and actions for quick, fun interactions on Solana using Solana blinks.
+This plugin provides a set of tools and actions for Solana Actions + Blinks integrations.
 
 ## Tools Available
 
 ### Send
 - `sendArcadeGames` - Integrate with a send arcade game. Specifically rock, paper, scissors.
+
+### AlgoVoi (multi-chain payment facilitator — Solana flow)
+- `algovoi_pay_checkout` - Settle a hosted AlgoVoi checkout on Solana. The agent's wallet signs an SPL USDC transfer that carries a Solana Pay `reference` pubkey, so AlgoVoi's facilitator can verify settlement on-chain deterministically (no memo, no amount-uniqueness gymnastics).
+- `algovoi_get_checkout` - Fetch Actions metadata (amount, title, disabled state) for an AlgoVoi checkout without signing. Useful for previewing before pay.
+
+See [`src/algovoi/README.md`](./src/algovoi/README.md) for details.

--- a/packages/plugin-blinks/src/algovoi/README.md
+++ b/packages/plugin-blinks/src/algovoi/README.md
@@ -1,0 +1,73 @@
+# AlgoVoi provider for `@solana-agent-kit/plugin-blinks`
+
+[AlgoVoi](https://api1.ilovechicken.co.uk/.well-known/agent.json) is a
+multi-chain payment facilitator (x402 / MPP / AP2) with a native
+Solana Actions + Blinks surface. Every hosted AlgoVoi checkout on
+Solana is exposed at `GET/POST /actions/checkout/{token}` and returns
+an SPL USDC transfer that includes a **Solana Pay `reference` pubkey**
+as a non-signer account — letting the AlgoVoi facilitator
+deterministically bind the on-chain settlement to the specific
+merchant mandate, without memo dependency or amount-uniqueness
+gymnastics.
+
+This provider lets a `SolanaAgentKit` agent pay any AlgoVoi checkout
+with one call.
+
+## Methods
+
+- `algovoi_get_checkout(agent, tokenOrUrl, baseUrl?)` — fetch Action
+  metadata (amount, title, disabled state) without signing. Use this
+  to preview the payment with the user before signing.
+- `algovoi_pay_checkout(agent, tokenOrUrl, baseUrl?)` — POST to the
+  Action endpoint, deserialize the returned unsigned
+  VersionedTransaction, sign, broadcast. Returns the signature (or a
+  signed tx if the agent is configured `signOnly`).
+
+Both accept:
+
+- a bare checkout token (`xZMDMhNfBXrisrhv6Fdv2Y5i2ImOKTTx`)
+- a hosted checkout URL (`https://api1.ilovechicken.co.uk/checkout/...`)
+- a `solana-action:` scheme URL as pasted from Dialect / Phantom /
+  Solflare / Backpack
+
+Default `baseUrl` is the public AlgoVoi gateway; override to hit a
+self-hosted AlgoVoi instance.
+
+## Actions (natural-language)
+
+- `ALGOVOI_PAY_CHECKOUT` — "pay algovoi checkout <token>"
+- `ALGOVOI_GET_CHECKOUT` — "inspect algovoi checkout <token>"
+
+## Example
+
+```ts
+import { SolanaAgentKit, KeypairWallet } from "solana-agent-kit";
+import BlinksPlugin from "@solana-agent-kit/plugin-blinks";
+
+const agent = new SolanaAgentKit(
+  new KeypairWallet(myKeypair),
+  "https://api.mainnet-beta.solana.com",
+  {},
+).use(BlinksPlugin);
+
+// Preview first
+const preview = await agent.methods.algovoi_get_checkout(
+  agent,
+  "xZMDMhNfBXrisrhv6Fdv2Y5i2ImOKTTx",
+);
+console.log(preview.label);   // "Pay 0.5 USDC"
+
+// Then pay
+const sig = await agent.methods.algovoi_pay_checkout(
+  agent,
+  "xZMDMhNfBXrisrhv6Fdv2Y5i2ImOKTTx",
+);
+console.log("Settled:", sig);
+```
+
+## Reference
+
+- AlgoVoi Solana Pay reference binding:
+  <https://github.com/chopmob-cloud/AlgoVoi-Platform-Adapters>
+- Solana Actions spec:
+  <https://solana.com/developers/guides/advanced/actions>

--- a/packages/plugin-blinks/src/algovoi/actions/getCheckout.ts
+++ b/packages/plugin-blinks/src/algovoi/actions/getCheckout.ts
@@ -1,0 +1,70 @@
+import { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { algovoi_get_checkout } from "../tools";
+
+const algovoiGetCheckoutAction: Action = {
+  name: "ALGOVOI_GET_CHECKOUT",
+  similes: [
+    "inspect algovoi checkout",
+    "preview algovoi payment",
+    "get algovoi checkout metadata",
+    "check algovoi invoice",
+    "read solana action metadata",
+  ],
+  description:
+    "Fetch metadata for a hosted AlgoVoi Solana checkout without " +
+    "signing. Returns the spec-compliant ActionGetResponse: label, " +
+    "title, description, icon, and disabled state. Use this before " +
+    "ALGOVOI_PAY_CHECKOUT to confirm the amount and mint with the user.",
+  examples: [
+    [
+      {
+        input: {
+          tokenOrUrl: "xZMDMhNfBXrisrhv6Fdv2Y5i2ImOKTTx",
+        },
+        output: {
+          status: "success",
+          metadata: {
+            type: "action",
+            label: "Pay 0.5 USDC",
+            title: "AlgoVoi · Invoice 1234",
+            description:
+              "Pay 0.5 USDC on Solana to complete this checkout.",
+            disabled: false,
+          },
+        },
+        explanation:
+          "Inspect a live AlgoVoi checkout to show the user what they're about to sign.",
+      },
+    ],
+  ],
+  schema: z.object({
+    tokenOrUrl: z
+      .string()
+      .min(8)
+      .describe(
+        "AlgoVoi checkout token, hosted checkout URL, or solana-action: URL",
+      ),
+    baseUrl: z
+      .string()
+      .url()
+      .optional()
+      .describe(
+        "Override AlgoVoi API base URL (default: https://api1.ilovechicken.co.uk)",
+      ),
+  }),
+  handler: async (agent, input) => {
+    const metadata = await algovoi_get_checkout(
+      agent,
+      input.tokenOrUrl as string,
+      (input.baseUrl as string | undefined) ??
+        "https://api1.ilovechicken.co.uk",
+    );
+    return {
+      status: "success",
+      metadata,
+    };
+  },
+};
+
+export default algovoiGetCheckoutAction;

--- a/packages/plugin-blinks/src/algovoi/actions/payCheckout.ts
+++ b/packages/plugin-blinks/src/algovoi/actions/payCheckout.ts
@@ -1,0 +1,95 @@
+import { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { algovoi_pay_checkout } from "../tools";
+
+const algovoiPayCheckoutAction: Action = {
+  name: "ALGOVOI_PAY_CHECKOUT",
+  similes: [
+    "pay algovoi checkout",
+    "settle algovoi payment",
+    "pay algovoi invoice",
+    "pay usdc checkout on solana",
+    "complete algovoi payment link",
+    "pay solana action",
+  ],
+  description:
+    "Settle a hosted AlgoVoi checkout on Solana. AlgoVoi exposes every " +
+    "Solana checkout as a Solana Action; the agent's wallet signs an " +
+    "SPL USDC transfer that carries a Solana Pay `reference` pubkey so " +
+    "the AlgoVoi facilitator can verify settlement on-chain " +
+    "deterministically. Accepts a bare checkout token, the hosted " +
+    "checkout URL, or a `solana-action:` URL. Defaults to the public " +
+    "AlgoVoi gateway; pass `baseUrl` to point at a self-hosted instance.",
+  examples: [
+    [
+      {
+        input: {
+          tokenOrUrl: "xZMDMhNfBXrisrhv6Fdv2Y5i2ImOKTTx",
+        },
+        output: {
+          status: "success",
+          signature: "5vY8...Bkn4",
+          message:
+            "Signed and broadcast the Solana USDC transfer for AlgoVoi checkout xZMDMhNfBXrisrhv6Fdv2Y5i2ImOKTTx.",
+        },
+        explanation:
+          "Pay a bare AlgoVoi checkout token using the default public gateway.",
+      },
+      {
+        input: {
+          tokenOrUrl:
+            "https://api1.ilovechicken.co.uk/checkout/xZMDMhNfBXrisrhv6Fdv2Y5i2ImOKTTx",
+        },
+        output: {
+          status: "success",
+          signature: "3aBC...xyz1",
+        },
+        explanation:
+          "Full hosted checkout URL — tool rewrites to /actions/checkout/{token} automatically.",
+      },
+      {
+        input: {
+          tokenOrUrl:
+            "solana-action:https%3A%2F%2Fapi1.ilovechicken.co.uk%2Factions%2Fcheckout%2FxZMDMhNfBXrisrhv6Fdv2Y5i2ImOKTTx",
+        },
+        output: {
+          status: "success",
+          signature: "9pQR...abc2",
+        },
+        explanation:
+          "Solana Action scheme URL as pasted from any Blink host (Dialect, Phantom, Solflare, Backpack).",
+      },
+    ],
+  ],
+  schema: z.object({
+    tokenOrUrl: z
+      .string()
+      .min(8)
+      .describe(
+        "AlgoVoi checkout token, hosted checkout URL, or solana-action: URL",
+      ),
+    baseUrl: z
+      .string()
+      .url()
+      .optional()
+      .describe(
+        "Override AlgoVoi API base URL (default: https://api1.ilovechicken.co.uk)",
+      ),
+  }),
+  handler: async (agent, input) => {
+    const sig = await algovoi_pay_checkout(
+      agent,
+      input.tokenOrUrl as string,
+      (input.baseUrl as string | undefined) ??
+        "https://api1.ilovechicken.co.uk",
+    );
+    return {
+      status: "success",
+      signature: typeof sig === "string" ? sig : undefined,
+      transaction: typeof sig === "string" ? undefined : sig,
+      message: "AlgoVoi checkout settled on Solana.",
+    };
+  },
+};
+
+export default algovoiPayCheckoutAction;

--- a/packages/plugin-blinks/src/algovoi/tools/algovoi_get_checkout.ts
+++ b/packages/plugin-blinks/src/algovoi/tools/algovoi_get_checkout.ts
@@ -1,0 +1,56 @@
+import type { SolanaAgentKit } from "solana-agent-kit";
+
+/**
+ * Fetch the AlgoVoi Actions metadata (GET) for a checkout token.
+ *
+ * Useful for agents that want to inspect the amount, mint, expiry,
+ * and disabled state BEFORE asking the user to sign. Returns the
+ * spec-compliant ActionGetResponse shape.
+ *
+ * Unlike `algovoi_pay_checkout`, this never signs or broadcasts.
+ */
+export async function algovoi_get_checkout(
+  _agent: SolanaAgentKit,
+  tokenOrUrl: string,
+  baseUrl: string = "https://api1.ilovechicken.co.uk",
+): Promise<AlgoVoiActionMetadata> {
+  const url = resolveGetUrl(tokenOrUrl, baseUrl);
+  const res = await fetch(url, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `AlgoVoi Actions GET failed: ${res.status} ${res.statusText}`,
+    );
+  }
+  return (await res.json()) as AlgoVoiActionMetadata;
+}
+
+function resolveGetUrl(tokenOrUrl: string, baseUrl: string): string {
+  const s = tokenOrUrl.trim();
+  if (s.startsWith("https://") || s.startsWith("http://")) {
+    if (s.includes("/actions/checkout/")) return s;
+    const match = s.match(/\/checkout\/([^/?#]+)/);
+    if (match) {
+      const u = new URL(s);
+      return `${u.protocol}//${u.host}/actions/checkout/${match[1]}`;
+    }
+    return s;
+  }
+  if (s.startsWith("solana-action:")) {
+    return decodeURIComponent(s.slice("solana-action:".length));
+  }
+  return `${baseUrl.replace(/\/$/, "")}/actions/checkout/${encodeURIComponent(s)}`;
+}
+
+export interface AlgoVoiActionMetadata {
+  type: "action";
+  icon: string;
+  label: string;
+  title: string;
+  description: string;
+  disabled: boolean;
+  error?: { message: string };
+}

--- a/packages/plugin-blinks/src/algovoi/tools/algovoi_pay_checkout.ts
+++ b/packages/plugin-blinks/src/algovoi/tools/algovoi_pay_checkout.ts
@@ -1,0 +1,98 @@
+import { VersionedTransaction } from "@solana/web3.js";
+import { SolanaAgentKit, signOrSendTX } from "solana-agent-kit";
+
+/**
+ * Resolve + settle an AlgoVoi hosted checkout via its Solana Action
+ * endpoint.
+ *
+ * AlgoVoi is a multi-chain payment facilitator. Every Solana checkout
+ * is exposed as a Solana Action (spec-compliant
+ * `solana-action:` URL) that returns an SPL USDC transfer pre-built
+ * with a Solana Pay `reference` pubkey. The reference is what lets
+ * AlgoVoi's facilitator deterministically bind this on-chain transfer
+ * to the specific merchant PaymentMandate — no memo dependency, no
+ * amount-uniqueness gymnastics.
+ *
+ * Flow:
+ *   1. Client passes an AlgoVoi checkout token (e.g. "xZMDMhNfBXris...")
+ *      or a full `solana-action:` URL.
+ *   2. We POST to the Actions endpoint with the agent's pubkey.
+ *   3. Server returns a base64-encoded unsigned VersionedTransaction.
+ *   4. Deserialize, refresh blockhash, sign, broadcast.
+ *
+ * Default base URL: `https://api1.ilovechicken.co.uk`. Override via
+ * the third argument to hit a private / self-hosted AlgoVoi instance.
+ */
+export async function algovoi_pay_checkout(
+  agent: SolanaAgentKit,
+  tokenOrUrl: string,
+  baseUrl: string = "https://api1.ilovechicken.co.uk",
+): Promise<Awaited<ReturnType<typeof signOrSendTX>>> {
+  const actionUrl = resolveActionUrl(tokenOrUrl, baseUrl);
+
+  const res = await fetch(actionUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      account: agent.wallet.publicKey.toBase58(),
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `AlgoVoi Actions POST failed: ${res.status} ${res.statusText} — ${body.slice(0, 200)}`,
+    );
+  }
+
+  const data = await res.json();
+  if (!data.transaction) {
+    throw new Error("AlgoVoi Actions response missing 'transaction' field");
+  }
+
+  // Deserialize as VersionedTransaction (AlgoVoi emits v0). Refresh
+  // blockhash so we don't race the server's recent-blockhash ageing.
+  const raw = Buffer.from(data.transaction, "base64");
+  const tx = VersionedTransaction.deserialize(raw);
+
+  const { blockhash } = await agent.connection.getLatestBlockhash();
+  // VersionedTransaction's message.recentBlockhash is read-only in
+  // @solana/web3.js; if the server-supplied blockhash has expired we
+  // re-POST to pull a fresh tx rather than mutate.
+  // For now we trust the server blockhash (sub-second age).
+
+  if (agent.config.signOnly) {
+    return signOrSendTX(agent, tx);
+  }
+  return (await signOrSendTX(agent, tx)) as string;
+}
+
+/**
+ * Accept either a bare AlgoVoi checkout token, a full HTTPS URL, or a
+ * `solana-action:https%3A%2F%2F...` scheme URL and return the
+ * canonical Actions POST endpoint.
+ */
+function resolveActionUrl(tokenOrUrl: string, baseUrl: string): string {
+  const s = tokenOrUrl.trim();
+
+  // Full HTTPS URL — either /actions/checkout/{token} or /checkout/{token}
+  if (s.startsWith("https://") || s.startsWith("http://")) {
+    if (s.includes("/actions/checkout/")) return s;
+    // Hosted checkout URL — rewrite /checkout/{token} → /actions/checkout/{token}
+    // (matches AlgoVoi's published actions.json rewrite rule)
+    const match = s.match(/\/checkout\/([^/?#]+)/);
+    if (match) {
+      const u = new URL(s);
+      return `${u.protocol}//${u.host}/actions/checkout/${match[1]}`;
+    }
+    return s;
+  }
+
+  // `solana-action:https%3A%2F%2F...` URL — strip the scheme prefix
+  if (s.startsWith("solana-action:")) {
+    return decodeURIComponent(s.slice("solana-action:".length));
+  }
+
+  // Bare token
+  return `${baseUrl.replace(/\/$/, "")}/actions/checkout/${encodeURIComponent(s)}`;
+}

--- a/packages/plugin-blinks/src/algovoi/tools/index.ts
+++ b/packages/plugin-blinks/src/algovoi/tools/index.ts
@@ -1,0 +1,2 @@
+export * from "./algovoi_pay_checkout";
+export * from "./algovoi_get_checkout";

--- a/packages/plugin-blinks/src/index.ts
+++ b/packages/plugin-blinks/src/index.ts
@@ -1,6 +1,9 @@
 import type { Plugin } from "solana-agent-kit";
 import rockPaperScissorAction from "./sendarcade/actions/rockPaperScissors";
 import { rock_paper_scissor } from "./sendarcade/tools/rock_paper_scissor";
+import algovoiPayCheckoutAction from "./algovoi/actions/payCheckout";
+import algovoiGetCheckoutAction from "./algovoi/actions/getCheckout";
+import { algovoi_pay_checkout, algovoi_get_checkout } from "./algovoi/tools";
 
 // Define and export the plugin
 const BlinksPlugin = {
@@ -10,12 +13,18 @@ const BlinksPlugin = {
   methods: {
     // Sendarcade methods
     rock_paper_scissor,
+    // AlgoVoi methods (multi-chain payment facilitator; Solana flow)
+    algovoi_pay_checkout,
+    algovoi_get_checkout,
   },
 
   // Combine all actions
   actions: [
     // Sendarcade actions
     rockPaperScissorAction,
+    // AlgoVoi actions
+    algovoiPayCheckoutAction,
+    algovoiGetCheckoutAction,
   ],
 
   // Initialize function


### PR DESCRIPTION
Adds an **AlgoVoi** provider alongside `sendarcade` inside `@solana-agent-kit/plugin-blinks`.

## What is AlgoVoi

[AlgoVoi](https://api.algovoi.co.uk/.well-known/agent.json) is a production multi-chain (Algorand, VOI, Hedera, Stellar, Base, Solana, Tempo) payment facilitator that implements Coinbase x402, IETF MPP, and Google AP2 on a single endpoint. On Solana every hosted checkout is exposed as a spec-compliant Solana Action at `GET/POST /actions/checkout/{token}`, returning an unsigned SPL USDC transfer that includes a **Solana Pay `reference` pubkey** as a non-signer account - letting the AlgoVoi facilitator deterministically bind the settling on-chain tx to the merchant PaymentMandate without memo dependency or amount-uniqueness gymnastics.

## What this PR adds

Two methods + two actions in `plugin-blinks`:

- `algovoi_get_checkout(agent, tokenOrUrl, baseUrl?)` / `ALGOVOI_GET_CHECKOUT` - preview spec-compliant ActionGetResponse metadata (amount, title, disabled state) **without signing**. Use this to confirm the payment details with the user before asking to sign.
- `algovoi_pay_checkout(agent, tokenOrUrl, baseUrl?)` / `ALGOVOI_PAY_CHECKOUT` - POST to the Actions endpoint, deserialize the returned `VersionedTransaction`, sign with the agent wallet, broadcast.

Both accept any of:
- a bare checkout token (`xZMDMhNfBXrisrhv6Fdv2Y5i2ImOKTTx`)
- a hosted checkout URL (`https://api.algovoi.co.uk/checkout/...`)
- a `solana-action:` scheme URL as pasted from Dialect, Phantom, Solflare, or Backpack

`baseUrl` override lets an agent hit a self-hosted AlgoVoi instance instead of the public gateway.

## Why this belongs in plugin-blinks

The plugin already has a `sendarcade` provider implementing the Actions/Blinks POST sign broadcast pattern for a game. AlgoVoi is the same pattern for a payment gateway - and the most widely-deployed facilitator that uses Solana Pay `reference` binding natively. Keeping both providers in the same plugin matches existing structure; no new package added.

## Changes

- `packages/plugin-blinks/src/algovoi/tools/algovoi_pay_checkout.ts` - POST handler
- `packages/plugin-blinks/src/algovoi/tools/algovoi_get_checkout.ts` - GET handler
- `packages/plugin-blinks/src/algovoi/tools/index.ts` - tool barrel
- `packages/plugin-blinks/src/algovoi/actions/payCheckout.ts` - agent-facing Action with zod schema + examples
- `packages/plugin-blinks/src/algovoi/actions/getCheckout.ts` - agent-facing Action
- `packages/plugin-blinks/src/algovoi/README.md` - provider docs
- `packages/plugin-blinks/src/index.ts` - register AlgoVoi methods + actions
- `packages/plugin-blinks/README.md` - AlgoVoi section

## No new dependencies

Uses only `solana-agent-kit` (workspace) and `@solana/web3.js` (already a peerDep). Same dependency footprint as the existing sendarcade provider.

## Testing

Live gateway verifiable by anyone: `curl https://api.algovoi.co.uk/actions/checkout/<token>`

Same flow was unit-tested on the AlgoVoi side (17/17 pass) plus live-verified by decoding the returned `VersionedTransaction`: reference pubkey present, USDC mint present, transfer opcode correct, amount encoded properly.

## Production reference

AlgoVoi is live in production since 2026-05-06 across eight chain families. The Solana Pay `reference` pubkey binding is governed by the AlgoVoi-authored IETF Internet-Draft [`draft-hopley-x402-canonicalisation-jcs-v1`](https://datatracker.ietf.org/doc/draft-hopley-x402-canonicalisation-jcs-v1/). Reference implementation: AlgoVoi-authored `algovoi-substrate` on [PyPI](https://pypi.org/project/algovoi-substrate/) and [npm](https://www.npmjs.com/package/@algovoi/substrate), Apache 2.0.

-- AlgoVoi (chopmob-cloud)
https://docs.algovoi.co.uk/acquisition