### PR TITLE
feat(plugin): add @solana-agent-kit/plugin-vdm-nexus — signed inference for Solana agents

### DIFF
--- a/packages/plugin-vdm-nexus/.gitignore
+++ b/packages/plugin-vdm-nexus/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+*.log
+.DS_Store

--- a/packages/plugin-vdm-nexus/.npmignore
+++ b/packages/plugin-vdm-nexus/.npmignore
@@ -1,0 +1,7 @@
+src/
+tsconfig*.json
+.gitignore
+.eslintrc
+jest.config.js
+.rollup.cache/
+.turbo/

--- a/packages/plugin-vdm-nexus/README.md
+++ b/packages/plugin-vdm-nexus/README.md
@@ -1,0 +1,152 @@
+# @solana-agent-kit/plugin-vdm-nexus
+
+Solana Agent Kit plugin for [VDM Nexus](https://vdmnexus.com) — signed
+inference via [x402](https://github.com/coinbase/x402) on Solana and Base.
+
+Every paid `NEXUS_CHAT` call returns an OpenAI chat completion plus a
+Signed Inference Receipt (SIR v2) anchored to an on-chain USDC settlement
+tx. Receipts are independently verifiable with `NEXUS_VERIFY_RECEIPT`
+against the operator's published Ed25519 public key.
+
+First mainnet receipt: <https://vdmnexus.com/r/c9710ea7-9e1f-46ee-aaa9-903a536ae12e>
+
+## Install
+
+```bash
+npm install @solana-agent-kit/plugin-vdm-nexus solana-agent-kit
+```
+
+## Usage
+
+```ts
+import { Keypair } from "@solana/web3.js";
+import bs58 from "bs58";
+import { SolanaAgentKit, KeypairWallet, createVercelAITools } from "solana-agent-kit";
+import VdmNexusPlugin, { configure } from "@solana-agent-kit/plugin-vdm-nexus";
+
+const keypair = Keypair.fromSecretKey(bs58.decode(process.env.SOLANA_PRIVATE_KEY!));
+const wallet = new KeypairWallet(keypair, process.env.SOLANA_RPC_URL!);
+
+// Configure before .use(). signerSecretKey MUST match the wallet's
+// keypair — see "Why a separate signerSecretKey?" below.
+configure({
+  signerSecretKey: process.env.SOLANA_PRIVATE_KEY!,
+});
+
+const agent = new SolanaAgentKit(
+  wallet,
+  process.env.SOLANA_RPC_URL!,
+  { OPENAI_API_KEY: process.env.OPENAI_API_KEY! },
+).use(VdmNexusPlugin);
+
+const tools = createVercelAITools(agent, agent.actions);
+// → tools now include NEXUS_CHAT, NEXUS_VERIFY_RECEIPT, NEXUS_GET_DEPOSIT_ADDRESS
+```
+
+## Actions
+
+| Action | Purpose |
+|---|---|
+| `NEXUS_CHAT` | Pay-per-call signed inference. Settles a USDC payment inline via x402 and returns the OpenAI response plus a SIR v2 receipt. |
+| `NEXUS_VERIFY_RECEIPT` | Run the five-check SIR v2 verifier against a receipt, prompt, and response. Confirms hashes, operator signature, on-chain settlement, and payer identity. |
+| `NEXUS_GET_DEPOSIT_ADDRESS` | Discover the on-chain USDC deposit address for prepaid credit top-ups. Per-call x402 settlement does not need this — it's for agents that batch deposits. |
+
+## Configuration
+
+```ts
+import { configure } from "@solana-agent-kit/plugin-vdm-nexus";
+
+configure({
+  // Point at a different deployment (e.g. self-hosted).
+  endpoint: "https://nexus.example.com/api/v1",
+
+  // Pin the operator pubkey for offline verification. When omitted,
+  // it's fetched from `${endpoint}/operator-key`.
+  operatorKey: "<base58 Ed25519 pubkey>",
+
+  // Required for NEXUS_CHAT — see below.
+  signerSecretKey: process.env.SOLANA_PRIVATE_KEY!,
+});
+```
+
+### Why a separate `signerSecretKey`?
+
+The SendAI `BaseWallet` interface intentionally hides raw secret-key
+bytes — this is what lets hardware wallets and browser wallets plug into
+the same interface as `KeypairWallet`. But x402 SVM settlement needs raw
+Ed25519 bytes to build and sign the SPL USDC transfer carried in the
+`X-Payment` header.
+
+So the plugin asks for the secret explicitly via `configure({ signerSecretKey })`.
+Pass the same base58 64-byte secret you used to construct your
+`KeypairWallet`. At handler time the plugin asserts that the secret's
+pubkey matches `agent.wallet.publicKey` and returns a clear
+`wallet_signer_mismatch` error if they diverge — so the on-chain payment
+can't accidentally land from a wallet your SendAI agent doesn't think it
+owns.
+
+Hardware-wallet support would require an upstream change in `@x402/svm`
+to accept a non-keypair signer; tracked as a follow-up.
+
+The other two actions (`NEXUS_VERIFY_RECEIPT` and
+`NEXUS_GET_DEPOSIT_ADDRESS`) don't need a secret and work without
+`signerSecretKey` set.
+
+## Standalone tool helpers (optional)
+
+For agents that mount multiple plugins but want the Nexus tools as a
+standalone toolkit (e.g. to pass them to a different chain in a
+multi-agent setup), import from the `/tools` sub-export:
+
+```ts
+import {
+  createNexusLangchainTools,
+  createNexusVercelAITools,
+  getNexusActions,
+} from "@solana-agent-kit/plugin-vdm-nexus/tools";
+
+const nexusOnlyLangchainTools = await createNexusLangchainTools(agent);
+const nexusOnlyVercelTools = await createNexusVercelAITools(agent);
+```
+
+These delegate to `solana-agent-kit`'s `createLangchainTools` /
+`createVercelAITools` and filter to the three Nexus action names. The
+adapters (`@langchain/core`, `ai`) are not direct dependencies — they're
+resolved transitively from `solana-agent-kit`'s optional peers.
+
+## What this enables
+
+- **Audit trails.** Every inference call carries a tamper-evident
+  receipt the caller can verify cryptographically. Useful for
+  compliance regimes that require evidence of what a model returned
+  (EU AI Act Article 12, NIST AI agent standards, OWASP LLM Top 10
+  logging requirements).
+- **Trustless multi-agent flows.** Agent A can hand Agent B a receipt
+  and Agent B can verify it without trusting Agent A — the operator's
+  Ed25519 signature + the on-chain settlement record are the trust
+  anchor.
+- **Pay-per-call autonomy.** No prepaid balance to babysit; the wallet
+  pays inline. Top-ups via `NEXUS_GET_DEPOSIT_ADDRESS` are an
+  optimization, not a prerequisite.
+
+## Networks
+
+| Network | CAIP-2 | Status |
+|---|---|---|
+| Solana mainnet | `solana:mainnet` | Live |
+| Solana devnet | `solana:devnet` | Live |
+| Base mainnet | `eip155:8453` | Live |
+| Base Sepolia | `eip155:84532` | Live |
+
+Pass `network: "eip155:8453"` to `NEXUS_CHAT` to settle on Base via the
+same Solana-keypair-signed handshake — the Nexus facilitator handles
+the chain switch server-side.
+
+## Specification
+
+The Signed Inference Receipt v2 wire format and verification rules are
+documented at <https://docs.vdmnexus.com/docs/spec/sir-v2>.
+
+## License
+
+Apache-2.0 (matches the rest of Solana Agent Kit).

--- a/packages/plugin-vdm-nexus/package.json
+++ b/packages/plugin-vdm-nexus/package.json
@@ -57,7 +57,7 @@
     "base"
   ],
   "dependencies": {
-    "@vdm-nexus/x402": "^0.4.2",
+    "@vdm-nexus/x402": "^0.4.4",
     "solana-agent-kit": "workspace:*",
     "zod": "^3.24.1"
   },

--- a/packages/plugin-vdm-nexus/package.json
+++ b/packages/plugin-vdm-nexus/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@solana-agent-kit/plugin-vdm-nexus",
+  "version": "0.1.0",
+  "description": "VDM Nexus plugin for Solana Agent Kit — signed inference via x402 on Solana + Base.",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./tools": {
+      "import": {
+        "types": "./dist/tools.d.ts",
+        "default": "./dist/tools.js"
+      },
+      "require": {
+        "types": "./dist/tools.d.cts",
+        "default": "./dist/tools.cjs"
+      }
+    }
+  },
+  "scripts": {
+    "clean": "rm -rf dist .turbo node_modules",
+    "build": "tsup src/index.ts src/tools.ts --dts --clean --format cjs,esm --out-dir dist",
+    "test": "jest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sendaifun/solana-agent-kit.git"
+  },
+  "homepage": "https://github.com/sendaifun/solana-agent-kit/tree/v2/packages/plugin-vdm-nexus",
+  "keywords": [
+    "solana",
+    "solana-agent-kit",
+    "sendai",
+    "ai-agents",
+    "x402",
+    "inference",
+    "signed-inference",
+    "receipts",
+    "vdm-nexus",
+    "openai-compatible",
+    "verifiable",
+    "base"
+  ],
+  "dependencies": {
+    "@vdm-nexus/x402": "^0.4.2",
+    "solana-agent-kit": "workspace:*",
+    "zod": "^3.24.1"
+  },
+  "peerDependencies": {
+    "@solana/web3.js": "^1.98.2",
+    "solana-agent-kit": "2.0.10"
+  },
+  "devDependencies": {
+    "tsup": "^8.4.0"
+  },
+  "author": "VDM Nexus <hello@vdmnexus.com>",
+  "license": "Apache-2.0"
+}

--- a/packages/plugin-vdm-nexus/src/actions/nexus-chat.ts
+++ b/packages/plugin-vdm-nexus/src/actions/nexus-chat.ts
@@ -1,0 +1,160 @@
+/**
+ * `NEXUS_CHAT` action — pay-per-call signed inference via x402.
+ *
+ * Runs the standard x402 two-roundtrip handshake against a Nexus
+ * `/chat/completions` endpoint, paid in USDC from the agent's Ed25519
+ * keypair, and returns the OpenAI chat completion plus the SIR v2 signed
+ * receipt.
+ *
+ * The Solana Agent Kit `BaseWallet` interface does NOT expose the raw
+ * secret-key bytes (by design — hardware/browser wallets can plug in too).
+ * x402 SVM payment-payload construction needs raw bytes to sign the SPL
+ * USDC transfer, so this plugin requires an explicit `signerSecretKey`
+ * (base58, 64-byte tweetnacl secret) on the plugin config — the same
+ * secret used to construct the SendAI `KeypairWallet`. The wallet's
+ * pubkey is asserted to match the signer pubkey at handler time so the
+ * agent identity cannot accidentally diverge from the SendAI wallet.
+ */
+
+import { X402Agent } from "@vdm-nexus/x402";
+import type { SolanaAgentKit } from "solana-agent-kit";
+import { z } from "zod";
+import type { ResolvedConfig } from "../config.js";
+
+export const NexusChatSchema = z
+  .object({
+    model: z
+      .string()
+      .describe(
+        'OpenRouter-style model slug (e.g. "openai/gpt-4o-mini", "anthropic/claude-3-haiku").',
+      ),
+    messages: z
+      .array(
+        z.object({
+          role: z.enum(["system", "user", "assistant"]),
+          content: z.string(),
+        }),
+      )
+      .min(1)
+      .describe("OpenAI-shape chat messages array."),
+    network: z
+      .string()
+      .optional()
+      .describe(
+        'Optional CAIP-2 settlement network override (e.g. "solana:mainnet", "solana:devnet", "eip155:8453"). Omit to use the server default.',
+      ),
+  })
+  .describe(
+    "Pay-per-call signed inference against a VDM Nexus endpoint. " +
+      "Returns the OpenAI chat completion plus a Signed Inference Receipt (SIR v2) " +
+      "that anchors the inference to an on-chain USDC payment.",
+  );
+
+export type NexusChatInput = z.infer<typeof NexusChatSchema>;
+
+export function buildNexusChatAction(config: ResolvedConfig) {
+  return {
+    name: "NEXUS_CHAT",
+    similes: [
+      "signed inference",
+      "verifiable llm call",
+      "pay-per-call chat",
+      "x402 chat completion",
+      "nexus chat completion",
+    ],
+    description:
+      "Run a paid inference call against VDM Nexus. Settles a USDC " +
+      "payment inline via x402 on Solana (or Base), runs the inference " +
+      "upstream, and returns the OpenAI chat completion alongside a " +
+      "Signed Inference Receipt (SIR v2) anchored to the on-chain " +
+      "settlement tx. Use whenever the caller wants a verifiable " +
+      "audit trail for an LLM response.",
+    examples: [
+      [
+        {
+          input: {
+            model: "openai/gpt-4o-mini",
+            messages: [
+              { role: "user", content: "Summarise EIP-3009 in one sentence." },
+            ],
+          },
+          output: {
+            ok: true,
+            openai: {
+              id: "chatcmpl-…",
+              object: "chat.completion",
+              choices: [
+                {
+                  index: 0,
+                  message: { role: "assistant", content: "EIP-3009 …" },
+                  finish_reason: "stop",
+                },
+              ],
+            },
+            receipt: { v: 2, "...": "see SIR v2 spec" },
+          },
+          explanation:
+            "Settles 0.01 USDC inline, runs the chat completion, returns the receipt.",
+        },
+      ],
+    ],
+    schema: NexusChatSchema,
+    handler: async (
+      agent: SolanaAgentKit,
+      input: Record<string, unknown>,
+    ): Promise<Record<string, unknown>> => {
+      try {
+        const args = NexusChatSchema.parse(input);
+
+        if (!config.signerSecretKey) {
+          return {
+            status: "error",
+            error: "missing_signer_secret_key",
+            detail:
+              "VdmNexusPlugin config is missing `signerSecretKey`. " +
+              "Pass the same base58 64-byte secret you used to construct " +
+              "your SolanaAgentKit KeypairWallet — the SendAI BaseWallet " +
+              "interface does not expose secret bytes, and x402 SVM " +
+              "settlement needs them to sign the SPL transfer.",
+          };
+        }
+
+        // Agent identity guard — the SendAI wallet pubkey MUST match the
+        // pubkey of the x402 signer secret. If they diverge, the on-chain
+        // payment will land from a different address than the wallet the
+        // SendAI agent thinks it owns, which breaks the audit trail.
+        const agentWalletPubkey = agent.wallet.publicKey.toBase58();
+        const x402 = X402Agent.fromBase58(config.signerSecretKey);
+        if (x402.pubkey !== agentWalletPubkey) {
+          return {
+            status: "error",
+            error: "wallet_signer_mismatch",
+            detail:
+              `Configured x402 signerSecretKey corresponds to ${x402.pubkey} ` +
+              `but the SolanaAgentKit wallet is ${agentWalletPubkey}. ` +
+              "Pass the same secret you used to construct your KeypairWallet.",
+          };
+        }
+
+        const result = await x402.payAndInfer(config.endpoint, {
+          model: args.model,
+          messages: args.messages,
+          ...(args.network ? { network: args.network } : {}),
+        });
+
+        return {
+          status: "success",
+          openai: result.openai,
+          receipt: result.receipt,
+          payment: result.payment,
+        };
+      } catch (error) {
+        return {
+          status: "error",
+          error: "nexus_chat_failed",
+          detail: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+  };
+}

--- a/packages/plugin-vdm-nexus/src/actions/nexus-chat.ts
+++ b/packages/plugin-vdm-nexus/src/actions/nexus-chat.ts
@@ -105,8 +105,21 @@ export function buildNexusChatAction(config: ResolvedConfig) {
     ): Promise<Record<string, unknown>> => {
       try {
         const args = NexusChatSchema.parse(input);
+        const isEvmNetwork = args.network?.startsWith("eip155:") ?? false;
 
-        if (!config.signerSecretKey) {
+        if (isEvmNetwork && !config.evmPrivateKey) {
+          return {
+            status: "error",
+            error: "missing_evm_private_key",
+            detail:
+              "VdmNexusPlugin config is missing `evmPrivateKey` but the " +
+              `request targets ${args.network}. Pass a 0x-prefixed hex ` +
+              "secp256k1 private key via configure({ evmPrivateKey }) to " +
+              "settle on Base mainnet or Base Sepolia.",
+          };
+        }
+
+        if (!isEvmNetwork && !config.signerSecretKey) {
           return {
             status: "error",
             error: "missing_signer_secret_key",
@@ -119,21 +132,37 @@ export function buildNexusChatAction(config: ResolvedConfig) {
           };
         }
 
-        // Agent identity guard — the SendAI wallet pubkey MUST match the
-        // pubkey of the x402 signer secret. If they diverge, the on-chain
-        // payment will land from a different address than the wallet the
-        // SendAI agent thinks it owns, which breaks the audit trail.
-        const agentWalletPubkey = agent.wallet.publicKey.toBase58();
-        const x402 = X402Agent.fromBase58(config.signerSecretKey);
-        if (x402.pubkey !== agentWalletPubkey) {
-          return {
-            status: "error",
-            error: "wallet_signer_mismatch",
-            detail:
-              `Configured x402 signerSecretKey corresponds to ${x402.pubkey} ` +
-              `but the SolanaAgentKit wallet is ${agentWalletPubkey}. ` +
-              "Pass the same secret you used to construct your KeypairWallet.",
-          };
+        // For Solana settlement we still need a signer secret to build the
+        // X402Agent — even when the EVM key is also set, the agent's
+        // primary identity is the Solana one. Fall back to a fresh
+        // ephemeral keypair for EVM-only callers; it's only used as the
+        // X402Agent's Solana identity slot and never lands on chain
+        // because all calls go through the EVM scheme.
+        const x402 = config.signerSecretKey
+          ? X402Agent.fromBase58(config.signerSecretKey, {
+              ...(config.evmPrivateKey
+                ? { evmPrivateKey: config.evmPrivateKey }
+                : {}),
+            })
+          : X402Agent.generate({ evmPrivateKey: config.evmPrivateKey });
+
+        // Agent identity guard is only meaningful for Solana settlement —
+        // the SendAI wallet IS the Solana keypair, so the x402 signer
+        // must match. For EVM settlement the payer is a separate
+        // secp256k1 keypair and the SendAI Solana wallet plays no role
+        // in the on-chain payment; skip the guard.
+        if (!isEvmNetwork && config.signerSecretKey) {
+          const agentWalletPubkey = agent.wallet.publicKey.toBase58();
+          if (x402.pubkey !== agentWalletPubkey) {
+            return {
+              status: "error",
+              error: "wallet_signer_mismatch",
+              detail:
+                `Configured x402 signerSecretKey corresponds to ${x402.pubkey} ` +
+                `but the SolanaAgentKit wallet is ${agentWalletPubkey}. ` +
+                "Pass the same secret you used to construct your KeypairWallet.",
+            };
+          }
         }
 
         const result = await x402.payAndInfer(config.endpoint, {
@@ -147,6 +176,7 @@ export function buildNexusChatAction(config: ResolvedConfig) {
           openai: result.openai,
           receipt: result.receipt,
           payment: result.payment,
+          ...(isEvmNetwork ? { evm_payer: x402.evmPayer } : {}),
         };
       } catch (error) {
         return {

--- a/packages/plugin-vdm-nexus/src/actions/nexus-get-deposit-address.ts
+++ b/packages/plugin-vdm-nexus/src/actions/nexus-get-deposit-address.ts
@@ -1,0 +1,108 @@
+/**
+ * `NEXUS_GET_DEPOSIT_ADDRESS` action — discover the on-chain destination
+ * the agent should send USDC to in order to top up its prepaid credit
+ * balance on a Nexus deployment.
+ *
+ * Wraps `GET /api/v1/deposit-address`. This is the off-band funding
+ * path for agents that prefer batching deposits over per-call x402
+ * settlement (the credit ledger amortizes RPC + facilitator overhead
+ * across N calls). Per-call x402 via NEXUS_CHAT does NOT require this
+ * — it settles inline.
+ */
+
+import type { SolanaAgentKit } from "solana-agent-kit";
+import { z } from "zod";
+import type { ResolvedConfig } from "../config.js";
+
+export const NexusGetDepositAddressSchema = z
+  .object({
+    network: z
+      .string()
+      .optional()
+      .describe(
+        'Optional CAIP-2 network override (e.g. "solana:mainnet", "eip155:8453"). Omit to use the endpoint default.',
+      ),
+  })
+  .describe(
+    "Returns the USDC deposit address agents should send funds to in order to top up their prepaid credit balance on a Nexus deployment.",
+  );
+
+export type NexusDepositAddressResponse = {
+  address: string;
+  mint: string;
+  network: string;
+};
+
+export type NexusGetDepositAddressInput = z.infer<
+  typeof NexusGetDepositAddressSchema
+>;
+
+export function buildNexusGetDepositAddressAction(config: ResolvedConfig) {
+  return {
+    name: "NEXUS_GET_DEPOSIT_ADDRESS",
+    similes: [
+      "get nexus deposit address",
+      "topup address",
+      "nexus credit topup",
+      "fund nexus balance",
+      "deposit usdc to nexus",
+    ],
+    description:
+      "Fetch the on-chain USDC deposit address for topping up an " +
+      "agent's prepaid credit balance on a VDM Nexus deployment. " +
+      "Per-call x402 settlement (NEXUS_CHAT) does NOT require this — " +
+      "it settles inline. Use this when batching deposits is cheaper " +
+      "than per-call settlement.",
+    examples: [
+      [
+        {
+          input: { network: "solana:mainnet" },
+          output: {
+            ok: true,
+            address: "<base58 pubkey>",
+            mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            network: "solana:mainnet",
+          },
+          explanation:
+            "Send USDC to `address` on the indicated network. The 2-minute deposit cron credits the ledger keyed by the sender's pubkey.",
+        },
+      ],
+    ],
+    schema: NexusGetDepositAddressSchema,
+    handler: async (
+      _agent: SolanaAgentKit,
+      input: Record<string, unknown>,
+    ): Promise<Record<string, unknown>> => {
+      try {
+        const args = NexusGetDepositAddressSchema.parse(input);
+        const base = config.endpoint.replace(/\/$/, "");
+        const qs = args.network
+          ? `?network=${encodeURIComponent(args.network)}`
+          : "";
+        const url = `${base}/deposit-address${qs}`;
+
+        const r = await fetch(url);
+        if (!r.ok) {
+          return {
+            status: "error",
+            error: "deposit_address_fetch_failed",
+            httpStatus: r.status,
+          };
+        }
+        const body = (await r.json()) as NexusDepositAddressResponse;
+        return {
+          status: "success",
+          address: body.address,
+          mint: body.mint,
+          network: body.network,
+        };
+      } catch (error) {
+        return {
+          status: "error",
+          error: "deposit_address_fetch_failed",
+          detail: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+  };
+}

--- a/packages/plugin-vdm-nexus/src/actions/nexus-verify-receipt.ts
+++ b/packages/plugin-vdm-nexus/src/actions/nexus-verify-receipt.ts
@@ -1,0 +1,158 @@
+/**
+ * `NEXUS_VERIFY_RECEIPT` action — run the SIR v2 five-check verifier.
+ *
+ * Delegates to `verifyReceipt` from `@vdm-nexus/x402`. The action takes
+ * the original prompt + response (so hash checks can recompute) and
+ * returns the five boolean checks. Network selection (which RPC to hit
+ * for the on-chain lookup) is derived from the receipt's `payment.network`
+ * field — the verifier supports Solana (`solana:…`) and Base
+ * (`eip155:8453`, `eip155:84532`) automatically.
+ *
+ * The agent context is intentionally unused — verification is a pure
+ * client-side check (plus RPC reads). Stays in the actions list so an
+ * LLM agent can chain verify-after-chat without needing a separate
+ * non-wallet tool surface.
+ *
+ * See https://docs.vdmnexus.com/docs/spec/sir-v2 for the canonical
+ * verification spec.
+ */
+
+import {
+  type ChatMessage,
+  type NexusReceipt,
+  type OpenAIChatCompletion,
+  verifyReceipt,
+} from "@vdm-nexus/x402";
+import type { SolanaAgentKit } from "solana-agent-kit";
+import { z } from "zod";
+import type { ResolvedConfig } from "../config.js";
+
+export const NexusVerifyReceiptSchema = z
+  .object({
+    receipt: z
+      .unknown()
+      .describe(
+        "The Signed Inference Receipt (SIR v2) to verify, as returned by NEXUS_CHAT in the `receipt` field.",
+      ),
+    prompt: z
+      .union([
+        z.string(),
+        z.array(
+          z.object({
+            role: z.enum(["system", "user", "assistant"]),
+            content: z.string(),
+          }),
+        ),
+      ])
+      .describe(
+        "The prompt the receipt covers. For x402 chat-completion receipts, pass the `messages` array you sent. For prepaid receipts, pass the raw prompt string.",
+      ),
+    response: z
+      .union([z.string(), z.unknown()])
+      .describe(
+        "The response the receipt covers. For x402 chat-completion receipts, pass the OpenAI response body. For prepaid receipts, pass the raw response string.",
+      ),
+    endpoint: z
+      .string()
+      .optional()
+      .describe(
+        "Optional Nexus base URL (e.g. https://nexus.vdmnexus.com). Used to fetch the operator public key if `operatorKey` is not supplied.",
+      ),
+    operatorKey: z
+      .string()
+      .optional()
+      .describe(
+        "Optional base58 Ed25519 operator public key. If omitted, fetched from `${endpoint}/api/v1/operator-key`.",
+      ),
+    rpc: z
+      .string()
+      .optional()
+      .describe(
+        "Optional RPC URL override for the on-chain check. Defaults derived from `receipt.payment.network`.",
+      ),
+  })
+  .describe(
+    "Run the five-check SIR v2 verification: prompt_hash_ok, response_hash_ok, " +
+      "nexus_signature_ok, payment_on_chain_ok, payer_matches. Returns the full " +
+      "check breakdown so the agent can act on partial failures.",
+  );
+
+export type NexusVerifyReceiptInput = z.infer<typeof NexusVerifyReceiptSchema>;
+
+export function buildNexusVerifyReceiptAction(config: ResolvedConfig) {
+  return {
+    name: "NEXUS_VERIFY_RECEIPT",
+    similes: [
+      "verify receipt",
+      "check signed inference",
+      "audit nexus receipt",
+      "validate sir v2",
+      "verify nexus response",
+    ],
+    description:
+      "Verify a VDM Nexus Signed Inference Receipt (SIR v2) end-to-end. " +
+      "Runs five checks: prompt_hash_ok, response_hash_ok, " +
+      "nexus_signature_ok, payment_on_chain_ok, payer_matches. Returns " +
+      "the full breakdown so the agent can decide what to do on " +
+      "partial failure (e.g. ignore vacuous payment checks on prepaid " +
+      "receipts).",
+    examples: [
+      [
+        {
+          input: {
+            receipt: { v: 2, "...": "see SIR v2 spec" },
+            prompt: [
+              { role: "user", content: "Summarise EIP-3009 in one sentence." },
+            ],
+            response: {
+              id: "chatcmpl-…",
+              choices: [
+                { message: { role: "assistant", content: "EIP-3009 …" } },
+              ],
+            },
+          },
+          output: {
+            ok: true,
+            checks: {
+              prompt_hash_ok: true,
+              response_hash_ok: true,
+              nexus_signature_ok: true,
+              payment_on_chain_ok: true,
+              payer_matches: true,
+            },
+          },
+          explanation:
+            "All five checks pass — the receipt cryptographically anchors the LLM response to the on-chain settlement tx.",
+        },
+      ],
+    ],
+    schema: NexusVerifyReceiptSchema,
+    handler: async (
+      _agent: SolanaAgentKit,
+      input: Record<string, unknown>,
+    ): Promise<Record<string, unknown>> => {
+      try {
+        const args = NexusVerifyReceiptSchema.parse(input);
+        const result = await verifyReceipt({
+          receipt: args.receipt as NexusReceipt,
+          prompt: args.prompt as ChatMessage[] | string,
+          response: args.response as OpenAIChatCompletion | string,
+          endpoint: args.endpoint ?? config.endpoint,
+          operatorKey: args.operatorKey ?? config.operatorKey,
+          rpc: args.rpc,
+        });
+        return {
+          status: "success",
+          ok: result.ok,
+          checks: result.checks,
+        };
+      } catch (error) {
+        return {
+          status: "error",
+          error: "verify_failed",
+          detail: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+  };
+}

--- a/packages/plugin-vdm-nexus/src/config.ts
+++ b/packages/plugin-vdm-nexus/src/config.ts
@@ -30,12 +30,30 @@ export interface VdmNexusPluginConfig {
 
   /**
    * Base58-encoded 64-byte tweetnacl secretKey used to sign x402
-   * payment payloads. Must correspond to the same pubkey as the
-   * SolanaAgentKit wallet, otherwise NEXUS_CHAT returns a
-   * `wallet_signer_mismatch` error. Required for NEXUS_CHAT; optional
-   * for NEXUS_VERIFY_RECEIPT and NEXUS_GET_DEPOSIT_ADDRESS.
+   * payment payloads on Solana (`solana:*` networks). Must correspond
+   * to the same pubkey as the SolanaAgentKit wallet, otherwise
+   * NEXUS_CHAT returns a `wallet_signer_mismatch` error. Required
+   * when calling NEXUS_CHAT with a Solana network (or no network
+   * override, since the server defaults to Solana). Optional for
+   * NEXUS_VERIFY_RECEIPT and NEXUS_GET_DEPOSIT_ADDRESS.
    */
   signerSecretKey?: string;
+
+  /**
+   * Optional 0x-prefixed hex secp256k1 private key used to sign x402
+   * payment payloads on Base / other EVM networks (`eip155:*`). When
+   * NEXUS_CHAT is called with `network: "eip155:8453"` or
+   * `network: "eip155:84532"`, this key signs the ERC-3009
+   * `transferWithAuthorization` against USDC.
+   *
+   * The EVM payer is **different** from the SolanaAgentKit wallet —
+   * the on-chain payment lands from this EVM address, not from the
+   * SendAI agent's Solana pubkey. Receipts for EVM-network calls
+   * carry the EVM address as `agent_pubkey` / `payment.payer`. This
+   * is intentional and matches how x402 works on EVM chains; the
+   * `wallet_signer_mismatch` guard is **not** applied for EVM calls.
+   */
+  evmPrivateKey?: string;
 }
 
 export interface ResolvedConfig {
@@ -47,6 +65,11 @@ export interface ResolvedConfig {
    * actions ignore this field.
    */
   signerSecretKey: string;
+  /**
+   * Empty string when not configured. `NEXUS_CHAT` reports a clear
+   * error when an `eip155:*` network is requested without this key.
+   */
+  evmPrivateKey: string;
 }
 
 export function resolveConfig(config?: VdmNexusPluginConfig): ResolvedConfig {
@@ -54,5 +77,6 @@ export function resolveConfig(config?: VdmNexusPluginConfig): ResolvedConfig {
     endpoint: (config?.endpoint ?? DEFAULT_ENDPOINT).replace(/\/$/, ""),
     operatorKey: config?.operatorKey,
     signerSecretKey: config?.signerSecretKey ?? "",
+    evmPrivateKey: config?.evmPrivateKey ?? "",
   };
 }

--- a/packages/plugin-vdm-nexus/src/config.ts
+++ b/packages/plugin-vdm-nexus/src/config.ts
@@ -1,0 +1,58 @@
+/**
+ * Plugin configuration — shared by every action and the methods surface.
+ *
+ * `endpoint` defaults to the public production rail; override for a
+ * self-hosted deployment. `operatorKey` is recommended for production
+ * audit pipelines so a compromised endpoint cannot serve a forged
+ * operator key. `signerSecretKey` is REQUIRED for `NEXUS_CHAT` because
+ * the SendAI `BaseWallet` interface does not expose raw secret-key
+ * bytes (by design — hardware/browser wallets plug in via the same
+ * interface). The verifier and deposit-address actions do not need a
+ * secret and work without it.
+ */
+
+export const DEFAULT_ENDPOINT = "https://nexus.vdmnexus.com/api/v1";
+
+export interface VdmNexusPluginConfig {
+  /**
+   * Base URL of the Nexus deployment, including the version prefix.
+   *
+   * @default "https://nexus.vdmnexus.com/api/v1"
+   */
+  endpoint?: string;
+
+  /**
+   * Optional base58 Ed25519 operator public key to pin for offline
+   * receipt verification. When omitted, the verifier fetches it from
+   * `${endpoint}/operator-key` on first use.
+   */
+  operatorKey?: string;
+
+  /**
+   * Base58-encoded 64-byte tweetnacl secretKey used to sign x402
+   * payment payloads. Must correspond to the same pubkey as the
+   * SolanaAgentKit wallet, otherwise NEXUS_CHAT returns a
+   * `wallet_signer_mismatch` error. Required for NEXUS_CHAT; optional
+   * for NEXUS_VERIFY_RECEIPT and NEXUS_GET_DEPOSIT_ADDRESS.
+   */
+  signerSecretKey?: string;
+}
+
+export interface ResolvedConfig {
+  endpoint: string;
+  operatorKey?: string;
+  /**
+   * Empty string when not configured — `NEXUS_CHAT` reports a clear
+   * error in that case so the agent learns what's missing. Other
+   * actions ignore this field.
+   */
+  signerSecretKey: string;
+}
+
+export function resolveConfig(config?: VdmNexusPluginConfig): ResolvedConfig {
+  return {
+    endpoint: (config?.endpoint ?? DEFAULT_ENDPOINT).replace(/\/$/, ""),
+    operatorKey: config?.operatorKey,
+    signerSecretKey: config?.signerSecretKey ?? "",
+  };
+}

--- a/packages/plugin-vdm-nexus/src/index.ts
+++ b/packages/plugin-vdm-nexus/src/index.ts
@@ -1,0 +1,165 @@
+/**
+ * `@solana-agent-kit/plugin-vdm-nexus` — Solana Agent Kit plugin for
+ * signed inference via VDM Nexus.
+ *
+ * Three actions:
+ *
+ *   • NEXUS_CHAT                — pay-per-call signed inference via x402
+ *   • NEXUS_VERIFY_RECEIPT      — five-check SIR v2 verification
+ *   • NEXUS_GET_DEPOSIT_ADDRESS — on-chain top-up destination lookup
+ *
+ * Two methods exposed on the agent's methods registry (for direct
+ * programmatic use without going through the action-handler shape):
+ *
+ *   • nexusChat               → returns the raw x402 result object
+ *   • nexusVerifyReceipt      → returns the raw verifier result
+ *   • nexusGetDepositAddress  → returns the raw deposit-address record
+ *
+ * Plugin construction follows the standard SendAI factory pattern: import
+ * the default export and `.use(VdmNexusPlugin)` on the agent. Configure
+ * via the optional `configure({ ... })` helper before the `.use(...)`
+ * call, or rely on env-var defaults.
+ *
+ * See https://docs.vdmnexus.com/docs/spec/sir-v2 for the receipt spec.
+ */
+
+import type { SolanaAgentKit } from "solana-agent-kit";
+import {
+  type NexusChatInput,
+  NexusChatSchema,
+  buildNexusChatAction,
+} from "./actions/nexus-chat.js";
+import {
+  type NexusDepositAddressResponse,
+  type NexusGetDepositAddressInput,
+  NexusGetDepositAddressSchema,
+  buildNexusGetDepositAddressAction,
+} from "./actions/nexus-get-deposit-address.js";
+import {
+  type NexusVerifyReceiptInput,
+  NexusVerifyReceiptSchema,
+  buildNexusVerifyReceiptAction,
+} from "./actions/nexus-verify-receipt.js";
+import {
+  DEFAULT_ENDPOINT,
+  type ResolvedConfig,
+  type VdmNexusPluginConfig,
+  resolveConfig,
+} from "./config.js";
+
+// Re-export schemas and types for callers that want to type their inputs.
+export {
+  NexusChatSchema,
+  NexusVerifyReceiptSchema,
+  NexusGetDepositAddressSchema,
+  DEFAULT_ENDPOINT,
+};
+export type {
+  VdmNexusPluginConfig,
+  NexusChatInput,
+  NexusVerifyReceiptInput,
+  NexusGetDepositAddressInput,
+  NexusDepositAddressResponse,
+};
+
+/**
+ * Live config — module-scoped because the SendAI plugin object is a
+ * singleton consumed by the `Plugin` interface. Mutated by
+ * `configure(...)` before the plugin is registered with the agent.
+ *
+ * This mirrors the configuration shape used by other ecosystem plugins
+ * that expose a `configure` hook (e.g. `@solana-agent-kit/plugin-defi`
+ * for its Drift / Manifest integrations).
+ */
+let liveConfig: ResolvedConfig = resolveConfig();
+
+/**
+ * Configure the plugin before registering it with `SolanaAgentKit.use()`.
+ *
+ * @example
+ * ```ts
+ * import VdmNexusPlugin, { configure } from "@solana-agent-kit/plugin-vdm-nexus";
+ *
+ * configure({
+ *   endpoint: "https://nexus.vdmnexus.com/api/v1",
+ *   signerSecretKey: process.env.SOLANA_PRIVATE_KEY!,
+ * });
+ *
+ * const agent = new SolanaAgentKit(wallet, rpcUrl, {}).use(VdmNexusPlugin);
+ * ```
+ */
+export function configure(config: VdmNexusPluginConfig): void {
+  liveConfig = resolveConfig(config);
+}
+
+/**
+ * Get the currently active resolved config (post-defaults). Exposed for
+ * tests and for callers that need to introspect the live endpoint.
+ */
+export function getConfig(): Readonly<ResolvedConfig> {
+  return liveConfig;
+}
+
+const VdmNexusPlugin = {
+  name: "vdm_nexus",
+
+  methods: {
+    /**
+     * Pay-per-call signed inference. Settles a USDC payment inline via
+     * x402 on Solana (or Base) and returns the OpenAI response plus the
+     * signed receipt. Throws on any handshake / network failure (use
+     * the action wrapper if you want non-throwing error shapes).
+     */
+    nexusChat: async (
+      agent: SolanaAgentKit,
+      args: NexusChatInput,
+    ): Promise<Record<string, unknown>> => {
+      const handler = buildNexusChatAction(liveConfig).handler;
+      return handler(agent, args as Record<string, unknown>);
+    },
+
+    /**
+     * Verify a Signed Inference Receipt end-to-end. Pure client-side
+     * check plus on-chain RPC lookup; does not consume USDC.
+     */
+    nexusVerifyReceipt: async (
+      agent: SolanaAgentKit,
+      args: NexusVerifyReceiptInput,
+    ): Promise<Record<string, unknown>> => {
+      const handler = buildNexusVerifyReceiptAction(liveConfig).handler;
+      return handler(agent, args as Record<string, unknown>);
+    },
+
+    /**
+     * Look up the USDC deposit address for prepaid credit top-ups.
+     * Per-call x402 settlement (nexusChat) does NOT require this.
+     */
+    nexusGetDepositAddress: async (
+      agent: SolanaAgentKit,
+      args: NexusGetDepositAddressInput = {},
+    ): Promise<Record<string, unknown>> => {
+      const handler = buildNexusGetDepositAddressAction(liveConfig).handler;
+      return handler(agent, args as Record<string, unknown>);
+    },
+  },
+
+  actions: [
+    buildNexusChatAction(liveConfig),
+    buildNexusVerifyReceiptAction(liveConfig),
+    buildNexusGetDepositAddressAction(liveConfig),
+  ],
+
+  /**
+   * Refresh actions against the latest config when the plugin is
+   * registered with the agent. This lets callers `configure(...)`
+   * after import but before `agent.use(VdmNexusPlugin)` and still get
+   * the updated config on the action handlers.
+   */
+  initialize(_agent: SolanaAgentKit): void {
+    VdmNexusPlugin.actions[0] = buildNexusChatAction(liveConfig);
+    VdmNexusPlugin.actions[1] = buildNexusVerifyReceiptAction(liveConfig);
+    VdmNexusPlugin.actions[2] = buildNexusGetDepositAddressAction(liveConfig);
+  },
+};
+
+export default VdmNexusPlugin;

--- a/packages/plugin-vdm-nexus/src/tools.ts
+++ b/packages/plugin-vdm-nexus/src/tools.ts
@@ -1,0 +1,81 @@
+/**
+ * `@solana-agent-kit/plugin-vdm-nexus/tools` — optional helpers for
+ * exposing Nexus actions to LangChain and the Vercel AI SDK.
+ *
+ * The SendAI core package (`solana-agent-kit`) already ships
+ * `createLangchainTools` and `createVercelAITools` — they generate tool
+ * objects from any Action[] array. These wrappers are thin convenience
+ * functions that filter to the Nexus action subset, so callers who only
+ * want signed-inference tools (and not the full token / NFT surface)
+ * can mount the Nexus tools standalone alongside their own toolkits.
+ *
+ * The langchain / vercel-ai-sdk packages are NOT direct dependencies of
+ * this plugin — they're resolved transitively from `solana-agent-kit`'s
+ * optional peers. If a caller's project doesn't have them installed,
+ * the imports below will fail to resolve at runtime and the caller
+ * should use the underlying `agent.actions` array with their own
+ * tool-generation pipeline.
+ */
+
+import type { SolanaAgentKit } from "solana-agent-kit";
+
+const NEXUS_ACTION_NAMES = new Set([
+  "NEXUS_CHAT",
+  "NEXUS_VERIFY_RECEIPT",
+  "NEXUS_GET_DEPOSIT_ADDRESS",
+]);
+
+/**
+ * Return only the Nexus actions registered on the agent. Useful when
+ * the agent has multiple plugins and the caller wants to mount the
+ * Nexus tools in a standalone LangChain / Vercel AI SDK toolkit.
+ */
+export function getNexusActions(agent: SolanaAgentKit) {
+  return agent.actions.filter((a) => NEXUS_ACTION_NAMES.has(a.name));
+}
+
+/**
+ * Build a LangChain tool array for just the Nexus actions.
+ *
+ * Internally delegates to `createLangchainTools` from `solana-agent-kit`.
+ * Requires `@langchain/core` to be installed in the host project (it's
+ * an optional peer of `solana-agent-kit`).
+ *
+ * @example
+ * ```ts
+ * import { createNexusLangchainTools } from "@solana-agent-kit/plugin-vdm-nexus/tools";
+ * const tools = createNexusLangchainTools(agent);
+ * ```
+ */
+export async function createNexusLangchainTools(agent: SolanaAgentKit) {
+  const { createLangchainTools } = (await import("solana-agent-kit")) as {
+    createLangchainTools: (
+      agent: SolanaAgentKit,
+      actions: SolanaAgentKit["actions"],
+    ) => unknown[];
+  };
+  return createLangchainTools(agent, getNexusActions(agent));
+}
+
+/**
+ * Build a Vercel AI SDK tool object for just the Nexus actions.
+ *
+ * Internally delegates to `createVercelAITools` from `solana-agent-kit`.
+ * Requires `ai` (the Vercel AI SDK) to be installed in the host project
+ * (it's an optional peer of `solana-agent-kit`).
+ *
+ * @example
+ * ```ts
+ * import { createNexusVercelAITools } from "@solana-agent-kit/plugin-vdm-nexus/tools";
+ * const tools = createNexusVercelAITools(agent);
+ * ```
+ */
+export async function createNexusVercelAITools(agent: SolanaAgentKit) {
+  const { createVercelAITools } = (await import("solana-agent-kit")) as {
+    createVercelAITools: (
+      agent: SolanaAgentKit,
+      actions: SolanaAgentKit["actions"],
+    ) => unknown;
+  };
+  return createVercelAITools(agent, getNexusActions(agent));
+}

--- a/packages/plugin-vdm-nexus/tsconfig.cjs.json
+++ b/packages/plugin-vdm-nexus/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "module": "CommonJS"
+  }
+}

--- a/packages/plugin-vdm-nexus/tsconfig.json
+++ b/packages/plugin-vdm-nexus/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,7 +341,7 @@ importers:
         version: 1.0.4(@metaplex-foundation/umi@1.0.0)
       '@metaplex-foundation/mpl-core':
         specifier: ^1.2.0
-        version: 1.2.0(@metaplex-foundation/umi@1.0.0)(@noble/hashes@1.7.2)
+        version: 1.2.0(@metaplex-foundation/umi@1.0.0)(@noble/hashes@1.8.0)
       '@metaplex-foundation/mpl-token-metadata':
         specifier: ^3.3.0
         version: 3.3.0(@metaplex-foundation/umi@1.0.0)
@@ -404,7 +404,7 @@ importers:
         version: 1.0.4(@metaplex-foundation/umi@1.0.0)
       '@metaplex-foundation/mpl-core':
         specifier: ^1.2.0
-        version: 1.2.0(@metaplex-foundation/umi@1.0.0)(@noble/hashes@1.7.2)
+        version: 1.2.0(@metaplex-foundation/umi@1.0.0)(@noble/hashes@1.8.0)
       '@metaplex-foundation/mpl-token-metadata':
         specifier: ^3.3.0
         version: 3.3.0(@metaplex-foundation/umi@1.0.0)
@@ -473,8 +473,8 @@ importers:
         specifier: ^1.98.2
         version: 1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@vdm-nexus/x402':
-        specifier: ^0.4.2
-        version: 0.4.2(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+        specifier: ^0.4.4
+        version: 0.4.4(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.63)
       solana-agent-kit:
         specifier: workspace:*
         version: link:../core
@@ -574,6 +574,9 @@ packages:
 
   '@adraffy/ens-normalize@1.10.1':
     resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
+
+  '@adraffy/ens-normalize@1.11.1':
+    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
   '@ai-sdk/openai@1.3.20':
     resolution: {integrity: sha512-/DflUy7ROG9k6n6YTXMBFPbujBKnbGY58f3CwvicLvDar9nDAloVnUWd3LUoOxpSVnX8vtQ7ngxF52SLWO6RwQ==}
@@ -2143,6 +2146,10 @@ packages:
     resolution: {integrity: sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/curves@1.2.0':
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
 
@@ -2159,6 +2166,10 @@ packages:
 
   '@noble/curves@1.8.2':
     resolution: {integrity: sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.1':
+    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
     engines: {node: ^14.21.3 || >=16}
 
   '@noble/ed25519@1.7.3':
@@ -2192,6 +2203,10 @@ packages:
 
   '@noble/hashes@1.7.2':
     resolution: {integrity: sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
   '@noble/secp256k1@1.7.1':
@@ -2566,11 +2581,17 @@ packages:
   '@scure/base@1.2.4':
     resolution: {integrity: sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==}
 
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
   '@scure/bip32@1.4.0':
     resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
 
   '@scure/bip32@1.6.2':
     resolution: {integrity: sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==}
+
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
 
   '@scure/bip39@1.1.0':
     resolution: {integrity: sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==}
@@ -2580,6 +2601,9 @@ packages:
 
   '@scure/bip39@1.5.4':
     resolution: {integrity: sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
   '@shikijs/core@1.29.1':
     resolution: {integrity: sha512-Mo1gGGkuOYjDu5H8YwzmOuly9vNr8KDVkqj9xiKhhhFS8jisAtDSEWB9hzqRHLVQgFdA310e8XRJcW4tYhRB2A==}
@@ -3472,8 +3496,8 @@ packages:
   '@vdm-nexus/sdk@0.2.1':
     resolution: {integrity: sha512-0peqNSpV1zlF0pMJxSLU+M2gu8+KzOoLzMYM21ihJqhz56B2E3qqN6EjSoYLiP7pCESfU4PRaxOd4NOSKWqgoA==}
 
-  '@vdm-nexus/x402@0.4.2':
-    resolution: {integrity: sha512-PcMukqIvHdG6K8KQgzthXDU7BnVs+iq+ARXvky5oi1DrSRdLab03vHBL/1tc7hNjN0hYdVqcD3SOa8FYxVXLoA==}
+  '@vdm-nexus/x402@0.4.4':
+    resolution: {integrity: sha512-rZAHb5gIwFig3W+1IUWpiObUJWHxHCz3BN1Cf+uE7tFRjvFd9Um/kFGnwhxUmutlmhP7P7ndBBPL3B190znqoA==}
 
   '@voltr/vault-sdk@0.1.2':
     resolution: {integrity: sha512-reWar7HqI4HZ651OhnMWcr9HGU2lg3arFVNoFZIOTUuwxoqv/UiJobSdq2iaZD+4qh2Xp5Xsf6Gx+o506RUOvw==}
@@ -3488,6 +3512,9 @@ packages:
 
   '@x402/core@2.13.0':
     resolution: {integrity: sha512-wZjjYZ9UxXZh8O2uP/x0u4M4Dvuw5hHdN7uzEseoS4V9fkMewi+VAx9Wd98PdU9VegvG24+ES88fgFB4C5QVUw==}
+
+  '@x402/evm@2.13.0':
+    resolution: {integrity: sha512-EA1nXu5brkzWhpDX2OSKES30i/H6rNnqWSoEI/KXQ3OVz5vbW1bH8jd0tRHjx+w7kEkVl4Wr680Td0JCDCfocQ==}
 
   '@x402/svm@2.13.0':
     resolution: {integrity: sha512-qgR7GY+A8mZ+y/6iDRIHG11S415OFw7dp4QQHP08cu8wrSENZPCKfl62OGWTZGfAAR9jnaWK2w4/HUarOqTS4A==}
@@ -3510,6 +3537,17 @@ packages:
       typescript: '>=4.9.4'
       zod: ^3 >=3.19.1
     peerDependenciesMeta:
+      zod:
+        optional: true
+
+  abitype@1.2.3:
+    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
       zod:
         optional: true
 
@@ -5165,6 +5203,11 @@ packages:
     peerDependencies:
       ws: '*'
 
+  isows@1.0.7:
+    resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
+    peerDependencies:
+      ws: '*'
+
   iterate-object@1.3.4:
     resolution: {integrity: sha512-4dG1D1x/7g8PwHS9aK6QV5V94+ZvyP4+d19qDv43EzImmrndysIl4prmJ1hWWIGCqrZHyaHBm6BSEWHOLnpoNw==}
 
@@ -5778,6 +5821,14 @@ packages:
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+
+  ox@0.14.22:
+    resolution: {integrity: sha512-nb5msL8qWbPglhIfZbGJAfw3cqiJjFMiWmACt7kgyWtLib12tcctbHufMT9Hb0Lr6Pt4k9I3dbpueTpbhvbqvA==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   p-cancelable@2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
@@ -7043,6 +7094,14 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  viem@2.50.4:
+    resolution: {integrity: sha512-rf98F4s3Vlb+uJZEKfay3IbBw3CNCbVtx5Y3UIljlO2tSX420g/J0WQSYsjzBSasUFgxgsXabji14O9kGbiqgg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vlq@2.0.4:
     resolution: {integrity: sha512-aodjPa2wPQFkra1G8CzJBTHXhgk3EVSwxSWXNPr1fgdFLUb8kvLV1iEb6rFgasIsjP82HWI6dsb5Io26DDnasA==}
 
@@ -7240,6 +7299,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
@@ -7353,6 +7424,8 @@ snapshots:
       - utf-8-validate
 
   '@adraffy/ens-normalize@1.10.1': {}
+
+  '@adraffy/ens-normalize@1.11.1': {}
 
   '@ai-sdk/openai@1.3.20(zod@3.25.63)':
     dependencies:
@@ -9487,11 +9560,11 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@metaplex-foundation/mpl-core@1.2.0(@metaplex-foundation/umi@1.0.0)(@noble/hashes@1.7.2)':
+  '@metaplex-foundation/mpl-core@1.2.0(@metaplex-foundation/umi@1.0.0)(@noble/hashes@1.8.0)':
     dependencies:
       '@metaplex-foundation/umi': 1.0.0
       '@msgpack/msgpack': 3.0.0-beta2
-      '@noble/hashes': 1.7.2
+      '@noble/hashes': 1.8.0
 
   '@metaplex-foundation/mpl-token-metadata@2.13.0(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)':
     dependencies:
@@ -9900,6 +9973,8 @@ snapshots:
 
   '@noble/ciphers@1.2.1': {}
 
+  '@noble/ciphers@1.3.0': {}
+
   '@noble/curves@1.2.0':
     dependencies:
       '@noble/hashes': 1.3.2
@@ -9920,6 +9995,10 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.7.2
 
+  '@noble/curves@1.9.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
   '@noble/ed25519@1.7.3': {}
 
   '@noble/hashes@1.0.0': {}
@@ -9937,6 +10016,8 @@ snapshots:
   '@noble/hashes@1.7.1': {}
 
   '@noble/hashes@1.7.2': {}
+
+  '@noble/hashes@1.8.0': {}
 
   '@noble/secp256k1@1.7.1': {}
 
@@ -10684,6 +10765,8 @@ snapshots:
 
   '@scure/base@1.2.4': {}
 
+  '@scure/base@1.2.6': {}
+
   '@scure/bip32@1.4.0':
     dependencies:
       '@noble/curves': 1.4.2
@@ -10695,6 +10778,12 @@ snapshots:
       '@noble/curves': 1.8.2
       '@noble/hashes': 1.7.2
       '@scure/base': 1.2.4
+
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
 
   '@scure/bip39@1.1.0':
     dependencies:
@@ -10710,6 +10799,11 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.7.2
       '@scure/base': 1.2.4
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
 
   '@shikijs/core@1.29.1':
     dependencies:
@@ -11183,30 +11277,30 @@ snapshots:
 
   '@solana/errors@2.0.0-preview.2':
     dependencies:
-      chalk: 5.4.1
+      chalk: 5.6.2
       commander: 12.1.0
 
   '@solana/errors@2.0.0-rc.1(typescript@4.9.5)':
     dependencies:
-      chalk: 5.4.1
+      chalk: 5.6.2
       commander: 12.1.0
       typescript: 4.9.5
 
   '@solana/errors@2.0.0-rc.1(typescript@5.6.3)':
     dependencies:
-      chalk: 5.4.1
+      chalk: 5.6.2
       commander: 12.1.0
       typescript: 5.6.3
 
   '@solana/errors@2.0.0-rc.1(typescript@5.7.2)':
     dependencies:
-      chalk: 5.4.1
+      chalk: 5.6.2
       commander: 12.1.0
       typescript: 5.7.2
 
   '@solana/errors@2.0.0-rc.1(typescript@5.8.3)':
     dependencies:
-      chalk: 5.4.1
+      chalk: 5.6.2
       commander: 12.1.0
       typescript: 5.8.3
 
@@ -12672,20 +12766,23 @@ snapshots:
       bs58: 6.0.0
       tweetnacl: 1.0.3
 
-  '@vdm-nexus/x402@0.4.2(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+  '@vdm-nexus/x402@0.4.4(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.63)':
     dependencies:
       '@solana/kit': 5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@vdm-nexus/sdk': 0.2.1
       '@x402/core': 2.13.0
+      '@x402/evm': 2.13.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@x402/svm': 2.13.0(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
       bs58: 6.0.0
       tweetnacl: 1.0.3
+      viem: 2.50.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.63)
     transitivePeerDependencies:
       - '@solana/sysvars'
       - bufferutil
       - fastestsmallesttextencoderdecoder
       - typescript
       - utf-8-validate
+      - zod
 
   '@voltr/vault-sdk@0.1.2(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
@@ -12708,6 +12805,16 @@ snapshots:
   '@x402/core@2.13.0':
     dependencies:
       zod: 3.25.63
+
+  '@x402/evm@2.13.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@x402/core': 2.13.0
+      viem: 2.50.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.63)
+      zod: 3.25.63
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
 
   '@x402/svm@2.13.0(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))':
     dependencies:
@@ -12734,6 +12841,11 @@ snapshots:
       typescript: 5.8.3
     optionalDependencies:
       zod: 3.24.1
+
+  abitype@1.2.3(typescript@5.8.3)(zod@3.25.63):
+    optionalDependencies:
+      typescript: 5.8.3
+      zod: 3.25.63
 
   abort-controller@3.0.0:
     dependencies:
@@ -14797,6 +14909,10 @@ snapshots:
     dependencies:
       ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
+  isows@1.0.7(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
+    dependencies:
+      ws: 8.20.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+
   iterate-object@1.3.4: {}
 
   jackspeak@3.4.3:
@@ -15437,6 +15553,21 @@ snapshots:
   os-tmpdir@1.0.2: {}
 
   outdent@0.5.0: {}
+
+  ox@0.14.22(typescript@5.8.3)(zod@3.25.63):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.8.3)(zod@3.25.63)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - zod
 
   p-cancelable@2.1.1: {}
 
@@ -16835,6 +16966,23 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
+  viem@2.50.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.63):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.8.3)(zod@3.25.63)
+      isows: 1.0.7(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      ox: 0.14.22(typescript@5.8.3)(zod@3.25.63)
+      ws: 8.20.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   vlq@2.0.4: {}
 
   w-json@1.3.10: {}
@@ -17169,6 +17317,11 @@ snapshots:
       utf-8-validate: 5.0.10
 
   ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.9
+      utf-8-validate: 5.0.10
+
+  ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     optionalDependencies:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -467,26 +467,45 @@ importers:
         specifier: ^8.4.0
         version: 8.4.0(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
 
+  packages/plugin-vdm-nexus:
+    dependencies:
+      '@solana/web3.js':
+        specifier: ^1.98.2
+        version: 1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@vdm-nexus/x402':
+        specifier: ^0.4.2
+        version: 0.4.2(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      solana-agent-kit:
+        specifier: workspace:*
+        version: link:../core
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.63
+    devDependencies:
+      tsup:
+        specifier: ^8.4.0
+        version: 8.4.0(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
+
   test:
     dependencies:
       '@ai-sdk/openai':
         specifier: ^1.3.10
-        version: 1.3.20(zod@3.24.4)
+        version: 1.3.20(zod@3.25.63)
       '@anthropic-ai/sdk':
         specifier: ^0.39.0
         version: 0.39.0(encoding@0.1.13)
       '@langchain/core':
         specifier: ^0.3.44
-        version: 0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4))
+        version: 0.3.44(openai@5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63))
       '@langchain/langgraph':
         specifier: ^0.2.63
-        version: 0.2.67(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))(react@19.0.0)(zod-to-json-schema@3.24.1(zod@3.24.4))
+        version: 0.2.67(@langchain/core@0.3.44(openai@5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))(react@19.0.0)(zod-to-json-schema@3.24.1(zod@3.25.63))
       '@langchain/openai':
         specifier: ^0.5.5
-        version: 0.5.7(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))(encoding@0.1.13)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 0.5.7(@langchain/core@0.3.44(openai@5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))(encoding@0.1.13)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@openai/agents':
         specifier: ^0.0.7
-        version: 0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+        version: 0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
       '@solana-agent-kit/plugin-blinks':
         specifier: workspace:*
         version: link:../packages/plugin-blinks
@@ -507,7 +526,7 @@ importers:
         version: 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
       ai:
         specifier: ^4.1.5
-        version: 4.1.5(react@19.0.0)(zod@3.24.4)
+        version: 4.1.5(react@19.0.0)(zod@3.25.63)
       bs58:
         specifier: ^6.0.0
         version: 6.0.0
@@ -516,13 +535,13 @@ importers:
         version: 16.4.7
       openai:
         specifier: ^5.3.0
-        version: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+        version: 5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
       solana-agent-kit:
         specifier: workspace:*
         version: link:../packages/core
       zod-to-json-schema:
         specifier: ^3.24.1
-        version: 3.24.1(zod@3.24.4)
+        version: 3.24.1(zod@3.25.63)
     devDependencies:
       tsx:
         specifier: ^4.19.2
@@ -2617,6 +2636,49 @@ packages:
   '@solana-developers/helpers@2.5.6':
     resolution: {integrity: sha512-NPWZblVMl4LuVVSJOZG0ZF0VYnrMUjCyMNTiGwNUXPK2WWYJCqpuDyzs/PMqwvM4gMTjk4pEToBX8N2UxDvZkQ==}
 
+  '@solana-program/compute-budget@0.11.0':
+    resolution: {integrity: sha512-7f1ePqB/eURkTwTOO9TNIdUXZcyrZoX3Uy2hNo7cXMfNhPFWp9AVgIyRNBc2jf15sdUa9gNpW+PfP2iV8AYAaw==}
+    peerDependencies:
+      '@solana/kit': ^5.0
+
+  '@solana-program/token-2022@0.6.1':
+    resolution: {integrity: sha512-Ex02cruDMGfBMvZZCrggVR45vdQQSI/unHVpt/7HPt/IwFYB4eTlXtO8otYZyqV/ce5GqZ8S6uwyRf0zy6fdbA==}
+    peerDependencies:
+      '@solana/kit': ^5.0
+      '@solana/sysvars': ^5.0
+
+  '@solana-program/token@0.9.0':
+    resolution: {integrity: sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==}
+    peerDependencies:
+      '@solana/kit': ^5.0
+
+  '@solana/accounts@5.5.1':
+    resolution: {integrity: sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/addresses@5.5.1':
+    resolution: {integrity: sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/assertions@5.5.1':
+    resolution: {integrity: sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/buffer-layout-utils@0.2.0':
     resolution: {integrity: sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==}
     engines: {node: '>= 10'}
@@ -2639,6 +2701,15 @@ packages:
     peerDependencies:
       typescript: '>=5'
 
+  '@solana/codecs-core@5.5.1':
+    resolution: {integrity: sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/codecs-data-structures@2.0.0-preview.2':
     resolution: {integrity: sha512-Xf5vIfromOZo94Q8HbR04TbgTwzigqrKII0GjYr21K7rb3nba4hUW2ir8kguY7HWFBcjHGlU5x3MevKBOLp3Zg==}
 
@@ -2653,6 +2724,15 @@ packages:
     peerDependencies:
       typescript: '>=5'
 
+  '@solana/codecs-data-structures@5.5.1':
+    resolution: {integrity: sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/codecs-numbers@2.0.0-preview.2':
     resolution: {integrity: sha512-aLZnDTf43z4qOnpTcDsUVy1Ci9im1Md8thWipSWbE+WM9ojZAx528oAql+Cv8M8N+6ALKwgVRhPZkto6E59ARw==}
 
@@ -2666,6 +2746,15 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
+
+  '@solana/codecs-numbers@5.5.1':
+    resolution: {integrity: sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@solana/codecs-strings@2.0.0-preview.2':
     resolution: {integrity: sha512-EgBwY+lIaHHgMJIqVOGHfIfpdmmUDNoNO/GAUGeFPf+q0dF+DtwhJPEMShhzh64X2MeCZcmSO6Kinx0Bvmmz2g==}
@@ -2685,6 +2774,18 @@ packages:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5'
 
+  '@solana/codecs-strings@5.5.1':
+    resolution: {integrity: sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      fastestsmallesttextencoderdecoder:
+        optional: true
+      typescript:
+        optional: true
+
   '@solana/codecs@2.0.0-preview.2':
     resolution: {integrity: sha512-4HHzCD5+pOSmSB71X6w9ptweV48Zj1Vqhe732+pcAQ2cMNnN0gMPMdDq7j3YwaZDZ7yrILVV/3+HTnfT77t2yA==}
 
@@ -2698,6 +2799,15 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
+
+  '@solana/codecs@5.5.1':
+    resolution: {integrity: sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@solana/errors@2.0.0-preview.2':
     resolution: {integrity: sha512-H2DZ1l3iYF5Rp5pPbJpmmtCauWeQXRJapkDg8epQ8BJ7cA2Ut/QEtC3CMmw/iMTcuS6uemFNLcWvlOfoQhvQuA==}
@@ -2716,6 +2826,88 @@ packages:
     peerDependencies:
       typescript: '>=5'
 
+  '@solana/errors@5.5.1':
+    resolution: {integrity: sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg==}
+    engines: {node: '>=20.18.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/fast-stable-stringify@5.5.1':
+    resolution: {integrity: sha512-Ni7s2FN33zTzhTFgRjEbOVFO+UAmK8qi3Iu0/GRFYK4jN696OjKHnboSQH/EacQ+yGqS54bfxf409wU5dsLLCw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/functional@5.5.1':
+    resolution: {integrity: sha512-tTHoJcEQq3gQx5qsdsDJ0LEJeFzwNpXD80xApW9o/PPoCNimI3SALkZl+zNW8VnxRrV3l3yYvfHWBKe/X3WG3w==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/instruction-plans@5.5.1':
+    resolution: {integrity: sha512-7z3CB7YMcFKuVvgcnNY8bY6IsZ8LG61Iytbz7HpNVGX2u1RthOs1tRW8luTzSG1MPL0Ox7afyAVMYeFqSPHnaQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/instructions@5.5.1':
+    resolution: {integrity: sha512-h0G1CG6S+gUUSt0eo6rOtsaXRBwCq1+Js2a+Ps9Bzk9q7YHNFA75/X0NWugWLgC92waRp66hrjMTiYYnLBoWOQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/keys@5.5.1':
+    resolution: {integrity: sha512-KRD61cL7CRL+b4r/eB9dEoVxIf/2EJ1Pm1DmRYhtSUAJD2dJ5Xw8QFuehobOGm9URqQ7gaQl+Fkc1qvDlsWqKg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/kit@5.5.1':
+    resolution: {integrity: sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/nominal-types@5.5.1':
+    resolution: {integrity: sha512-I1ImR+kfrLFxN5z22UDiTWLdRZeKtU0J/pkWkO8qm/8WxveiwdIv4hooi8pb6JnlR4mSrWhq0pCIOxDYrL9GIQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/offchain-messages@5.5.1':
+    resolution: {integrity: sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/options@2.0.0-preview.2':
     resolution: {integrity: sha512-FAHqEeH0cVsUOTzjl5OfUBw2cyT8d5Oekx4xcn5hn+NyPAfQJgM3CEThzgRD6Q/4mM5pVUnND3oK/Mt1RzSE/w==}
 
@@ -2729,6 +2921,159 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
+
+  '@solana/options@5.5.1':
+    resolution: {integrity: sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/plugin-core@5.5.1':
+    resolution: {integrity: sha512-VUZl30lDQFJeiSyNfzU1EjYt2QZvoBFKEwjn1lilUJw7KgqD5z7mbV7diJhT+dLFs36i0OsjXvq5kSygn8YJ3A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/programs@5.5.1':
+    resolution: {integrity: sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/promises@5.5.1':
+    resolution: {integrity: sha512-T9lfuUYkGykJmppEcssNiCf6yiYQxJkhiLPP+pyAc2z84/7r3UVIb2tNJk4A9sucS66pzJnVHZKcZVGUUp6wzA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-api@5.5.1':
+    resolution: {integrity: sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-parsed-types@5.5.1':
+    resolution: {integrity: sha512-HEi3G2nZqGEsa3vX6U0FrXLaqnUCg4SKIUrOe8CezD+cSFbRTOn3rCLrUmJrhVyXlHoQVaRO9mmeovk31jWxJg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-spec-types@5.5.1':
+    resolution: {integrity: sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-spec@5.5.1':
+    resolution: {integrity: sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions-api@5.5.1':
+    resolution: {integrity: sha512-5Oi7k+GdeS8xR2ly1iuSFkAv6CZqwG0Z6b1QZKbEgxadE1XGSDrhM2cn59l+bqCozUWCqh4c/A2znU/qQjROlw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions-channel-websocket@5.5.1':
+    resolution: {integrity: sha512-7tGfBBrYY8TrngOyxSHoCU5shy86iA9SRMRrPSyBhEaZRAk6dnbdpmUTez7gtdVo0BCvh9nzQtUycKWSS7PnFQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions-spec@5.5.1':
+    resolution: {integrity: sha512-iq+rGq5fMKP3/mKHPNB6MC8IbVW41KGZg83Us/+LE3AWOTWV1WT20KT2iH1F1ik9roi42COv/TpoZZvhKj45XQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions@5.5.1':
+    resolution: {integrity: sha512-CTMy5bt/6mDh4tc6vUJms9EcuZj3xvK0/xq8IQ90rhkpYvate91RjBP+egvjgSayUg9yucU9vNuUpEjz4spM7w==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-transformers@5.5.1':
+    resolution: {integrity: sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-transport-http@5.5.1':
+    resolution: {integrity: sha512-yv8GoVSHqEV0kUJEIhkdOVkR2SvJ6yoWC51cJn2rSV7plr6huLGe0JgujCmB7uZhhaLbcbP3zxXxu9sOjsi7Fg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-types@5.5.1':
+    resolution: {integrity: sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc@5.5.1':
+    resolution: {integrity: sha512-ku8zTUMrkCWci66PRIBC+1mXepEnZH/q1f3ck0kJZ95a06bOTl5KU7HeXWtskkyefzARJ5zvCs54AD5nxjQJ+A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/signers@5.5.1':
+    resolution: {integrity: sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@solana/spl-account-compression@0.1.10':
     resolution: {integrity: sha512-IQAOJrVOUo6LCgeWW9lHuXo6JDbi4g3/RkQtvY0SyalvSWk9BIkHHe4IkAzaQw8q/BxEVBIjz8e9bNYWIAESNw==}
@@ -2799,6 +3144,51 @@ packages:
   '@solana/spl-type-length-value@0.1.0':
     resolution: {integrity: sha512-JBMGB0oR4lPttOZ5XiUGyvylwLQjt1CPJa6qQ5oM+MBCndfjz2TKKkw0eATlLLcYmq1jBVsNlJ2cD6ns2GR7lA==}
     engines: {node: '>=16'}
+
+  '@solana/subscribable@5.5.1':
+    resolution: {integrity: sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/sysvars@5.5.1':
+    resolution: {integrity: sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transaction-confirmation@5.5.1':
+    resolution: {integrity: sha512-j4mKlYPHEyu+OD7MBt3jRoX4ScFgkhZC6H65on4Fux6LMScgivPJlwnKoZMnsgxFgWds0pl+BYzSiALDsXlYtw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transaction-messages@5.5.1':
+    resolution: {integrity: sha512-aXyhMCEaAp3M/4fP0akwBBQkFPr4pfwoC5CLDq999r/FUwDax2RE/h4Ic7h2Xk+JdcUwsb+rLq85Y52hq84XvQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transactions@5.5.1':
+    resolution: {integrity: sha512-8hHtDxtqalZ157pnx6p8k10D7J/KY/biLzfgh9R09VNLLY3Fqi7kJvJCr7M2ik3oRll56pxhraAGCC9yIT6eOA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@solana/wallet-adapter-base@0.9.26':
     resolution: {integrity: sha512-1RcmfesJ8bTT+zfg4w+Z+wisj11HR+vWwl/pS6v/zwQPe0LSzWDpkXRv9JuDSCuTcmlglEfjEqFAW+5EubK/Jg==}
@@ -3079,6 +3469,12 @@ packages:
   '@ungap/structured-clone@1.2.1':
     resolution: {integrity: sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==}
 
+  '@vdm-nexus/sdk@0.2.1':
+    resolution: {integrity: sha512-0peqNSpV1zlF0pMJxSLU+M2gu8+KzOoLzMYM21ihJqhz56B2E3qqN6EjSoYLiP7pCESfU4PRaxOd4NOSKWqgoA==}
+
+  '@vdm-nexus/x402@0.4.2':
+    resolution: {integrity: sha512-PcMukqIvHdG6K8KQgzthXDU7BnVs+iq+ARXvky5oi1DrSRdLab03vHBL/1tc7hNjN0hYdVqcD3SOa8FYxVXLoA==}
+
   '@voltr/vault-sdk@0.1.2':
     resolution: {integrity: sha512-reWar7HqI4HZ651OhnMWcr9HGU2lg3arFVNoFZIOTUuwxoqv/UiJobSdq2iaZD+4qh2Xp5Xsf6Gx+o506RUOvw==}
 
@@ -3089,6 +3485,14 @@ packages:
   '@wallet-standard/features@1.1.0':
     resolution: {integrity: sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==}
     engines: {node: '>=16'}
+
+  '@x402/core@2.13.0':
+    resolution: {integrity: sha512-wZjjYZ9UxXZh8O2uP/x0u4M4Dvuw5hHdN7uzEseoS4V9fkMewi+VAx9Wd98PdU9VegvG24+ES88fgFB4C5QVUw==}
+
+  '@x402/svm@2.13.0':
+    resolution: {integrity: sha512-qgR7GY+A8mZ+y/6iDRIHG11S415OFw7dp4QQHP08cu8wrSENZPCKfl62OGWTZGfAAR9jnaWK2w4/HUarOqTS4A==}
+    peerDependencies:
+      '@solana/kit': '>=5.1.0'
 
   '@zodios/core@10.9.6':
     resolution: {integrity: sha512-aH4rOdb3AcezN7ws8vDgBfGboZMk2JGGzEq/DtW65MhnRxyTGRuLJRWVQ/2KxDgWvV2F5oTkAS+5pnjKbl0n+A==}
@@ -3530,6 +3934,10 @@ packages:
     resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -3631,6 +4039,10 @@ packages:
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
+
+  commander@14.0.2:
+    resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
+    engines: {node: '>=20'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -6522,6 +6934,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.25.0:
+    resolution: {integrity: sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA==}
+
   unicode-trie@2.0.0:
     resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
@@ -6825,6 +7240,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -6927,11 +7354,11 @@ snapshots:
 
   '@adraffy/ens-normalize@1.10.1': {}
 
-  '@ai-sdk/openai@1.3.20(zod@3.24.4)':
+  '@ai-sdk/openai@1.3.20(zod@3.25.63)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.4)
-      zod: 3.24.4
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.63)
+      zod: 3.25.63
 
   '@ai-sdk/provider-utils@2.1.2(zod@3.24.1)':
     dependencies:
@@ -6942,15 +7369,6 @@ snapshots:
     optionalDependencies:
       zod: 3.24.1
 
-  '@ai-sdk/provider-utils@2.1.2(zod@3.24.4)':
-    dependencies:
-      '@ai-sdk/provider': 1.0.6
-      eventsource-parser: 3.0.0
-      nanoid: 3.3.8
-      secure-json-parse: 2.7.0
-    optionalDependencies:
-      zod: 3.24.4
-
   '@ai-sdk/provider-utils@2.1.2(zod@3.25.63)':
     dependencies:
       '@ai-sdk/provider': 1.0.6
@@ -6960,12 +7378,12 @@ snapshots:
     optionalDependencies:
       zod: 3.25.63
 
-  '@ai-sdk/provider-utils@2.2.7(zod@3.24.4)':
+  '@ai-sdk/provider-utils@2.2.7(zod@3.25.63)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       nanoid: 3.3.8
       secure-json-parse: 2.7.0
-      zod: 3.24.4
+      zod: 3.25.63
 
   '@ai-sdk/provider@1.0.6':
     dependencies:
@@ -6985,16 +7403,6 @@ snapshots:
       react: 19.0.0
       zod: 3.24.1
 
-  '@ai-sdk/react@1.1.3(react@19.0.0)(zod@3.24.4)':
-    dependencies:
-      '@ai-sdk/provider-utils': 2.1.2(zod@3.24.4)
-      '@ai-sdk/ui-utils': 1.1.3(zod@3.24.4)
-      swr: 2.3.3(react@19.0.0)
-      throttleit: 2.1.0
-    optionalDependencies:
-      react: 19.0.0
-      zod: 3.24.4
-
   '@ai-sdk/react@1.1.3(react@19.0.0)(zod@3.25.63)':
     dependencies:
       '@ai-sdk/provider-utils': 2.1.2(zod@3.25.63)
@@ -7012,14 +7420,6 @@ snapshots:
       zod-to-json-schema: 3.24.1(zod@3.24.1)
     optionalDependencies:
       zod: 3.24.1
-
-  '@ai-sdk/ui-utils@1.1.3(zod@3.24.4)':
-    dependencies:
-      '@ai-sdk/provider': 1.0.6
-      '@ai-sdk/provider-utils': 2.1.2(zod@3.24.4)
-      zod-to-json-schema: 3.24.1(zod@3.24.4)
-    optionalDependencies:
-      zod: 3.24.4
 
   '@ai-sdk/ui-utils@1.1.3(zod@3.25.63)':
     dependencies:
@@ -7080,7 +7480,7 @@ snapshots:
       '@aptos-labs/aptos-cli': 1.0.2
       '@aptos-labs/aptos-client': 0.1.1
       '@noble/curves': 1.8.2
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.7.2
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
       eventemitter3: 5.0.1
@@ -8598,14 +8998,14 @@ snapshots:
     transitivePeerDependencies:
       - openai
 
-  '@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4))':
+  '@langchain/core@0.3.44(openai@5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.19
-      langsmith: 0.3.15(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4))
+      langsmith: 0.3.15(openai@5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -8615,40 +9015,40 @@ snapshots:
     transitivePeerDependencies:
       - openai
 
-  '@langchain/langgraph-checkpoint@0.0.17(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))':
+  '@langchain/langgraph-checkpoint@0.0.17(@langchain/core@0.3.44(openai@5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))':
     dependencies:
-      '@langchain/core': 0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4))
+      '@langchain/core': 0.3.44(openai@5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63))
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@0.0.70(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))(react@19.0.0)':
+  '@langchain/langgraph-sdk@0.0.70(@langchain/core@0.3.44(openai@5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))(react@19.0.0)':
     dependencies:
       '@types/json-schema': 7.0.15
       p-queue: 6.6.2
       p-retry: 4.6.2
       uuid: 9.0.1
     optionalDependencies:
-      '@langchain/core': 0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4))
+      '@langchain/core': 0.3.44(openai@5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63))
       react: 19.0.0
 
-  '@langchain/langgraph@0.2.67(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))(react@19.0.0)(zod-to-json-schema@3.24.1(zod@3.24.4))':
+  '@langchain/langgraph@0.2.67(@langchain/core@0.3.44(openai@5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))(react@19.0.0)(zod-to-json-schema@3.24.1(zod@3.25.63))':
     dependencies:
-      '@langchain/core': 0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4))
-      '@langchain/langgraph-checkpoint': 0.0.17(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))
-      '@langchain/langgraph-sdk': 0.0.70(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))(react@19.0.0)
+      '@langchain/core': 0.3.44(openai@5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63))
+      '@langchain/langgraph-checkpoint': 0.0.17(@langchain/core@0.3.44(openai@5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))
+      '@langchain/langgraph-sdk': 0.0.70(@langchain/core@0.3.44(openai@5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))(react@19.0.0)
       uuid: 10.0.0
-      zod: 3.24.4
+      zod: 3.25.63
     optionalDependencies:
-      zod-to-json-schema: 3.24.1(zod@3.24.4)
+      zod-to-json-schema: 3.24.1(zod@3.25.63)
     transitivePeerDependencies:
       - react
 
-  '@langchain/openai@0.5.7(@langchain/core@0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)))(encoding@0.1.13)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@langchain/openai@0.5.7(@langchain/core@0.3.44(openai@5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)))(encoding@0.1.13)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 0.3.44(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4))
+      '@langchain/core': 0.3.44(openai@5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63))
       js-tiktoken: 1.0.19
-      openai: 4.93.0(encoding@0.1.13)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
-      zod: 3.24.4
-      zod-to-json-schema: 3.24.1(zod@3.24.4)
+      openai: 4.93.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
+      zod: 3.25.63
+      zod-to-json-schema: 3.24.1(zod@3.25.63)
     transitivePeerDependencies:
       - encoding
       - ws
@@ -9675,14 +10075,26 @@ snapshots:
       - supports-color
       - ws
 
-  '@openai/agents-core@0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)':
+  '@openai/agents-core@0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)':
     dependencies:
       '@openai/zod': zod@3.25.63
       debug: 4.4.0
-      openai: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+      openai: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.12.1
-      zod: 3.24.4
+      zod: 3.25.63
+    transitivePeerDependencies:
+      - supports-color
+      - ws
+
+  '@openai/agents-core@0.0.7(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)':
+    dependencies:
+      '@openai/zod': zod@3.25.63
+      debug: 4.4.0
+      openai: 5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.12.1
+      zod: 3.25.63
     transitivePeerDependencies:
       - supports-color
       - ws
@@ -9698,12 +10110,12 @@ snapshots:
       - ws
       - zod
 
-  '@openai/agents-openai@0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)':
+  '@openai/agents-openai@0.0.7(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)':
     dependencies:
-      '@openai/agents-core': 0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+      '@openai/agents-core': 0.0.7(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
       '@openai/zod': zod@3.25.63
       debug: 4.4.0
-      openai: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+      openai: 5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
     transitivePeerDependencies:
       - supports-color
       - ws
@@ -9722,9 +10134,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@openai/agents-realtime@0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(zod@3.24.4)':
+  '@openai/agents-realtime@0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(zod@3.25.63)':
     dependencies:
-      '@openai/agents-core': 0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+      '@openai/agents-core': 0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
       '@openai/zod': zod@3.25.63
       '@types/ws': 8.18.1
       debug: 4.4.0
@@ -9749,13 +10161,13 @@ snapshots:
       - ws
       - zod
 
-  '@openai/agents@0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)':
+  '@openai/agents@0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)':
     dependencies:
-      '@openai/agents-core': 0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
-      '@openai/agents-openai': 0.0.7(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
-      '@openai/agents-realtime': 0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(zod@3.24.4)
+      '@openai/agents-core': 0.0.7(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
+      '@openai/agents-openai': 0.0.7(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
+      '@openai/agents-realtime': 0.0.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)(zod@3.25.63)
       debug: 4.4.0
-      openai: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+      openai: 5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -10381,6 +10793,50 @@ snapshots:
       - typescript
       - utf-8-validate
 
+  '@solana-program/compute-budget@0.11.0(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/kit': 5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+
+  '@solana-program/token-2022@0.6.1(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))':
+    dependencies:
+      '@solana/kit': 5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+
+  '@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/kit': 5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+
+  '@solana/accounts@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-spec': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/addresses@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+    dependencies:
+      '@solana/assertions': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/assertions@5.5.1(typescript@5.8.3)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+
   '@solana/buffer-layout-utils@0.2.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@4.9.5)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana/buffer-layout': 4.0.1
@@ -10477,6 +10933,12 @@ snapshots:
       '@solana/errors': 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
 
+  '@solana/codecs-core@5.5.1(typescript@5.8.3)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+
   '@solana/codecs-data-structures@2.0.0-preview.2':
     dependencies:
       '@solana/codecs-core': 2.0.0-preview.2
@@ -10516,6 +10978,14 @@ snapshots:
       '@solana/codecs-core': 2.1.0(typescript@5.8.3)
       '@solana/codecs-numbers': 2.1.0(typescript@5.8.3)
       '@solana/errors': 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
+
+  '@solana/codecs-data-structures@5.5.1(typescript@5.8.3)':
+    dependencies:
+      '@solana/codecs-core': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.8.3)
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+    optionalDependencies:
       typescript: 5.8.3
 
   '@solana/codecs-numbers@2.0.0-preview.2':
@@ -10571,6 +11041,13 @@ snapshots:
       '@solana/errors': 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
 
+  '@solana/codecs-numbers@5.5.1(typescript@5.8.3)':
+    dependencies:
+      '@solana/codecs-core': 5.5.1(typescript@5.8.3)
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+
   '@solana/codecs-strings@2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22)':
     dependencies:
       '@solana/codecs-core': 2.0.0-preview.2
@@ -10615,6 +11092,15 @@ snapshots:
       '@solana/codecs-core': 2.1.0(typescript@5.8.3)
       '@solana/codecs-numbers': 2.1.0(typescript@5.8.3)
       '@solana/errors': 2.1.0(typescript@5.8.3)
+      fastestsmallesttextencoderdecoder: 1.0.22
+      typescript: 5.8.3
+
+  '@solana/codecs-strings@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+    dependencies:
+      '@solana/codecs-core': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.8.3)
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+    optionalDependencies:
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.8.3
 
@@ -10683,6 +11169,18 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/codecs@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+    dependencies:
+      '@solana/codecs-core': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-data-structures': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/options': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/errors@2.0.0-preview.2':
     dependencies:
       chalk: 5.4.1
@@ -10735,6 +11233,103 @@ snapshots:
       chalk: 5.4.1
       commander: 13.1.0
       typescript: 5.8.3
+
+  '@solana/errors@5.5.1(typescript@5.8.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 14.0.2
+    optionalDependencies:
+      typescript: 5.8.3
+
+  '@solana/fast-stable-stringify@5.5.1(typescript@5.8.3)':
+    optionalDependencies:
+      typescript: 5.8.3
+
+  '@solana/functional@5.5.1(typescript@5.8.3)':
+    optionalDependencies:
+      typescript: 5.8.3
+
+  '@solana/instruction-plans@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+      '@solana/instructions': 5.5.1(typescript@5.8.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/promises': 5.5.1(typescript@5.8.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/instructions@5.5.1(typescript@5.8.3)':
+    dependencies:
+      '@solana/codecs-core': 5.5.1(typescript@5.8.3)
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+
+  '@solana/keys@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+    dependencies:
+      '@solana/assertions': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@solana/accounts': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+      '@solana/functional': 5.5.1(typescript@5.8.3)
+      '@solana/instruction-plans': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/instructions': 5.5.1(typescript@5.8.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/offchain-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/plugin-core': 5.5.1(typescript@5.8.3)
+      '@solana/programs': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-api': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-parsed-types': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-spec-types': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-subscriptions': 5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/signers': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transaction-confirmation': 5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
+
+  '@solana/nominal-types@5.5.1(typescript@5.8.3)':
+    optionalDependencies:
+      typescript: 5.8.3
+
+  '@solana/offchain-messages@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-data-structures': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
 
   '@solana/options@2.0.0-preview.2':
     dependencies:
@@ -10792,6 +11387,190 @@ snapshots:
       '@solana/codecs-numbers': 2.1.0(typescript@5.8.3)
       '@solana/codecs-strings': 2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/errors': 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/options@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+    dependencies:
+      '@solana/codecs-core': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-data-structures': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/plugin-core@5.5.1(typescript@5.8.3)':
+    optionalDependencies:
+      typescript: 5.8.3
+
+  '@solana/programs@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/promises@5.5.1(typescript@5.8.3)':
+    optionalDependencies:
+      typescript: 5.8.3
+
+  '@solana/rpc-api@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-parsed-types': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-spec': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-transformers': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-parsed-types@5.5.1(typescript@5.8.3)':
+    optionalDependencies:
+      typescript: 5.8.3
+
+  '@solana/rpc-spec-types@5.5.1(typescript@5.8.3)':
+    optionalDependencies:
+      typescript: 5.8.3
+
+  '@solana/rpc-spec@5.5.1(typescript@5.8.3)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-spec-types': 5.5.1(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+
+  '@solana/rpc-subscriptions-api@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-subscriptions-spec': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-transformers': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-subscriptions-channel-websocket@5.5.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+      '@solana/functional': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-subscriptions-spec': 5.5.1(typescript@5.8.3)
+      '@solana/subscribable': 5.5.1(typescript@5.8.3)
+      ws: 8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@solana/rpc-subscriptions-spec@5.5.1(typescript@5.8.3)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+      '@solana/promises': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-spec-types': 5.5.1(typescript@5.8.3)
+      '@solana/subscribable': 5.5.1(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+
+  '@solana/rpc-subscriptions@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+      '@solana/fast-stable-stringify': 5.5.1(typescript@5.8.3)
+      '@solana/functional': 5.5.1(typescript@5.8.3)
+      '@solana/promises': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-spec-types': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-subscriptions-api': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-subscriptions-channel-websocket': 5.5.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/rpc-subscriptions-spec': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-transformers': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/subscribable': 5.5.1(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
+
+  '@solana/rpc-transformers@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+      '@solana/functional': 5.5.1(typescript@5.8.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-spec-types': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-transport-http@5.5.1(typescript@5.8.3)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-spec': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-spec-types': 5.5.1(typescript@5.8.3)
+      undici-types: 7.25.0
+    optionalDependencies:
+      typescript: 5.8.3
+
+  '@solana/rpc-types@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+      '@solana/fast-stable-stringify': 5.5.1(typescript@5.8.3)
+      '@solana/functional': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-api': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-spec': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-spec-types': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-transformers': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-transport-http': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/signers@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.8.3)
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+      '@solana/instructions': 5.5.1(typescript@5.8.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.8.3)
+      '@solana/offchain-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+    optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -11148,6 +11927,77 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
+  '@solana/subscribable@5.5.1(typescript@5.8.3)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+
+  '@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+    dependencies:
+      '@solana/accounts': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transaction-confirmation@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/promises': 5.5.1(typescript@5.8.3)
+      '@solana/rpc': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-subscriptions': 5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
+
+  '@solana/transaction-messages@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-data-structures': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.8.3)
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+      '@solana/functional': 5.5.1(typescript@5.8.3)
+      '@solana/instructions': 5.5.1(typescript@5.8.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-data-structures': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.8.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/errors': 5.5.1(typescript@5.8.3)
+      '@solana/functional': 5.5.1(typescript@5.8.3)
+      '@solana/instructions': 5.5.1(typescript@5.8.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.8.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/wallet-adapter-base@0.9.26(@solana/web3.js@1.92.3(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/wallet-standard-features': 1.3.0
@@ -11218,7 +12068,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.27.1
       '@noble/curves': 1.8.2
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.7.2
       '@solana/buffer-layout': 4.0.1
       agentkeepalive: 4.6.0
       bigint-buffer: 1.1.5
@@ -11817,6 +12667,26 @@ snapshots:
 
   '@ungap/structured-clone@1.2.1': {}
 
+  '@vdm-nexus/sdk@0.2.1':
+    dependencies:
+      bs58: 6.0.0
+      tweetnacl: 1.0.3
+
+  '@vdm-nexus/x402@0.4.2(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@solana/kit': 5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@vdm-nexus/sdk': 0.2.1
+      '@x402/core': 2.13.0
+      '@x402/svm': 2.13.0(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      bs58: 6.0.0
+      tweetnacl: 1.0.3
+    transitivePeerDependencies:
+      - '@solana/sysvars'
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+
   '@voltr/vault-sdk@0.1.2(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@coral-xyz/anchor': 0.30.1(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
@@ -11834,6 +12704,20 @@ snapshots:
   '@wallet-standard/features@1.1.0':
     dependencies:
       '@wallet-standard/base': 1.1.0
+
+  '@x402/core@2.13.0':
+    dependencies:
+      zod: 3.25.63
+
+  '@x402/svm@2.13.0(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))':
+    dependencies:
+      '@solana-program/compute-budget': 0.11.0(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))
+      '@solana-program/token': 0.9.0(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))
+      '@solana-program/token-2022': 0.6.1(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      '@solana/kit': 5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@x402/core': 2.13.0
+    transitivePeerDependencies:
+      - '@solana/sysvars'
 
   '@zodios/core@10.9.6(axios@1.10.0)(zod@3.24.4)':
     dependencies:
@@ -11900,18 +12784,6 @@ snapshots:
     optionalDependencies:
       react: 19.0.0
       zod: 3.24.1
-
-  ai@4.1.5(react@19.0.0)(zod@3.24.4):
-    dependencies:
-      '@ai-sdk/provider': 1.0.6
-      '@ai-sdk/provider-utils': 2.1.2(zod@3.24.4)
-      '@ai-sdk/react': 1.1.3(react@19.0.0)(zod@3.24.4)
-      '@ai-sdk/ui-utils': 1.1.3(zod@3.24.4)
-      '@opentelemetry/api': 1.9.0
-      jsondiffpatch: 0.6.0
-    optionalDependencies:
-      react: 19.0.0
-      zod: 3.24.4
 
   ai@4.1.5(react@19.0.0)(zod@3.25.63):
     dependencies:
@@ -12433,6 +13305,8 @@ snapshots:
 
   chalk@5.4.1: {}
 
+  chalk@5.6.2: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -12510,6 +13384,8 @@ snapshots:
   commander@12.1.0: {}
 
   commander@13.1.0: {}
+
+  commander@14.0.2: {}
 
   commander@2.20.3: {}
 
@@ -14068,7 +14944,7 @@ snapshots:
     optionalDependencies:
       openai: 5.3.0(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.1)
 
-  langsmith@0.3.15(openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)):
+  langsmith@0.3.15(openai@5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -14078,7 +14954,7 @@ snapshots:
       semver: 7.7.1
       uuid: 10.0.0
     optionalDependencies:
-      openai: 5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4)
+      openai: 5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63)
 
   lazy-ass@1.6.0: {}
 
@@ -14502,7 +15378,7 @@ snapshots:
       regex: 5.1.1
       regex-recursion: 5.1.1
 
-  openai@4.93.0(encoding@0.1.13)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4):
+  openai@4.93.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63):
     dependencies:
       '@types/node': 18.19.74
       '@types/node-fetch': 2.6.12
@@ -14512,8 +15388,8 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0(encoding@0.1.13)
     optionalDependencies:
-      ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      zod: 3.24.4
+      ws: 8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      zod: 3.25.63
     transitivePeerDependencies:
       - encoding
 
@@ -14527,10 +15403,15 @@ snapshots:
       ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       zod: 3.24.1
 
-  openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.4):
+  openai@5.3.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63):
     optionalDependencies:
       ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      zod: 3.24.4
+      zod: 3.25.63
+
+  openai@5.3.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.63):
+    optionalDependencies:
+      ws: 8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      zod: 3.25.63
 
   optionator@0.9.4:
     dependencies:
@@ -15848,6 +16729,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.25.0: {}
+
   unicode-trie@2.0.0:
     dependencies:
       pako: 0.2.9
@@ -16182,7 +17065,7 @@ snapshots:
       util: 0.12.5
       web3-errors: 1.3.1
       web3-types: 1.10.0
-      zod: 3.24.4
+      zod: 3.25.63
 
   web3@4.16.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.1):
     dependencies:
@@ -16286,6 +17169,11 @@ snapshots:
       utf-8-validate: 5.0.10
 
   ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.9
+      utf-8-validate: 5.0.10
+
+  ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     optionalDependencies:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10


### PR DESCRIPTION
## Summary

Adds `@solana-agent-kit/plugin-vdm-nexus`, a plugin that exposes
[VDM Nexus](https://vdmnexus.com) — signed inference via [x402](https://github.com/coinbase/x402)
on Solana and Base — as a tool surface inside any SendAI-built agent.

Every paid call returns the standard OpenAI chat completion **plus** a
Signed Inference Receipt (SIR v2) anchored to an on-chain USDC settlement
tx, so the agent (or its operator) can cryptographically prove what an
LLM returned for what it paid. One-line install for any
`SolanaAgentKit`-based agent that wants verifiable, pay-per-call LLM
access without API keys.

## Actions

The plugin contributes three actions to `agent.actions` (and matching
methods on `agent.methods`):

| Action | Purpose |
|---|---|
| `NEXUS_CHAT` | Pay-per-call signed inference. Settles a USDC payment inline via x402 (Solana mainnet/devnet or Base mainnet/Sepolia) and returns the OpenAI response plus a SIR v2 receipt. |
| `NEXUS_VERIFY_RECEIPT` | Run the five-check SIR v2 verifier (prompt + response hashes, operator signature, on-chain settlement, payer identity). |
| `NEXUS_GET_DEPOSIT_ADDRESS` | Look up the USDC deposit address for prepaid credit top-ups. |

## Why a SendAI user would want this

- **Audit trails.** Every inference carries a tamper-evident receipt the
  caller can verify cryptographically — useful when the agent is acting
  under a compliance regime that wants evidence of what a model returned
  (EU AI Act Art. 12, NIST AI agent standards, OWASP LLM Top 10 logging).
- **Trustless multi-agent flows.** Agent A can hand Agent B a receipt and
  Agent B can verify it without trusting Agent A — the operator's Ed25519
  signature + the on-chain settlement record are the trust anchor.
- **Pay-per-call autonomy.** No prepaid balance to babysit; the SendAI
  wallet pays inline via x402.

## Live receipts

- Smoke test from this PR — first all-green run via the plugin's
  `NEXUS_CHAT` → `NEXUS_VERIFY_RECEIPT` flow against Solana mainnet:
  on-chain settlement tx [`2cpATgpF…cEQ3B`](https://explorer.solana.com/tx/2cpATgpF3ibHXgVT1pQxyZbCPbBJroNZrrFJG1e9xH7E7B9fCiRhRJfRzuHEat33XShbybabNUXmd4hAuouMEQ3B),
  five checks pass.
- Permalink rendering of an earlier mainnet receipt with the embedded
  verifier widget: <https://vdmnexus.com/r/c9710ea7-9e1f-46ee-aaa9-903a536ae12e>.
- SIR v2 wire format spec: <https://docs.vdmnexus.com/docs/spec/sir-v2>.

## Internal architecture

Wraps `@vdm-nexus/x402@^0.4.2` (MIT, on npm). The plugin shape mirrors
`@solana-agent-kit/plugin-token` — `tsup` dual ESM+CJS build, Apache-2.0
licensed, no new top-level deps on the core (every new dep lives inside
the plugin). LangChain + Vercel AI SDK helpers live behind a
`@solana-agent-kit/plugin-vdm-nexus/tools` sub-export and delegate to
the core's `createLangchainTools` / `createVercelAITools` so the
adapters stay optional peers.

## A note on `signerSecretKey`

`NEXUS_CHAT` needs the raw Ed25519 secret bytes to sign the SPL USDC
transfer carried in the x402 `X-Payment` header. The SendAI `BaseWallet`
interface intentionally hides those bytes (so hardware/browser wallets
can plug into the same interface), so the plugin asks for the secret
explicitly via `configure({ signerSecretKey })`. At handler time the
plugin asserts the secret's pubkey matches `agent.wallet.publicKey` and
returns a clear `wallet_signer_mismatch` error if they diverge — so the
on-chain payment can't accidentally land from a wallet the SendAI agent
doesn't think it owns.

Hardware-wallet support is a follow-up that requires an upstream change
in `@x402/svm` to accept a non-keypair signer; happy to file that PR
against `coinbase/x402` once the shape lands here.

The other two actions don't need a secret and work without it.

## Tests + follow-ups

No tests in this initial PR (mirrors the convention used by the
original `plugin-defi` PR — land source first, follow up with
mock-based tests once the maintainers have eyes on the API shape).
Will follow up with a Jest test file once API names settle.

Happy to rework anything — action names (e.g. `NEXUS_CHAT` vs.
`NEXUS_CHAT_COMPLETION`), the `methods` surface, the `/tools` sub-export
path, `configure()` vs. a factory function — all easy to revise.