### PR TITLE
docs: add MadeOnSol to a new Community Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,15 @@ You can choose to install any of the plugins listed below or you could choose to
 npm install @solana-agent-kit/plugin-token @solana-agent-kit/plugin-nft @solana-agent-kit/plugin-defi @solana-agent-kit/plugin-misc @solana-agent-kit/plugin-blinks
 ```
 
+### Community Plugins
+
+Third-party plugins maintained by the community. Submit a PR to add yours.
+
+- **[MadeOnSol](https://madeonsol.com)** — `solana-agent-kit-plugin-madeonsol`: Real-time Solana memecoin intelligence — KOL wallet tracking (1,000+ wallets, <3s latency), Pump.fun deployer scoring, multi-KOL coordination signals, alpha-wallet intel, copy-trade rules. Free tier 200 req/day. [npm](https://www.npmjs.com/package/solana-agent-kit-plugin-madeonsol) · [Docs](https://madeonsol.com/api-docs)
+  ```bash
+  npm install solana-agent-kit-plugin-madeonsol
+  ```
+
 ## Quick Start
 
 Initializing the wallet interface and agent with plugins:


### PR DESCRIPTION
## Summary

Adds a **Community Plugins** subsection right after the official 5-plugin install list, and seeds it with the [`solana-agent-kit-plugin-madeonsol`](https://www.npmjs.com/package/solana-agent-kit-plugin-madeonsol) entry.

## Why a new section

The current README lists 5 first-party `@solana-agent-kit/*` plugins. There's currently no surface for third-party plugins, which makes them invisible to new SAK users. A `Community Plugins` block under the same heading is the lightest possible change that opens the door for future community submissions (and makes the precedent obvious).

## What MadeOnSol plugin provides

Real-time Solana memecoin trading intelligence as SAK actions:

- `MADEONSOL_KOL_FEED_ACTION` — *"What are KOLs buying right now?"* (1,000+ tracked wallets, <3s latency)
- `MADEONSOL_KOL_COORDINATION_ACTION` — multi-KOL convergence with 0–100 score + peak-density window
- `MADEONSOL_KOL_LEADERBOARD_ACTION` — PnL rankings, 180 days history
- `MADEONSOL_DEPLOYER_ALERTS_ACTION` — Pump.fun deployer launches with KOL enrichment
- `MADEONSOL_KOL_FIRST_TOUCHES_ACTION` — first-KOL-touch events from S-tier scouts (backtested: ≥3 follow-on KOLs ~50% of the time vs 14% baseline; 38d / 491k buys / 72,549 events)
- `MADEONSOL_WALLET_TRACKER_*` — track arbitrary Solana wallets, 120-day event retention
- `MADEONSOL_ME_ACTION` — quota/tier introspection so the agent can self-throttle

## Package quality

- ✅ Published as [`solana-agent-kit-plugin-madeonsol@1.7.3`](https://www.npmjs.com/package/solana-agent-kit-plugin-madeonsol) on npm
- ✅ ~500 npm downloads/week, ~2.1k/month
- ✅ Peer-depends on `solana-agent-kit >= 2.0.0`
- ✅ MIT licensed
- ✅ Live interactive API docs: https://madeonsol.com/api-docs
- ✅ Free tier: 200 req/day, no card — https://madeonsol.com/pricing

Happy to revise wording, move the section, or change the entry format to match whatever convention you'd prefer. Thanks!

🤖 Generated with [Claude Code](https://claude.com/claude-code)