### PR TITLE
feat(plugin-defi): add Bhairab pre-trade token risk scan

### DIFF
--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -40,6 +40,7 @@ export interface Config {
   PINATA_GATEWAY?: string;
   PUMP_FUN_REFERRAL_WALLET?: string;
   MAGIC_EDEN_API_KEY?: string;
+  BHAIRAB_API_KEY?: string;
   OTHER_API_KEYS?: Record<string, string>;
 }
 

--- a/packages/plugin-defi/src/bhairab/actions/scanToken.ts
+++ b/packages/plugin-defi/src/bhairab/actions/scanToken.ts
@@ -1,0 +1,98 @@
+import { Action, SolanaAgentKit } from "solana-agent-kit";
+import { z } from "zod";
+import { scanToken } from "../tools/scan_token";
+
+const scanTokenAction: Action = {
+  name: "BHAIRAB_SCAN_TOKEN",
+  description:
+    "Scan a Solana token for risk BEFORE trading it. Returns a verdict (proceed, caution, or stop) with cited reasons, based on live market signals (liquidity, 24h price move, volume, token age). Use this as a safety check before any buy/swap to avoid illiquid, crashing, or scam tokens. Works without an API key; BHAIRAB_API_KEY unlocks an AI-reasoned verdict.",
+  similes: [
+    "check if a token is safe before buying",
+    "is this token a scam or rug",
+    "risk check this token",
+    "scan token before trading",
+    "should I buy this token",
+    "pre-trade safety check",
+  ],
+  examples: [
+    [
+      {
+        input: {
+          token: "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
+          action: "buy",
+          amountUsd: 250,
+        },
+        output: {
+          status: "success",
+          verdict: "proceed",
+          confidence: 0.8,
+          summary:
+            "Established token with deep liquidity and no red flags in market data.",
+          reasons: [
+            "High liquidity reduces slippage and exit risk",
+            "Token is well-established (over 800 days old)",
+          ],
+          tier: "free",
+        },
+        explanation:
+          "Scan a token for risk before buying; the verdict came back proceed.",
+      },
+    ],
+    [
+      {
+        input: {
+          token: "So11111111111111111111111111111111111111112",
+        },
+        output: {
+          status: "success",
+          verdict: "proceed",
+          confidence: 1,
+          summary: "Wrapped SOL — highly liquid, established asset.",
+          reasons: ["no_red_flags_in_market_data"],
+          tier: "free",
+        },
+        explanation: "Scan with only a mint address, defaulting action to buy.",
+      },
+    ],
+  ],
+  schema: z.object({
+    token: z.string().describe("The Solana token mint address to scan"),
+    action: z
+      .enum(["buy", "sell", "swap", "transfer"])
+      .optional()
+      .describe("The intended action (defaults to buy)"),
+    amountUsd: z
+      .number()
+      .optional()
+      .describe("Optional intended amount in USD, for context"),
+  }),
+  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+    try {
+      const result = await scanToken(
+        agent,
+        input.token,
+        input.action ?? "buy",
+        input.amountUsd,
+      );
+
+      return {
+        status: "success",
+        verdict: result.verdict,
+        confidence: result.confidence,
+        summary: result.summary,
+        reasons: result.reasons,
+        signals: result.signals,
+        tier: result.tier,
+        message: `Risk verdict: ${result.verdict.toUpperCase()} — ${result.summary}`,
+      };
+    } catch (error: any) {
+      return {
+        status: "error",
+        message: `Failed to scan token: ${error.message}`,
+        code: error.code || "BHAIRAB_SCAN_FAILED",
+      };
+    }
+  },
+};
+
+export default scanTokenAction;

--- a/packages/plugin-defi/src/bhairab/tools/index.ts
+++ b/packages/plugin-defi/src/bhairab/tools/index.ts
@@ -1,0 +1,1 @@
+export * from "./scan_token";

--- a/packages/plugin-defi/src/bhairab/tools/scan_token.ts
+++ b/packages/plugin-defi/src/bhairab/tools/scan_token.ts
@@ -1,0 +1,68 @@
+import { SolanaAgentKit } from "solana-agent-kit";
+
+const BHAIRAB_ENDPOINT = "https://tao-gateway.fly.dev/v1/risk/scan";
+
+export interface TokenRiskScan {
+  verdict: "proceed" | "caution" | "stop";
+  confidence: number;
+  summary: string;
+  reasons: string[];
+  signals: {
+    found: boolean;
+    symbol?: string;
+    name?: string;
+    priceUsd: number;
+    priceChange24hPct: number;
+    liquidityUsd: number;
+    volume24hUsd: number;
+    ageDays: number;
+    pairCount: number;
+    topDex?: string;
+    source: string;
+  };
+  tier: "free" | "keyed";
+  verdictSource: string;
+}
+
+/**
+ * Scan a token for risk BEFORE trading it, using Bhairab's guardian endpoint.
+ *
+ * Fetches live market signals (liquidity, 24h move, volume, token age) and
+ * returns a verdict — `proceed`, `caution`, or `stop` — with cited reasons.
+ * Works with no API key (heuristic verdict, free). Setting `BHAIRAB_API_KEY`
+ * in the agent config unlocks an AI-reasoned verdict.
+ *
+ * @param agent      SolanaAgentKit instance
+ * @param token      The token mint address to scan
+ * @param action     The intended action: buy | sell | swap | transfer (default "buy")
+ * @param amountUsd  Optional intended amount in USD, for context
+ * @returns          The risk verdict, reasons, and live signals
+ */
+export async function scanToken(
+  agent: SolanaAgentKit,
+  token: string,
+  action = "buy",
+  amountUsd?: number,
+): Promise<TokenRiskScan> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  const apiKey = agent.config.BHAIRAB_API_KEY;
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+
+  const res = await fetch(BHAIRAB_ENDPOINT, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ chain: "solana", token, action, amountUsd }),
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `Bhairab risk scan failed (${res.status}): ${await res.text()}`,
+    );
+  }
+
+  return (await res.json()) as TokenRiskScan;
+}

--- a/packages/plugin-defi/src/index.ts
+++ b/packages/plugin-defi/src/index.ts
@@ -45,6 +45,10 @@ import getSwapDataAction from "./okx/actions/getSwapData";
 // Import OKX actions
 import getTokensAction from "./okx/actions/getTokens";
 
+// Import Bhairab actions & tools — pre-trade token risk scan
+import scanTokenAction from "./bhairab/actions/scanToken";
+import { scanToken } from "./bhairab/tools";
+
 // Import Debridge tools & actions
 import checkDebridgeTransactionStatusAction from "./debridge/actions/checkTransactionStatus";
 import createDebridgeBridgeOrderAction from "./debridge/actions/createBridgeOrder";
@@ -390,6 +394,9 @@ const DefiPlugin = {
     lavarageGetQuote,
     lavarageCloseQuote,
     lavarageTradeHistory,
+
+    // Bhairab methods
+    scanToken,
   },
 
   // Combine all actions
@@ -495,6 +502,9 @@ const DefiPlugin = {
     getLiquidityAction,
     getChainDataAction,
     executeSwapAction,
+
+    // Bhairab actions — pre-trade token risk scan
+    scanTokenAction,
 
     // Lavarage actions — spot margin leverage + borrow on any Solana token
     lavarageOpenPositionAction,


### PR DESCRIPTION
## What

Adds a `BHAIRAB_SCAN_TOKEN` action to `plugin-defi`: a **pre-trade safety check** that returns a `proceed` / `caution` / `stop` verdict for a Solana token, based on live market signals (liquidity, 24h price move, volume, token age, pair count).

## Why

The kit can already swap and trade tokens, but there's no built-in way for an agent to **vet a token's risk before buying it**. Autonomous agents trading trending tokens can walk straight into illiquid, crashing, or scam tokens. This adds that guardrail as a composable action an agent can call before executing a trade.

## Usage

```ts
const result = await agent.methods.scanToken(
  "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263", // BONK
  "buy",
  250,
);
// → { verdict: "proceed", confidence, summary, reasons, signals, tier }

if (result.verdict === "stop") return; // skip the trade
```

Because it's a registered action, the agent's model can also call it autonomously as a safety step before a swap.

- **No API key required** — returns a heuristic verdict (free).
- Setting `BHAIRAB_API_KEY` in the agent config unlocks an AI-reasoned verdict.

## Changes

- `plugin-defi/src/bhairab/tools/scan_token.ts` — typed fetch wrapper
- `plugin-defi/src/bhairab/actions/scanToken.ts` — `Action` with zod schema, similes, examples
- registered in `plugin-defi` `methods` + `actions`
- added optional `BHAIRAB_API_KEY` to core `Config`

## Testing

- `pnpm build` passes for `core` and `plugin-defi` (including DTS typecheck)
- `biome check` clean on the new files
- Functional smoke test against the live endpoint: known token → `proceed`, unknown mint → `caution`
