### PR TITLE
docs: add Codex MCP integration guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,112 @@
+# AGENTS.md
+
+This file provides guidance to Codex when working in this repository.
+
+## Build and Development Commands
+
+```bash
+# Install dependencies (requires pnpm 9+ and Node 22+)
+pnpm install
+
+# Build all packages
+pnpm run build
+
+# Build specific packages
+pnpm run build:core
+pnpm run build:plugin-token
+pnpm run build:plugin-defi
+pnpm run build:plugin-nft
+pnpm run build:plugin-misc
+pnpm run build:plugin-blinks
+pnpm run build:adapter-mcp
+
+# Lint and format
+pnpm run lint
+pnpm run lint:fix
+pnpm run format
+
+# Run tests. This is interactive and requires test/.env values.
+pnpm run test
+
+# Generate documentation
+pnpm run docs
+
+# Clean all build artifacts
+pnpm run clean
+```
+
+## Repository Architecture
+
+This is a pnpm workspace and Turborepo monorepo for building AI agents that interact with Solana protocols.
+
+### Package Structure
+
+```text
+packages/
+  core/           solana-agent-kit core SDK and SolanaAgentKit class
+  plugin-token/   token transfers, swaps, Jupiter, PumpFun
+  plugin-defi/    Drift, Orca, Raydium, Meteora, and other DeFi protocols
+  plugin-nft/     NFT operations through Metaplex, 3Land, and others
+  plugin-misc/    utilities such as CoinGecko, Allora, domains, webhooks
+  plugin-blinks/  Solana Blinks actions
+  adapter-mcp/    Model Context Protocol server adapter
+```
+
+## Core Concepts
+
+V2 uses a composable plugin architecture. Plugins register direct methods for programmatic use and actions for AI agent tool use.
+
+```typescript
+interface Plugin {
+  name: string;
+  methods: Record<string, Function>;
+  actions: Action[];
+  initialize(agent: SolanaAgentKit): void;
+}
+
+interface Action {
+  name: string;
+  similes: string[];
+  description: string;
+  examples: ActionExample[][];
+  schema: z.ZodType<any>;
+  handler: Handler;
+}
+```
+
+Initialize agents by composing plugins:
+
+```typescript
+const agent = new SolanaAgentKit(wallet, rpcUrl, config)
+  .use(TokenPlugin)
+  .use(DefiPlugin);
+
+await agent.methods.trade(...);
+
+const tools = createVercelAITools(agent, agent.actions);
+```
+
+## AI and MCP Integrations
+
+- `createVercelAITools(agent, actions)` converts actions for the Vercel AI SDK.
+- `createLangchainTools(agent, actions)` converts actions for LangChain.
+- `createOpenAITools(agent, actions)` converts actions for the OpenAI Agents SDK.
+- `createClaudeTools(agent, actions)` converts actions for the Claude Agents SDK.
+- `@solana-agent-kit/adapter-mcp` exposes selected actions through MCP for MCP clients such as Claude Desktop and Codex.
+
+Codex does not need a separate in-process action adapter. Use the MCP adapter when Codex should call Solana Agent Kit actions.
+
+## Code Style
+
+- Use Biome for linting and formatting.
+- Keep TypeScript ESM-compatible.
+- Prefer camelCase for functions and variables, PascalCase for types and classes.
+- Follow Conventional Commits for commit messages.
+- Keep public APIs typed and exported through package entrypoints.
+
+## Safety Notes
+
+- Do not commit private keys, RPC credentials, API keys, or generated wallet files.
+- When documenting MCP examples, expose only a minimal action set by default.
+- Prefer devnet or low-risk read-only actions in examples.
+- After changing package source, run the targeted package build and `pnpm run lint` when dependencies are available.

--- a/docs.json
+++ b/docs.json
@@ -59,7 +59,7 @@
           },
           {
             "group": "Using LLMs",
-            "pages": ["docs/v2/using-llms/overview"]
+            "pages": ["docs/v2/using-llms/overview", "docs/v2/using-llms/codex"]
           },
           {
             "group": "Examples",

--- a/docs/v2/adapters/mcp/mcp-adapter-intro.mdx
+++ b/docs/v2/adapters/mcp/mcp-adapter-intro.mdx
@@ -19,7 +19,7 @@ npm install solana-agent-kit @solana-agent-kit/adapter-mcp @solana-agent-kit/plu
 ## Features
 
 - Supports all actions from the Solana Agent Kit
-- MCP server implementation for standardized interactions with Claude Desktop
+- MCP server implementation for standardized interactions with MCP clients such as Claude Desktop and Codex
 - Environment-based configuration
 - Selective action exposure
 
@@ -29,7 +29,7 @@ npm install solana-agent-kit @solana-agent-kit/adapter-mcp @solana-agent-kit/plu
 - pnpm, yarn, or npm
 - Solana wallet with private key
 - Solana RPC URL
-- Claude Desktop application
+- An MCP client such as Claude Desktop or Codex CLI
 
 ## Basic Setup
 
@@ -141,9 +141,40 @@ Update your `package.json` to add the `type` field:
 
 3. Restart Claude Desktop after updating the configuration.
 
+## Codex Configuration
+
+Codex can load the same MCP server through `~/.codex/config.toml` or the Codex CLI.
+
+Add the server with the CLI:
+
+```bash
+codex mcp add solana-agent \
+  --env RPC_URL=your_solana_rpc_url_here \
+  --env SOLANA_PRIVATE_KEY=your_private_key_here \
+  --env OPENAI_API_KEY=your_openai_api_key_here \
+  -- node /ABSOLUTE/PATH/TO/YOUR/solana-agent-mcp/index.js
+```
+
+Or configure it in `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.solana-agent]
+command = "node"
+args = ["/ABSOLUTE/PATH/TO/YOUR/solana-agent-mcp/index.js"]
+startup_timeout_sec = 20
+tool_timeout_sec = 60
+
+[mcp_servers.solana-agent.env]
+RPC_URL = "your_solana_rpc_url_here"
+SOLANA_PRIVATE_KEY = "your_private_key_here"
+OPENAI_API_KEY = "your_openai_api_key_here"
+```
+
+Restart Codex after editing `config.toml`, then run `/mcp` in Codex to confirm that the server is active.
+
 ## Customizing Available Actions
 
-You can customize which actions are available to Claude by modifying the `finalActions` object:
+You can customize which actions are available to the MCP client by modifying the `finalActions` object:
 
 ```javascript
 // Example of adding more actions from different plugins
@@ -168,12 +199,12 @@ const finalActions = {
    node index.js
    ```
 
-2. Open Claude Desktop and ask questions about Solana, like:
+2. Open your MCP client and ask questions about Solana, like:
    - "What's my SOL balance?"
    - "Show me my token balances"
    - "What's my wallet address?"
 
-Claude will use your MCP server to interact with the Solana blockchain and provide responses based on the available actions.
+The client will use your MCP server to interact with the Solana blockchain and provide responses based on the available actions.
 
 For more detailed information, please refer to the full documentation at [docs.sendai.fun](https://docs.sendai.fun).
 
@@ -182,11 +213,11 @@ For more detailed information, please refer to the full documentation at [docs.s
 [![npm version](https://badge.fury.io/js/solana-mcp.svg)](https://www.npmjs.com/package/solana-mcp)
 [![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)
 
-A Model Context Protocol (MCP) server that provides onchain tools for Claude AI, allowing it to interact with the Solana blockchain through a standardized interface. This implementation is based on the Solana Agent Kit and enables AI agents to perform blockchain operations seamlessly.
+A Model Context Protocol (MCP) server that provides onchain tools for MCP clients such as Claude Desktop and Codex, allowing them to interact with the Solana blockchain through a standardized interface. This implementation is based on the Solana Agent Kit and enables AI agents to perform blockchain operations seamlessly.
 
 ### Overview
 
-This MCP server extends Claude's capabilities by providing tools to:
+This MCP server extends compatible MCP clients by providing tools to:
 
 * Interact with Solana blockchain
 * Execute transactions

--- a/docs/v2/using-llms/codex.mdx
+++ b/docs/v2/using-llms/codex.mdx
@@ -1,0 +1,132 @@
+---
+title: 'Codex MCP Integration'
+description: 'Connect Codex to Solana Agent Kit actions through the MCP adapter'
+icon: 'code'
+---
+
+# Codex MCP Integration
+
+Codex can use Solana Agent Kit through the Model Context Protocol (MCP). The `@solana-agent-kit/adapter-mcp` package exposes selected Solana Agent Kit actions as MCP tools, and Codex can load that server from its MCP configuration.
+
+Codex does not need a separate `createCodexTools` helper in `solana-agent-kit`. Use the MCP adapter when Codex should call Solana tools, and use the Codex SDK only when another application needs to control Codex sessions programmatically.
+
+## Prerequisites
+
+- Codex CLI installed and authenticated
+- Node.js 22 or higher
+- A Solana wallet private key for the environment you want to target
+- A Solana RPC URL
+- A small Solana Agent Kit MCP project
+
+## Create the MCP Server
+
+Create a project for the MCP server:
+
+```bash
+mkdir solana-agent-mcp
+cd solana-agent-mcp
+npm init -y
+npm install solana-agent-kit @solana-agent-kit/adapter-mcp @solana-agent-kit/plugin-token dotenv
+```
+
+Add environment variables:
+
+```env
+SOLANA_PRIVATE_KEY=your_private_key_here
+RPC_URL=your_solana_rpc_url_here
+OPENAI_API_KEY=your_openai_api_key_here
+```
+
+Create `index.js`:
+
+```javascript
+import { SolanaAgentKit, KeypairWallet } from "solana-agent-kit";
+import { startMcpServer } from "@solana-agent-kit/adapter-mcp";
+import TokenPlugin from "@solana-agent-kit/plugin-token";
+import * as dotenv from "dotenv";
+
+dotenv.config();
+
+const wallet = new KeypairWallet(process.env.SOLANA_PRIVATE_KEY);
+
+const agent = new SolanaAgentKit(wallet, process.env.RPC_URL, {
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+}).use(TokenPlugin);
+
+const actionNames = [
+  "BALANCE_ACTION",
+  "TOKEN_BALANCE_ACTION",
+  "GET_WALLET_ADDRESS_ACTION",
+];
+
+const finalActions = Object.fromEntries(
+  actionNames
+    .map((name) => [name, agent.actions.find((action) => action.name === name)])
+    .filter(([, action]) => Boolean(action)),
+);
+
+startMcpServer(finalActions, agent, {
+  name: "solana-agent",
+  version: "0.0.1",
+});
+```
+
+Set the package to ESM:
+
+```json
+{
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  }
+}
+```
+
+## Add the Server to Codex
+
+You can register the server with the Codex CLI:
+
+```bash
+codex mcp add solana-agent \
+  --env RPC_URL=your_solana_rpc_url_here \
+  --env SOLANA_PRIVATE_KEY=your_private_key_here \
+  --env OPENAI_API_KEY=your_openai_api_key_here \
+  -- node /ABSOLUTE/PATH/TO/solana-agent-mcp/index.js
+```
+
+Or edit `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.solana-agent]
+command = "node"
+args = ["/ABSOLUTE/PATH/TO/solana-agent-mcp/index.js"]
+startup_timeout_sec = 20
+tool_timeout_sec = 60
+
+[mcp_servers.solana-agent.env]
+RPC_URL = "your_solana_rpc_url_here"
+SOLANA_PRIVATE_KEY = "your_private_key_here"
+OPENAI_API_KEY = "your_openai_api_key_here"
+```
+
+Restart Codex after editing `config.toml`.
+
+## Verify the Integration
+
+Open Codex from a trusted project and run `/mcp` to confirm that the `solana-agent` server is active.
+
+Then ask Codex to use the server:
+
+```text
+Use the solana-agent MCP server to show my wallet address.
+```
+
+For a low-risk first test, expose only read-only actions such as wallet address and balance checks. Add transfer, swap, or mint actions only after you have confirmed the target network, wallet, and approval flow.
+
+## Security Notes
+
+- Do not commit `SOLANA_PRIVATE_KEY`, RPC credentials, or API keys.
+- Use a dedicated wallet for Codex MCP experiments.
+- Prefer devnet while validating setup.
+- Expose the smallest useful action set in `finalActions`.
+- Review prompts carefully before enabling transaction-producing actions.

--- a/docs/v2/using-llms/overview.mdx
+++ b/docs/v2/using-llms/overview.mdx
@@ -1,6 +1,6 @@
 # Using LLMs with Solana Agent Kit
 
-Solana Agent Kit's documentation is designed to be LLM-friendly, helping developers integrate with the toolkit more efficiently. This guide covers two powerful ways to integrate Solana Agent Kit with LLMs: Cursor IDE integration and Model Context Protocol (MCP) setup.
+Solana Agent Kit's documentation is designed to be LLM-friendly, helping developers integrate with the toolkit more efficiently. This guide covers Cursor IDE integration and Model Context Protocol (MCP) setup for AI clients such as Codex and Claude Desktop.
 
 ## Cursor IDE Integration
 
@@ -64,6 +64,10 @@ Once configured, you can use the MCP server to:
 - Query Solana Agent Kit documentation programmatically
 - Access API endpoints with AI-powered context
 - Get intelligent suggestions based on the documentation
+
+### Codex Integration
+
+Codex can also use Solana Agent Kit actions through the MCP adapter. See [Codex MCP Integration](/docs/v2/using-llms/codex) for setup instructions.
 
 ## Benefits
 

--- a/packages/adapter-mcp/README.md
+++ b/packages/adapter-mcp/README.md
@@ -5,7 +5,7 @@ This utility provides a framework for creating a Model Context Protocol (MCP) se
 ## Features
 
 - Supports all actions from the Solana Agent Kit
-- MCP server implementation for standardized interactions
+- MCP server implementation for standardized interactions with MCP clients such as Claude Desktop and Codex
 - Environment-based configuration
 
 ## Prerequisites
@@ -30,7 +30,7 @@ SOLANA_PRIVATE_KEY=your_private_key_here
 RPC_URL=your_solana_rpc_url_here
 ```
 
-2. Change the Claude Desktop MCP server settings:
+2. Change the MCP client settings. For Claude Desktop:
 
 For MacOS:
 ```bash
@@ -62,6 +62,33 @@ The final configuration should look like the following (replace the path with yo
 ```
 
 Note: Make sure to restart Claude Desktop after updating the configuration and building the project.
+
+For Codex, add the same server to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.solana-agent]
+command = "node"
+args = ["/ABSOLUTE/PATH/TO/YOUR/MCP/PROJECT/FILE"]
+startup_timeout_sec = 20
+tool_timeout_sec = 60
+
+[mcp_servers.solana-agent.env]
+RPC_URL = "your_solana_rpc_url_here"
+SOLANA_PRIVATE_KEY = "your_private_key_here"
+OPENAI_API_KEY = "your_openai_api_key_here"
+```
+
+You can also register it with the Codex CLI:
+
+```bash
+codex mcp add solana-agent \
+  --env RPC_URL=your_solana_rpc_url_here \
+  --env SOLANA_PRIVATE_KEY=your_private_key_here \
+  --env OPENAI_API_KEY=your_openai_api_key_here \
+  -- node /ABSOLUTE/PATH/TO/YOUR/MCP/PROJECT/FILE
+```
+
+Restart Codex after editing `config.toml`, then run `/mcp` in Codex to confirm the server is active.
 
 ## Building the Project
 

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -1,0 +1,83 @@
+# AGENTS.md
+
+This file provides Codex guidance for the `solana-agent-kit` core package.
+
+## Package Overview
+
+`packages/core` is the main SDK package. It exports the `SolanaAgentKit` class, wallet utilities, action execution helpers, and framework adapters for AI tool use.
+
+## Commands
+
+```bash
+# From packages/core
+pnpm run build
+pnpm run clean
+pnpm run test
+
+# From the repository root
+pnpm run build:core
+pnpm run lint
+pnpm run lint:fix
+```
+
+## Core Exports
+
+The package entrypoint is `src/index.ts`. Keep new public core APIs exported there.
+
+```typescript
+export { SolanaAgentKit } from "./agent";
+export { createVercelAITools } from "./vercel-ai";
+export { createLangchainTools } from "./langchain";
+export { createOpenAITools } from "./openai";
+export { createClaudeTools } from "./claude";
+export * from "./types";
+export * from "./types/wallet";
+export * from "./utils/actionExecutor";
+export * from "./utils/send_tx";
+export * from "./utils/keypairWallet";
+```
+
+## Architecture
+
+`SolanaAgentKit` composes plugin methods and actions:
+
+```typescript
+class SolanaAgentKit<TPlugins = Record<string, never>> {
+  connection: Connection;
+  config: Config;
+  wallet: BaseWallet;
+  evmWallet?: EvmWallet;
+  methods: TPlugins;
+  actions: Action[];
+
+  use<P extends Plugin>(plugin: P): SolanaAgentKit<TPlugins & PluginMethods<P>>;
+}
+```
+
+Plugin methods are merged into `agent.methods` with type inference. Actions are converted into framework-specific tools by the adapters.
+
+## Adapter Pattern
+
+Framework adapters live under `src/<framework>/index.ts`.
+
+- Accept `(solanaAgentKit: SolanaAgentKit, actions: Action[])`.
+- Convert each `Action` into the target framework's tool representation.
+- Use `executeAction(action, solanaAgentKit, params)` when possible so validation and response handling stay consistent.
+- Preserve the existing action count limit behavior consistently across adapters.
+
+Use `@solana-agent-kit/adapter-mcp` for Codex integration. Codex consumes tools over MCP instead of using an in-process `createCodexTools` helper.
+
+## Key Files
+
+- `src/agent/index.ts` defines `SolanaAgentKit`.
+- `src/types/index.ts` defines `Plugin`, `Config`, and core response types.
+- `src/types/action.ts` defines action helper types.
+- `src/types/wallet.ts` defines wallet interfaces.
+- `src/utils/actionExecutor.ts` validates action input and calls handlers.
+- `src/utils/keypairWallet.ts` implements the default server-side wallet.
+
+## Safety Notes
+
+- Do not broaden wallet, transaction, or key handling behavior without targeted tests.
+- Keep adapter changes narrowly scoped to schema conversion and action execution.
+- Avoid adding runtime dependencies unless the target SDK requires them and exposes a stable tool abstraction.


### PR DESCRIPTION
## Summary
- add Codex AGENTS.md guidance at the repo root and core package level
- document how to connect Codex to Solana Agent Kit through the existing MCP adapter
- update MCP adapter docs and Using LLMs navigation to include Codex

## Validation
- node -e "JSON.parse(require('fs').readFileSync('docs.json','utf8')); console.log('docs.json parsed')"
- corepack pnpm dlx @biomejs/biome@1.9.4 check --formatter-enabled=false docs.json
- git diff --check

## Notes
Codex consumes tool integrations through MCP, so this PR uses the existing @solana-agent-kit/adapter-mcp package rather than adding a misleading createCodexTools SDK adapter.
