### PR TITLE
fix(plugin-token): update Jupiter swap API from deprecated quote-api.jup.ag/v6 to api.jup.ag/swap/v1

### DIFF
--- a/packages/plugin-token/src/jupiter/tools/trade.ts
+++ b/packages/plugin-token/src/jupiter/tools/trade.ts
@@ -69,7 +69,7 @@ export async function trade(
     }
 
     const { swapTransaction } = await (
-      await fetch("https://quote-api.jup.ag/v6/swap", {
+      await fetch(`${JUP_API}/swap`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/packages/plugin-token/src/jupiter/tools/utils/constants.ts
+++ b/packages/plugin-token/src/jupiter/tools/utils/constants.ts
@@ -25,7 +25,7 @@ export const DEFAULT_OPTIONS = {
 /**
  * Jupiter API URL
  */
-export const JUP_API = "https://quote-api.jup.ag/v6";
+export const JUP_API = "https://api.jup.ag/swap/v1";
 export const JUP_REFERRAL_ADDRESS =
   "REFER4ZgmyYx9c6He5XfaTMiGfdLwRnkV4RPp9t9iF3";
 


### PR DESCRIPTION
## Problem

`quote-api.jup.ag` has been shut down — the domain no longer resolves in DNS. This causes **all token swaps to silently fail** with `Swap failed: fetch failed` in any app using `plugin-token`.

```
$ host quote-api.jup.ag
Host quote-api.jup.ag not found: 3(NXDOMAIN)
```

There are two issues in the same file:

1. `JUP_API` constant in `constants.ts` points to the dead domain
2. The swap endpoint in `trade.ts` was **hardcoded separately** from the `JUP_API` constant instead of using `${JUP_API}/swap`, so it was missed when the constant might have been updated

## Fix

- Update `JUP_API` in `constants.ts`: `https://quote-api.jup.ag/v6` → `https://api.jup.ag/swap/v1`
- Replace the hardcoded `https://quote-api.jup.ag/v6/swap` in `trade.ts` with `${JUP_API}/swap`

## Verification

```bash
# New endpoint responds correctly
curl "https://api.jup.ag/swap/v1/quote?inputMint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&outputMint=So11111111111111111111111111111111111111112&amount=1000000"
# {"inputMint":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","inAmount":"1000000","outputMint":"So11...",...}
```

Related to the token fetch fix in #453/#454 which updated a different Jupiter URL.