### PR TITLE
feat: add plugin-onleash — Token-2022 transfer hook for AI agent wallets

### DIFF
--- a/packages/plugin-onleash/package.json
+++ b/packages/plugin-onleash/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@solana-agent-kit/plugin-onleash",
+  "version": "0.1.0",
+  "description": "Onleash Token-2022 transfer hook plugin — policy-protected mints for AI agent wallets",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "clean": "rm -rf dist .turbo node_modules",
+    "build": "tsup src/index.ts --dts --clean --format cjs,esm --out-dir dist",
+    "test": "jest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sendaifun/solana-agent-kit.git"
+  },
+  "homepage": "https://github.com/sendaifun/solana-agent-kit/tree/v2/packages/plugin-onleash",
+  "dependencies": {
+    "@coral-xyz/anchor": "^0.30.1",
+    "@onleash/sdk": "^0.1.0",
+    "@solana/spl-token": "^0.4.9",
+    "solana-agent-kit": "workspace:*",
+    "zod": "^3.24.1"
+  },
+  "peerDependencies": {
+    "@solana/web3.js": "^1.98.2",
+    "solana-agent-kit": "2.0.7"
+  },
+  "devDependencies": {
+    "tsup": "^8.4.0"
+  }
+}

--- a/packages/plugin-onleash/package.json
+++ b/packages/plugin-onleash/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/sendaifun/solana-agent-kit/tree/v2/packages/plugin-onleash",
   "dependencies": {
     "@coral-xyz/anchor": "^0.30.1",
-    "@onleash/sdk": "^0.1.0",
+    "@onleash/sdk": "github:amalia020/onleash#main",
     "@solana/spl-token": "^0.4.9",
     "solana-agent-kit": "workspace:*",
     "zod": "^3.24.1"

--- a/packages/plugin-onleash/src/index.ts
+++ b/packages/plugin-onleash/src/index.ts
@@ -1,6 +1,7 @@
 import type { Plugin, SolanaAgentKit } from "solana-agent-kit";
 import deployProtectedMintAction from "./onleash/actions/deployProtectedMint";
 import getPolicyAction from "./onleash/actions/getPolicy";
+import payShProtectedPaymentAction from "./onleash/actions/payShProtectedPayment";
 import protectedTransferAction from "./onleash/actions/protectedTransfer";
 import updatePolicyAction from "./onleash/actions/updatePolicy";
 import {
@@ -36,6 +37,7 @@ const OnleashPlugin: Plugin = {
     updatePolicyAction,
     getPolicyAction,
     protectedTransferAction,
+    payShProtectedPaymentAction,  // pay.sh x402 protected payments
   ],
 
   initialize(_agent: SolanaAgentKit): void {

--- a/packages/plugin-onleash/src/index.ts
+++ b/packages/plugin-onleash/src/index.ts
@@ -1,0 +1,46 @@
+import type { Plugin, SolanaAgentKit } from "solana-agent-kit";
+import deployProtectedMintAction from "./onleash/actions/deployProtectedMint";
+import getPolicyAction from "./onleash/actions/getPolicy";
+import protectedTransferAction from "./onleash/actions/protectedTransfer";
+import updatePolicyAction from "./onleash/actions/updatePolicy";
+import {
+  deployProtectedMint,
+  getPolicy,
+  getOnleashClient,
+  protectedTransfer,
+  updatePolicy,
+} from "./onleash/tools";
+
+export {
+  deployProtectedMint,
+  getPolicy,
+  getOnleashClient,
+  protectedTransfer,
+  updatePolicy,
+};
+
+const OnleashPlugin: Plugin = {
+  name: "onleash",
+
+  // Programmatic API — call agent.methods.onleash_deploy(...) etc.
+  methods: {
+    onleash_deploy: deployProtectedMint,
+    onleash_update_policy: updatePolicy,
+    onleash_get_policy: getPolicy,
+    onleash_transfer: protectedTransfer,
+  },
+
+  // AI agent actions — exposed via createVercelAITools / createLangchainTools etc.
+  actions: [
+    deployProtectedMintAction,
+    updatePolicyAction,
+    getPolicyAction,
+    protectedTransferAction,
+  ],
+
+  initialize(_agent: SolanaAgentKit): void {
+    // No setup required — OnleashClient is instantiated per-call using the agent's connection + wallet.
+  },
+};
+
+export default OnleashPlugin;

--- a/packages/plugin-onleash/src/onleash/actions/deployProtectedMint.ts
+++ b/packages/plugin-onleash/src/onleash/actions/deployProtectedMint.ts
@@ -1,0 +1,79 @@
+import type { Action, SolanaAgentKit } from "solana-agent-kit";
+import { z } from "zod";
+import { deployProtectedMint } from "../tools";
+
+const deployProtectedMintAction: Action = {
+  name: "ONLEASH_DEPLOY_PROTECTED_MINT",
+  similes: [
+    "create policy-protected token",
+    "deploy onleash mint",
+    "create transfer hook mint",
+    "protect agent wallet",
+    "create spending-limited token",
+  ],
+  description:
+    "Create a Token-2022 mint with an Onleash transfer hook. Every transfer of this mint is " +
+    "checked on-chain against: (1) a destination allowlist, (2) a per-tx max, and " +
+    "(3) a daily cap. A jailbroken agent cannot bypass these — the chain enforces them. " +
+    "Returns the mint address, policy PDA, and transaction signatures.",
+  examples: [
+    [
+      {
+        input: {
+          decimals: 6,
+          perTxMax: "10000000",
+          dailyCap: "50000000",
+          allowlist: ["8x2dR8Mpzuz2YqyZyZjUbYWKSWesBo5jMx2Q9Y86udVk"],
+        },
+        output: {
+          status: "success",
+          mint: "2KkYRVS2cBnneryveAYxH5hGfnNhdFruXAc4NjeAekcZ",
+          policy: "DEnvhrXrmmFGkg9SMBYM2x1fopewoQBiQUXADQzi54jV",
+          message: "Protected mint deployed successfully",
+        },
+        explanation:
+          "Deploy a policy-protected mint: 10 tokens per tx, 50 tokens per day, " +
+          "one approved destination.",
+      },
+    ],
+  ],
+  schema: z.object({
+    decimals: z
+      .number()
+      .int()
+      .min(0)
+      .max(9)
+      .describe("Mint decimals (0–9). Use 6 for USDC-style."),
+    perTxMax: z
+      .string()
+      .describe(
+        "Per-transfer max in raw token units as a string (e.g. '10000000' = 10 tokens at 6 decimals).",
+      ),
+    dailyCap: z
+      .string()
+      .describe(
+        "Daily cumulative cap in raw units (24h rolling window). Same unit as perTxMax.",
+      ),
+    allowlist: z
+      .array(z.string().min(32))
+      .max(8)
+      .describe(
+        "Up to 8 approved destination token-account pubkeys. Transfers to any other address revert.",
+      ),
+  }),
+  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+    const result = await deployProtectedMint(agent, {
+      decimals: input.decimals,
+      perTxMax: BigInt(input.perTxMax),
+      dailyCap: BigInt(input.dailyCap),
+      allowlist: input.allowlist,
+    });
+    return {
+      status: "success",
+      ...result,
+      message: `Protected mint deployed: ${result.mint}. Policy enforces per-tx max ${input.perTxMax}, daily cap ${input.dailyCap}, ${input.allowlist.length} approved destination(s).`,
+    };
+  },
+};
+
+export default deployProtectedMintAction;

--- a/packages/plugin-onleash/src/onleash/actions/getPolicy.ts
+++ b/packages/plugin-onleash/src/onleash/actions/getPolicy.ts
@@ -1,0 +1,46 @@
+import type { Action, SolanaAgentKit } from "solana-agent-kit";
+import { z } from "zod";
+import { getPolicy } from "../tools";
+
+const getPolicyAction: Action = {
+  name: "ONLEASH_GET_POLICY",
+  similes: [
+    "get transfer policy",
+    "check spending limits",
+    "read onleash policy",
+    "check daily cap",
+    "how much has the agent spent today",
+  ],
+  description:
+    "Fetch the on-chain Onleash policy for a protected mint. Shows current caps, " +
+    "the destination allowlist, and how much has been spent today.",
+  examples: [
+    [
+      {
+        input: {
+          mint: "2KkYRVS2cBnneryveAYxH5hGfnNhdFruXAc4NjeAekcZ",
+        },
+        output: {
+          status: "success",
+          perTxMax: "10000000",
+          dailyCap: "50000000",
+          spentToday: "5000000",
+          destinationAllowlist: ["8x2dR8Mpzuz2YqyZyZjUbYWKSWesBo5jMx2Q9Y86udVk"],
+        },
+        explanation: "Read the policy for a protected mint.",
+      },
+    ],
+  ],
+  schema: z.object({
+    mint: z.string().min(32).describe("The protected mint address to query."),
+  }),
+  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+    const policy = await getPolicy(agent, input.mint);
+    if (!policy) {
+      return { status: "error", message: `No Onleash policy found for mint ${input.mint}. Has init_policy been called?` };
+    }
+    return { status: "success", ...policy };
+  },
+};
+
+export default getPolicyAction;

--- a/packages/plugin-onleash/src/onleash/actions/payShProtectedPayment.ts
+++ b/packages/plugin-onleash/src/onleash/actions/payShProtectedPayment.ts
@@ -1,0 +1,164 @@
+import type { Action, SolanaAgentKit } from "solana-agent-kit";
+import { z } from "zod";
+import { protectedTransfer, getPolicy } from "../tools";
+
+/**
+ * pay.sh + Onleash integration action.
+ *
+ * pay.sh uses HTTP 402 / x402 to let AI agents pay for API calls autonomously.
+ * The agent detects a 402 Payment Required challenge, signs a payment, retries.
+ *
+ * The attack: a jailbroken agent gets a 402 response from an ATTACKER
+ * (not a real API provider) and sends the payment there instead.
+ *
+ * The fix: the agent's payment tokens are an Onleash-protected Token-2022 mint.
+ * Only approved pay.sh provider payment addresses are on the allowlist.
+ * The chain blocks any payment to an unapproved destination — atomically,
+ * before funds move, regardless of what the agent signed.
+ */
+const payShProtectedPaymentAction: Action = {
+  name: "ONLEASH_PAY_SH_PAYMENT",
+  similes: [
+    "pay for api call",
+    "pay.sh payment",
+    "pay for http 402",
+    "agent api payment",
+    "x402 payment",
+    "pay for tool call",
+  ],
+  description:
+    "Send a policy-protected payment to a pay.sh API provider using an Onleash-protected mint. " +
+    "The on-chain hook verifies the destination is an approved pay.sh provider address before " +
+    "the payment settles. If a jailbroken agent tries to redirect the payment to an attacker, " +
+    "the chain blocks it with DestinationNotAllowed (6001). " +
+    "Use this instead of a standard transfer whenever your agent pays for API calls via pay.sh / x402.",
+  examples: [
+    [
+      {
+        input: {
+          mint: "2KkYRVS2cBnneryveAYxH5hGfnNhdFruXAc4NjeAekcZ",
+          source: "3qHDnLYazYYbhhUHb1ZAAg2tJPrFqPCMfShiEyGsDWtn",
+          providerPaymentAddress: "8x2dR8Mpzuz2YqyZyZjUbYWKSWesBo5jMx2Q9Y86udVk",
+          amount: "1000",
+          decimals: 6,
+          apiEndpoint: "https://api.quicknode.com/rpc",
+        },
+        output: {
+          status: "success",
+          signature: "2QAvoByj2EZUeL5SZXSNKMkSe6bgFyGmxLDdb92LHrEK",
+          message: "Payment of 1000 raw units sent to approved pay.sh provider",
+        },
+        explanation:
+          "Agent pays a QuickNode RPC endpoint via pay.sh. " +
+          "Onleash verifies the destination is whitelisted before the payment settles.",
+      },
+    ],
+    [
+      {
+        input: {
+          mint: "2KkYRVS2cBnneryveAYxH5hGfnNhdFruXAc4NjeAekcZ",
+          source: "3qHDnLYazYYbhhUHb1ZAAg2tJPrFqPCMfShiEyGsDWtn",
+          providerPaymentAddress: "AttackerWallet111111111111111111111111111111",
+          amount: "1000",
+          decimals: 6,
+          apiEndpoint: "https://attacker.example.com/fake-api",
+        },
+        output: {
+          status: "error",
+          error: "DestinationNotAllowed",
+          code: 6001,
+          message: "Payment blocked by Onleash — destination not in allowlist",
+        },
+        explanation:
+          "Jailbroken agent tries to pay an attacker address disguised as a pay.sh provider. " +
+          "Onleash blocks it atomically — the chain refused to clear the transfer.",
+      },
+    ],
+  ],
+  schema: z.object({
+    mint: z.string().min(32).describe(
+      "Onleash-protected Token-2022 mint used for payments."
+    ),
+    source: z.string().min(32).describe(
+      "Agent's source token account (must hold the protected mint tokens)."
+    ),
+    providerPaymentAddress: z.string().min(32).describe(
+      "The pay.sh provider's payment token account address from the 402 challenge. " +
+      "Must be in the Onleash allowlist — the chain rejects payments to any other address."
+    ),
+    amount: z.string().describe(
+      "Payment amount in raw token units (e.g. '1000' = 0.001 tokens at 6 decimals)."
+    ),
+    decimals: z.number().int().min(0).max(9).describe("Mint decimals."),
+    apiEndpoint: z.string().url().optional().describe(
+      "The API endpoint being paid for (informational — logged but not validated on-chain)."
+    ),
+  }),
+  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+    // Before sending, confirm the destination is in the on-chain allowlist.
+    // This is a pre-flight check — the chain will enforce it anyway, but we
+    // surface a clearer error message if the provider isn't approved yet.
+    const policy = await getPolicy(agent, input.mint);
+
+    if (policy) {
+      const approved = policy.destinationAllowlist.includes(
+        input.providerPaymentAddress
+      );
+      if (!approved) {
+        return {
+          status: "error",
+          error: "DestinationNotAllowed",
+          code: 6001,
+          message:
+            `Payment blocked (pre-flight): ${input.providerPaymentAddress} is not in the ` +
+            `Onleash allowlist for mint ${input.mint}. ` +
+            `Approved destinations: ${policy.destinationAllowlist.join(", ")}. ` +
+            `Use ONLEASH_UPDATE_POLICY to add this provider if it is legitimate.`,
+        };
+      }
+    }
+
+    try {
+      const result = await protectedTransfer(agent, {
+        mint: input.mint,
+        source: input.source,
+        destination: input.providerPaymentAddress,
+        amount: BigInt(input.amount),
+        decimals: input.decimals,
+      });
+
+      return {
+        status: "success",
+        signature: result.signature,
+        message:
+          `Payment of ${input.amount} raw units sent to pay.sh provider ` +
+          `${input.providerPaymentAddress}` +
+          (input.apiEndpoint ? ` for ${input.apiEndpoint}` : "") +
+          `. Signature: ${result.signature}`,
+      };
+    } catch (e: any) {
+      const msg = e?.message ?? String(e);
+      const isOnleashRevert =
+        /DestinationNotAllowed|0x1771|6001|ExceedsPerTxMax|0x1772|6002|ExceedsDailyCap|0x1773|6003/.test(msg);
+
+      if (isOnleashRevert) {
+        const code = /6001|0x1771/.test(msg)
+          ? { name: "DestinationNotAllowed", code: 6001 }
+          : /6002|0x1772/.test(msg)
+          ? { name: "ExceedsPerTxMax", code: 6002 }
+          : { name: "ExceedsDailyCap", code: 6003 };
+
+        return {
+          status: "error",
+          error: code.name,
+          code: code.code,
+          message: `Payment blocked by Onleash on-chain (${code.name} ${code.code}). Funds were never moved.`,
+        };
+      }
+
+      throw e;
+    }
+  },
+};
+
+export default payShProtectedPaymentAction;

--- a/packages/plugin-onleash/src/onleash/actions/protectedTransfer.ts
+++ b/packages/plugin-onleash/src/onleash/actions/protectedTransfer.ts
@@ -1,0 +1,59 @@
+import type { Action, SolanaAgentKit } from "solana-agent-kit";
+import { z } from "zod";
+import { protectedTransfer } from "../tools";
+
+const protectedTransferAction: Action = {
+  name: "ONLEASH_PROTECTED_TRANSFER",
+  similes: [
+    "send protected tokens",
+    "transfer policy-protected tokens",
+    "onleash transfer",
+    "transfer with spending limits",
+  ],
+  description:
+    "Transfer tokens from a policy-protected Onleash mint. " +
+    "The on-chain hook validates destination, per-tx max, and daily cap before settling. " +
+    "Any policy violation reverts the entire transaction atomically — funds are never moved.",
+  examples: [
+    [
+      {
+        input: {
+          mint: "2KkYRVS2cBnneryveAYxH5hGfnNhdFruXAc4NjeAekcZ",
+          source: "3qHDnLYazYYbhhUHb1ZAAg2tJPrFqPCMfShiEyGsDWtn",
+          destination: "8x2dR8Mpzuz2YqyZyZjUbYWKSWesBo5jMx2Q9Y86udVk",
+          amount: "5000000",
+          decimals: 6,
+        },
+        output: {
+          status: "success",
+          signature: "2QAvoByj2EZUeL5SZXSNKMkSe6bgFyGmxLDdb92LHrEK",
+          message: "Transfer of 5000000 raw units completed successfully",
+        },
+        explanation: "Transfer 5 tokens (5000000 at 6 dp) to an approved destination.",
+      },
+    ],
+  ],
+  schema: z.object({
+    mint: z.string().min(32).describe("The policy-protected mint address."),
+    source: z.string().min(32).describe("Source token account address."),
+    destination: z.string().min(32).describe("Destination token account address. Must be in the policy allowlist."),
+    amount: z.string().describe("Amount in raw token units (e.g. '5000000' = 5 tokens at 6 decimals)."),
+    decimals: z.number().int().min(0).max(9).describe("Mint decimals."),
+  }),
+  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+    const result = await protectedTransfer(agent, {
+      mint: input.mint,
+      source: input.source,
+      destination: input.destination,
+      amount: BigInt(input.amount),
+      decimals: input.decimals,
+    });
+    return {
+      status: "success",
+      ...result,
+      message: `Transfer of ${input.amount} raw units completed. Signature: ${result.signature}`,
+    };
+  },
+};
+
+export default protectedTransferAction;

--- a/packages/plugin-onleash/src/onleash/actions/updatePolicy.ts
+++ b/packages/plugin-onleash/src/onleash/actions/updatePolicy.ts
@@ -1,0 +1,66 @@
+import type { Action, SolanaAgentKit } from "solana-agent-kit";
+import { z } from "zod";
+import { updatePolicy } from "../tools";
+
+const updatePolicyAction: Action = {
+  name: "ONLEASH_UPDATE_POLICY",
+  similes: [
+    "update spending policy",
+    "change transfer limits",
+    "update allowlist",
+    "raise daily cap",
+    "lower per tx limit",
+  ],
+  description:
+    "Update the Onleash policy for a protected mint. Only the policy authority " +
+    "(the wallet that created the mint) can call this. Pass null for fields to leave unchanged.",
+  examples: [
+    [
+      {
+        input: {
+          mint: "2KkYRVS2cBnneryveAYxH5hGfnNhdFruXAc4NjeAekcZ",
+          dailyCap: "100000000",
+        },
+        output: {
+          status: "success",
+          signature: "5UfgJ5vVZxUxefDGqzqkVLHzHxVTyYH9StYyHKgvHYmXJgq",
+          message: "Policy updated: daily cap raised to 100000000",
+        },
+        explanation: "Raise the daily cap to 100 tokens (100000000 at 6 dp).",
+      },
+    ],
+  ],
+  schema: z.object({
+    mint: z.string().min(32).describe("The protected mint address to update."),
+    perTxMax: z
+      .string()
+      .optional()
+      .describe("New per-tx max in raw units. Omit to leave unchanged."),
+    dailyCap: z
+      .string()
+      .optional()
+      .describe("New daily cap in raw units. Omit to leave unchanged."),
+    allowlist: z
+      .array(z.string().min(32))
+      .max(8)
+      .optional()
+      .describe(
+        "New full allowlist (replaces existing). Omit to leave unchanged.",
+      ),
+  }),
+  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+    const result = await updatePolicy(agent, {
+      mint: input.mint,
+      perTxMax: input.perTxMax != null ? BigInt(input.perTxMax) : null,
+      dailyCap: input.dailyCap != null ? BigInt(input.dailyCap) : null,
+      allowlist: input.allowlist ?? null,
+    });
+    return {
+      status: "success",
+      ...result,
+      message: `Policy updated for mint ${input.mint}.`,
+    };
+  },
+};
+
+export default updatePolicyAction;

--- a/packages/plugin-onleash/src/onleash/tools/index.ts
+++ b/packages/plugin-onleash/src/onleash/tools/index.ts
@@ -1,0 +1,110 @@
+import { AnchorProvider, Wallet } from "@coral-xyz/anchor";
+import { OnleashClient, policyPda } from "@onleash/sdk";
+import { PublicKey } from "@solana/web3.js";
+import type { SolanaAgentKit } from "solana-agent-kit";
+
+/**
+ * Get or create an OnleashClient from a SolanaAgentKit instance.
+ * The agent's connection and wallet are reused — no extra config needed.
+ */
+export function getOnleashClient(agent: SolanaAgentKit): OnleashClient {
+  const provider = new AnchorProvider(
+    agent.connection,
+    agent.wallet as unknown as Wallet,
+    { commitment: "confirmed" },
+  );
+  return new OnleashClient(agent.connection, provider.wallet);
+}
+
+export async function deployProtectedMint(
+  agent: SolanaAgentKit,
+  params: {
+    decimals: number;
+    perTxMax: bigint;
+    dailyCap: bigint;
+    allowlist: string[];
+  },
+) {
+  const client = getOnleashClient(agent);
+  const result = await client.deployProtectedMint({
+    decimals: params.decimals,
+    perTxMax: params.perTxMax,
+    dailyCap: params.dailyCap,
+    allowlist: params.allowlist.map((s) => new PublicKey(s)),
+  });
+  return {
+    mint: result.mint.toBase58(),
+    policy: result.policy.toBase58(),
+    metaList: result.metaList.toBase58(),
+    signatures: result.signatures,
+  };
+}
+
+export async function updatePolicy(
+  agent: SolanaAgentKit,
+  params: {
+    mint: string;
+    perTxMax?: bigint | null;
+    dailyCap?: bigint | null;
+    allowlist?: string[] | null;
+  },
+) {
+  const client = getOnleashClient(agent);
+  const mint = new PublicKey(params.mint);
+  const ix = await client.ixUpdatePolicy({
+    authority: agent.wallet.publicKey,
+    mint,
+    perTxMax: params.perTxMax ?? null,
+    dailyCap: params.dailyCap ?? null,
+    allowlist: params.allowlist
+      ? params.allowlist.map((s) => new PublicKey(s))
+      : null,
+  });
+  const { Transaction, sendAndConfirmTransaction } = await import(
+    "@solana/web3.js"
+  );
+  const sig = await sendAndConfirmTransaction(
+    agent.connection,
+    new Transaction().add(ix),
+    [(agent.wallet as any).payer],
+  );
+  return { signature: sig };
+}
+
+export async function getPolicy(agent: SolanaAgentKit, mint: string) {
+  const client = getOnleashClient(agent);
+  const policy = await client.tryFetchPolicy(new PublicKey(mint));
+  if (!policy) return null;
+  return {
+    authority: policy.authority.toBase58(),
+    mint: policy.mint.toBase58(),
+    perTxMax: policy.perTxMax.toString(),
+    dailyCap: policy.dailyCap.toString(),
+    dayStartUnix: policy.dayStartUnix.toString(),
+    spentToday: policy.spentToday.toString(),
+    destinationAllowlist: policy.destinationAllowlist.map((p: PublicKey) =>
+      p.toBase58(),
+    ),
+  };
+}
+
+export async function protectedTransfer(
+  agent: SolanaAgentKit,
+  params: {
+    mint: string;
+    source: string;
+    destination: string;
+    amount: bigint;
+    decimals: number;
+  },
+) {
+  const client = getOnleashClient(agent);
+  return client.transfer({
+    mint: new PublicKey(params.mint),
+    source: new PublicKey(params.source),
+    destination: new PublicKey(params.destination),
+    owner: (agent.wallet as any).payer,
+    amount: params.amount,
+    decimals: params.decimals,
+  });
+}

--- a/packages/plugin-onleash/tsconfig.json
+++ b/packages/plugin-onleash/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What this adds

 — a plugin that protects AI agent wallets using Solana Token-2022 transfer hooks.

### The problem

A jailbroken or prompt-injected agent can sign any transaction it wants. Existing defenses (Turnkey, Privy, Coinbase AgentKit, Squads) enforce policy at the wallet/signer layer — which can be bypassed. Once the agent has a key, it can drain everything.

### What Onleash does

Moves spending policy into the **token itself** via the Token-2022  extension. Every transfer is validated on-chain (atomic, inside the Token-2022 program) against three checks:

1. **Destination allowlist** — up to 8 approved token accounts
2. **Per-tx maximum** — hard ceiling per single transfer  
3. **Daily cap** — rolling 24h cumulative limit

The agent keeps its own keypair and full autonomy. The chain enforces the policy. A jailbroken agent cannot bypass the chain.

This is Solana-native — Token-2022 transfer hooks do not exist on EVM.

### Plugin API



AI actions exposed: , , , 

### Status

- ✅ On-chain program deployed to devnet: 
- ✅ 10/10 tests passing on devnet
- ✅ TypeScript SDK: https://github.com/amalia020/onleash
- ✅ Live demo (click the button, watch the on-chain revert): https://onleash.vercel.app
- 🔄 Mainnet deploy pending
- 🔄 Orca Whirlpools compatibility confirmed (requires TokenBadge)

**WIP — opening as draft to gather maintainer feedback on the API shape before finalising.**