### PR TITLE
Add Trade Router to Community Plugins (Solana swap & limit-order MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,53 @@ You can choose to install any of the plugins listed below or you could choose to
 npm install @solana-agent-kit/plugin-token @solana-agent-kit/plugin-nft @solana-agent-kit/plugin-defi @solana-agent-kit/plugin-misc @solana-agent-kit/plugin-blinks
 ```
 
+## 🌐 Community Plugins
+
+Third-party plugins that extend Solana Agent Kit with additional protocols and capabilities:
+
+### Trade Router (`@traderouter/trade-router-mcp`)
+
+Non-custodial Solana swap & limit-order MCP server. 21 tools (swap, limit, trailing, TWAP, DCA, and 4 combo orders) routed across Raydium, PumpSwap, Orca, and Meteora. Jito MEV-protected execution by default. Ed25519 server-message verification on order callbacks. Private key never leaves the agent.
+
+```bash
+# No SDK install required — Trade Router exposes tools through MCP.
+npx -y @traderouter/trade-router-mcp
+```
+
+```typescript
+// Pair Trade Router (writes) with SAK (reads + token launches).
+// SAK calls Trade Router via SAK's MCP-client adapter.
+import { SolanaAgentKit, KeypairWallet } from "solana-agent-kit";
+import { createMCPClient } from "@solana-agent-kit/adapter-mcp";
+
+const agent = new SolanaAgentKit(wallet, rpcUrl, {});
+
+const traderouter = await createMCPClient({
+  command: "npx",
+  args: ["-y", "@traderouter/trade-router-mcp"],
+  env: { TRADEROUTER_PRIVATE_KEY: process.env.TRADEROUTER_PRIVATE_KEY },
+});
+
+// All 21 Trade Router tools registered as agent actions:
+// AUTO_SWAP, BUILD_SWAP, GET_HOLDINGS, GET_MCAP,
+// PLACE_LIMIT_ORDER, PLACE_TRAILING_ORDER, PLACE_TWAP_ORDER,
+// PLACE_LIMIT_TWAP_ORDER, PLACE_TRAILING_TWAP_ORDER,
+// PLACE_LIMIT_TRAILING_ORDER, PLACE_LIMIT_TRAILING_TWAP_ORDER,
+// CANCEL_ORDER, EXTEND_ORDER, LIST_ORDERS, CHECK_ORDER,
+// CONNECT_WEBSOCKET, GET_FILL_LOG, etc.
+
+// Programmatic API via the MCP client:
+await traderouter.callTool({
+  name: "auto_swap",
+  arguments: {
+    wallet_address: WALLET, token_address: TARGET_MINT,
+    action: "buy", amount: 100_000_000, slippage: 1500,
+  },
+});
+```
+
+Ideal for autonomous Solana trading agents that need limit / trailing / TWAP / DCA / combo orders with MEV-protected execution out of the box. Set `TRADEROUTER_DRY_RUN=true` to short-circuit every write tool for safe iteration. [GitHub](https://github.com/TradeRouter/trade-router-mcp) · [npm](https://www.npmjs.com/package/@traderouter/trade-router-mcp) · [docs](https://traderouter.ai) · [cookbook](https://github.com/TradeRouter/cookbook) (7 examples including `06-elizaos-agent` and `07-langchain-agent`)
+
 ## Quick Start
 
 Initializing the wallet interface and agent with plugins:


### PR DESCRIPTION
## What this adds

Adds **Trade Router** to a new "Community Plugins" section in the README.

[`@traderouter/trade-router-mcp`](https://github.com/TradeRouter/trade-router-mcp) is a non-custodial Solana swap & limit-order MCP server that complements SAK on the **write side**:

- **21 tools** — swap, limit, trailing, TWAP, DCA, and 4 combo orders (limit+TWAP, trailing+TWAP, limit+trailing, limit+trailing+TWAP)
- **Multi-DEX routing** — Raydium, PumpSwap, Orca, Meteora
- **MEV-protected** by default via Jito bundles
- **Ed25519 server-message verification** on `order_filled` callbacks
- **Private key never leaves the agent** — read once from `TRADEROUTER_PRIVATE_KEY`, signs locally with `@solana/web3.js` + `tweetnacl`, only signed transactions go on the wire
- **Safe iteration** — `TRADEROUTER_DRY_RUN=true` short-circuits every write tool

## Format

I followed the same format as PR #518 (A2A-Swap) — section header `## 🌐 Community Plugins`, plugin sub-section with description + npm install + TypeScript usage + footer with GitHub/npm/docs links. If #518 lands first, this PR will rebase cleanly into the existing section.

## Why ship this here

SAK and Trade Router are complementary, not competitive:

- **SAK is best at**: token launches, NFT operations, holdings reads, lending/borrowing/perp protocols, broad ecosystem coverage
- **Trade Router is best at**: agent-facing swap routing, MEV-protected execution, and order-management primitives (limit / trailing / TWAP / DCA / combo) that aren't first-class in SAK

The pattern: SAK for token discovery and on-chain reads → Trade Router for the swap-routing and order-management write side. Both are non-custodial with the same key-handling model.

## Trust signals

- VirusTotal 0/62 on the published `@traderouter/trade-router-mcp@1.0.12` tarball
- CI green on Node 18/20/22 with tarball-leak guard (`.mcpregistry_*` and `.env*` blocked)
- Branch protection on `main` (no force-push, required status checks)
- Signed npm publishes (`dist.signatures` on every release)
- Already in the official MCP Registry as `ai.traderouter/trade-router-mcp@1.0.12` (`isLatest: true`, DNS-auth published)
- Glama listing (author-verified): <https://glama.ai/mcp/servers/@traderouter/trade-router-mcp>

## Cookbook

Two of the 7 examples in [TradeRouter/cookbook](https://github.com/TradeRouter/cookbook) are framework integrations:

- `06-elizaos-agent` — uses `@fleek-platform/eliza-plugin-mcp`
- `07-langchain-agent` — uses `langchain-mcp-adapters`
- `08-helius-trade-router-combo` — Helius reads + Trade Router writes (canonical production pattern)

A SAK-specific example will land in the cookbook once this entry is in the README and we know which adapter path SAK users prefer.