### PR TITLE
feat(plugin-misc): add txguard pre-sign transaction safety check

### DIFF
--- a/docs/v2/plugins/misc/misc-plugin-intro.mdx
+++ b/docs/v2/plugins/misc/misc-plugin-intro.mdx
@@ -168,5 +168,12 @@ Configure Alchemy credentials only when using these tools. RPC, price, and portf
 | `get_verified_programs` | Get list of all verified programs |
 | `verify_program` | Verify a Solana program |
 
+### TxGuard
+| Tool Name | Description |
+|-----------|-------------|
+| `checkTransactionSafety` | Deterministically screen a decoded transaction for drain/seizure patterns before signing (`allow`/`warn`/`halt`) |
+| `checkTransactionFromRpc` | Run the safety check on a `getParsedTransaction` RPC result |
+| `checkTransactionBySignature` | Fetch a confirmed transaction by signature and screen it (read-only) |
+
 
 For more detailed information, please refer to the full documentation at [docs.sendai.fun](https://docs.sendai.fun).

--- a/packages/plugin-misc/src/index.ts
+++ b/packages/plugin-misc/src/index.ts
@@ -162,6 +162,14 @@ import {
 } from "./squads/tools";
 import { simulate_switchboard_feed } from "./switchboard/tools";
 
+import { checkTransactionSafetyAction } from "./txguard/actions";
+// txguard
+import {
+  checkTransactionBySignature,
+  checkTransactionFromRpc,
+  checkTransactionSafety,
+} from "./txguard/tools";
+
 // crossmint
 import checkoutAction from "./crossmint/actions/checkoutAction";
 import confirmOrderAction from "./crossmint/actions/confirmOrderAction";
@@ -300,6 +308,9 @@ const MiscPlugin = {
     get_verification_job_status,
     get_verified_programs,
     verify_program,
+    checkTransactionSafety,
+    checkTransactionFromRpc,
+    checkTransactionBySignature,
   },
 
   // Combine all actions
@@ -379,6 +390,7 @@ const MiscPlugin = {
     getVerificationJobStatusAction,
     getVerifiedProgramsAction,
     verifyProgramAction,
+    checkTransactionSafetyAction,
   ],
 
   // Initialize function

--- a/packages/plugin-misc/src/txguard/actions/checkTransactionSafety.ts
+++ b/packages/plugin-misc/src/txguard/actions/checkTransactionSafety.ts
@@ -1,0 +1,121 @@
+import { Action, SolanaAgentKit } from "solana-agent-kit";
+import { z } from "zod";
+import { checkTransactionSafety } from "../tools";
+
+const instructionSchema = z.object({
+  program: z.string().describe("program id the instruction invokes"),
+  type: z
+    .string()
+    .optional()
+    .describe(
+      "decoded instruction type, e.g. transfer / setAuthority / approve",
+    ),
+  dest: z.string().optional().describe("destination / new-authority pubkey"),
+  delegate: z
+    .string()
+    .optional()
+    .describe("delegate pubkey for token approvals"),
+  new_authority: z
+    .string()
+    .optional()
+    .describe("new authority/owner for setAuthority/assign"),
+  owner: z
+    .string()
+    .optional()
+    .describe("new owner program for a System assign"),
+  amount: z
+    .union([z.number(), z.string()])
+    .optional()
+    .describe(
+      'lamports or token base units; "unlimited" or 2^64-1 ⇒ unlimited delegate',
+    ),
+  balance: z
+    .number()
+    .optional()
+    .describe("fee-payer balance hint for full-drain detection"),
+  drains_balance: z.boolean().optional(),
+});
+
+const checkTransactionSafetyAction: Action = {
+  name: "CHECK_TRANSACTION_SAFETY",
+  description:
+    "Deterministically screen a decoded Solana transaction for known drain/seizure patterns BEFORE signing. " +
+    "No model, no key, no network — pure structural analysis. Returns allow|warn|halt with per-rule reasons. " +
+    "Catches: unknown program invokes, full-balance / split drains, setAuthority & closeAccount seizures, " +
+    "assign-to-foreign-owner, and unlimited token delegates. Fail-safe: unknowns escalate to halt.",
+  similes: [
+    "check if this transaction is safe to sign",
+    "screen transaction for drain patterns",
+    "is this solana transaction a scam",
+    "pre-sign safety check",
+    "detect wallet drainer transaction",
+  ],
+  examples: [
+    [
+      {
+        input: {
+          fee_payer: "AgentWa11et1111111111111111111111111111111",
+          owned_accounts: ["AgentWa11et1111111111111111111111111111111"],
+          instructions: [
+            {
+              program: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              type: "approve",
+              delegate: "Attacker11111111111111111111111111111111111",
+              amount: "18446744073709551615",
+            },
+          ],
+        },
+        output: {
+          status: "success",
+          verdict: "halt",
+          safe_to_sign: false,
+          summary: "⛔ 1 halt · 0 warn — DO NOT auto-sign",
+        },
+        explanation:
+          "An unlimited token delegate to an unknown spender is a drain-later attack — flagged halt.",
+      },
+    ],
+  ],
+  schema: z.object({
+    fee_payer: z.string().optional().describe("fee payer / signer pubkey"),
+    owned_accounts: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "pubkeys the agent controls — payouts to anything else are suspect",
+      ),
+    balance: z
+      .number()
+      .optional()
+      .describe("fee-payer lamport balance, for split-drain detection"),
+    instructions: z
+      .array(instructionSchema)
+      .describe("decoded instructions of the transaction"),
+  }),
+  handler: async (_agent: SolanaAgentKit, input: Record<string, any>) => {
+    try {
+      const verdict = checkTransactionSafety({
+        fee_payer: input.fee_payer,
+        owned_accounts: input.owned_accounts,
+        balance: input.balance,
+        instructions: input.instructions ?? [],
+      });
+      return {
+        status: "success",
+        ...verdict,
+        message: verdict.summary,
+      };
+    } catch (error: any) {
+      // Fail safe: never let an error read as "safe".
+      return {
+        status: "error",
+        verdict: "halt",
+        safe_to_sign: false,
+        message: `Failed to check transaction safety: ${error.message}`,
+        code: error.code || "CHECK_TRANSACTION_SAFETY_FAILED",
+      };
+    }
+  },
+};
+
+export default checkTransactionSafetyAction;

--- a/packages/plugin-misc/src/txguard/actions/index.ts
+++ b/packages/plugin-misc/src/txguard/actions/index.ts
@@ -1,0 +1,1 @@
+export { default as checkTransactionSafetyAction } from "./checkTransactionSafety";

--- a/packages/plugin-misc/src/txguard/tools/check_transaction_by_signature.ts
+++ b/packages/plugin-misc/src/txguard/tools/check_transaction_by_signature.ts
@@ -1,0 +1,42 @@
+import { SolanaAgentKit } from "solana-agent-kit";
+import {
+  type SafetyVerdict,
+  checkTransactionFromRpc,
+} from "./check_transaction_safety";
+
+/**
+ * Fetch a confirmed transaction by signature and run the deterministic safety check on it.
+ * Useful for auditing a tx the agent (or a counterparty) already submitted. Read-only.
+ *
+ * @param agent     the Solana Agent Kit instance (uses `agent.connection`)
+ * @param signature base-58 transaction signature
+ * @param owner     optional pubkey the agent controls (defaults to the agent wallet)
+ */
+export async function checkTransactionBySignature(
+  agent: SolanaAgentKit,
+  signature: string,
+  owner?: string,
+): Promise<SafetyVerdict> {
+  const parsed = await agent.connection.getParsedTransaction(signature, {
+    maxSupportedTransactionVersion: 0,
+  });
+  if (!parsed) {
+    return {
+      verdict: "halt",
+      safe_to_sign: false,
+      risk: 1,
+      n_instructions: 0,
+      flags: [
+        {
+          rule: "tx_not_found",
+          severity: "halt",
+          ix: -1,
+          detail: `transaction ${signature.slice(0, 12)}… not found / not yet confirmed — cannot verify`,
+        },
+      ],
+      summary: "⛔ transaction not found — cannot verify, do not trust",
+    };
+  }
+  const self = owner ?? agent.wallet.publicKey.toBase58();
+  return checkTransactionFromRpc(parsed, self);
+}

--- a/packages/plugin-misc/src/txguard/tools/check_transaction_safety.ts
+++ b/packages/plugin-misc/src/txguard/tools/check_transaction_safety.ts
@@ -1,0 +1,305 @@
+/**
+ * txguard — deterministic Solana transaction safety pre-flight.
+ *
+ * Call BEFORE an agent signs: get a verdict + reasons. No model, no API key, no network — pure
+ * structural analysis of a decoded transaction. An autonomous signer (or any Solana AI Kit agent)
+ * can be drained by a crafted tx — a full-balance transfer to an unknown address, a
+ * setAuthority/closeAccount seizure, an unlimited token delegate, or a call into an unknown program.
+ * This catches the known drain patterns deterministically so a bad tx HALTs before signature.
+ *
+ * Fail-safe: anything unrecognised escalates toward `halt`, never a false `allow`.
+ */
+
+/** Known-good Solana programs (system, token, ATA, memo, compute budget, common DEX/stake). */
+export const KNOWN_PROGRAMS: Record<string, string> = {
+  "11111111111111111111111111111111": "system",
+  TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA: "spl-token",
+  TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb: "spl-token-2022",
+  ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL: "associated-token",
+  MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr: "memo",
+  ComputeBudget111111111111111111111111111111: "compute-budget",
+  JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4: "jupiter-v6",
+  Stake11111111111111111111111111111111111111: "stake",
+};
+
+const SYSTEM_PROGRAM = "11111111111111111111111111111111";
+const UINT64_MAX = 18446744073709551615n; // 2**64 - 1, the canonical "unlimited" delegate amount
+
+/** Instruction types that can drain or seize control, with their base severity. */
+const DANGER_TYPES: Record<string, { severity: Severity; detail: string }> = {
+  setAuthority: {
+    severity: "halt",
+    detail: "changes who controls an account/mint — classic seizure",
+  },
+  closeAccount: {
+    severity: "warn",
+    detail: "closes account & sends rent/balance to a destination — check dest",
+  },
+  approve: {
+    severity: "warn",
+    detail:
+      "delegates token spend authority — check it is bounded & to a known spender",
+  },
+  approveChecked: {
+    severity: "warn",
+    detail: "delegates token spend authority — check amount & spender",
+  },
+};
+
+export type Severity = "halt" | "warn";
+export type Verdict = "allow" | "warn" | "halt";
+
+/** A single decoded instruction. Unknown fields are tolerated; missing ones fail safe. */
+export interface DecodedInstruction {
+  program: string;
+  type?: string;
+  dest?: string;
+  delegate?: string;
+  /** New owner/authority for `assign` / `setAuthority`. */
+  new_authority?: string;
+  owner?: string;
+  /** Lamports (System) or token base units. `"unlimited"` or 2^64-1 ⇒ unlimited delegate. */
+  amount?: number | bigint | string | null;
+  /** Per-instruction balance hint for full-drain detection. */
+  balance?: number;
+  /** Explicit hint that this transfer drains the whole balance. */
+  drains_balance?: boolean;
+}
+
+export interface TxToCheck {
+  fee_payer?: string;
+  /** Accounts the agent controls. Anything paying out to a non-owned address is suspect. */
+  owned_accounts?: string[];
+  /** Current lamport balance of the fee payer, for split-drain detection. */
+  balance?: number;
+  instructions?: DecodedInstruction[];
+}
+
+export interface SafetyFlag {
+  rule: string;
+  severity: Severity;
+  ix: number;
+  detail: string;
+}
+
+export interface SafetyVerdict {
+  verdict: Verdict;
+  safe_to_sign: boolean;
+  risk: number;
+  n_instructions: number;
+  flags: SafetyFlag[];
+  summary: string;
+}
+
+function toBigInt(v: unknown): bigint | null {
+  if (typeof v === "bigint") {
+    return v;
+  }
+  if (typeof v === "number" && Number.isFinite(v)) {
+    return BigInt(Math.trunc(v));
+  }
+  if (typeof v === "string" && /^\d+$/.test(v)) {
+    return BigInt(v);
+  }
+  return null;
+}
+
+function isUnlimited(amount: DecodedInstruction["amount"]): boolean {
+  if (amount === null || amount === undefined || amount === "unlimited") {
+    return true;
+  }
+  return toBigInt(amount) === UINT64_MAX;
+}
+
+function isFullBalance(ix: DecodedInstruction, feePayer: string): boolean {
+  if (ix.program !== SYSTEM_PROGRAM || ix.type !== "transfer") {
+    return false;
+  }
+  const dest = ix.dest ?? "";
+  if (dest && dest !== feePayer && ix.drains_balance) {
+    return true;
+  }
+  const amt = toBigInt(ix.amount);
+  const bal = toBigInt(ix.balance);
+  return amt !== null && bal !== null && amt === bal;
+}
+
+/**
+ * Deterministic pre-sign verdict. Never throws.
+ * @param tx decoded transaction `{ fee_payer, owned_accounts?, balance?, instructions[] }`
+ * @returns verdict (`allow | warn | halt`), per-rule flags, and a risk score in [0,1].
+ */
+export function checkTransactionSafety(tx: TxToCheck): SafetyVerdict {
+  const flags: SafetyFlag[] = [];
+  const feePayer = tx?.fee_payer ?? "";
+  const owned = new Set(tx?.owned_accounts ?? (feePayer ? [feePayer] : []));
+  const balance = toBigInt(tx?.balance);
+  const instructions = tx?.instructions ?? [];
+  let sysOut = 0n; // cumulative SOL leaving the fee payer (split-drain evasion)
+
+  instructions.forEach((ix, i) => {
+    // System `assign` hands an account to a new owner program → seizure
+    if (ix.program === SYSTEM_PROGRAM && ix.type === "assign") {
+      const newOwner = ix.owner || ix.new_authority || "";
+      if (newOwner && !owned.has(newOwner) && !(newOwner in KNOWN_PROGRAMS)) {
+        flags.push({
+          rule: "assign_foreign_owner",
+          severity: "halt",
+          ix: i,
+          detail: `reassigns account ownership to ${newOwner.slice(0, 12)}… — seizure`,
+        });
+      }
+    }
+
+    // cumulative drain: many small transfers that together empty the wallet
+    if (
+      ix.program === SYSTEM_PROGRAM &&
+      ix.type === "transfer" &&
+      ix.dest &&
+      !owned.has(ix.dest)
+    ) {
+      const amt = toBigInt(ix.amount);
+      if (amt !== null) {
+        sysOut += amt;
+      }
+    }
+
+    // unknown program → could do anything
+    if (!(ix.program in KNOWN_PROGRAMS)) {
+      flags.push({
+        rule: "unknown_program",
+        severity: "halt",
+        ix: i,
+        detail: `instruction calls unknown program ${(ix.program || "").slice(0, 12)}… — could do anything`,
+      });
+    }
+
+    const t = ix.type ?? "";
+    if (t in DANGER_TYPES) {
+      let { severity, detail } = DANGER_TYPES[t];
+      const target = ix.dest || ix.delegate || ix.new_authority || "";
+      if (
+        target &&
+        !owned.has(target) &&
+        (t === "setAuthority" || t === "closeAccount")
+      ) {
+        severity = "halt";
+      }
+      if (
+        (t === "approve" || t === "approveChecked") &&
+        isUnlimited(ix.amount)
+      ) {
+        severity = "halt";
+        detail =
+          "UNLIMITED token delegate — spender can drain the whole balance";
+      }
+      flags.push({ rule: t, severity, ix: i, detail });
+    }
+
+    if (isFullBalance(ix, feePayer)) {
+      const dest = ix.dest ?? "";
+      flags.push({
+        rule: "full_balance_transfer",
+        severity: owned.has(dest) ? "warn" : "halt",
+        ix: i,
+        detail: `moves (near) entire SOL balance to ${dest.slice(0, 8)}…`,
+      });
+    }
+  });
+
+  // cumulative split-drain: sum of foreign System transfers ≥ (near) whole balance
+  if (balance !== null && balance > 0n && sysOut * 10n >= balance * 9n) {
+    flags.push({
+      rule: "cumulative_drain",
+      severity: "halt",
+      ix: -1,
+      detail: `transfers total ${sysOut} ≥ 90% of balance ${balance} — split-drain`,
+    });
+  }
+
+  const halts = flags.filter((f) => f.severity === "halt");
+  const warns = flags.filter((f) => f.severity === "warn");
+  const verdict: Verdict = halts.length
+    ? "halt"
+    : warns.length
+      ? "warn"
+      : "allow";
+  const risk =
+    Math.round(Math.min(1, 0.5 * halts.length + 0.2 * warns.length) * 100) /
+    100;
+  const summary = halts.length
+    ? `⛔ ${halts.length} halt · ${warns.length} warn — DO NOT auto-sign`
+    : warns.length
+      ? `⚠ ${warns.length} warning(s) — review before signing`
+      : "✅ no known drain patterns";
+
+  return {
+    verdict,
+    safe_to_sign: verdict === "allow",
+    risk,
+    n_instructions: instructions.length,
+    flags,
+    summary,
+  };
+}
+
+/**
+ * Adapt a Solana RPC `getParsedTransaction` result → {@link checkTransactionSafety} input.
+ * The RPC does the wire-decoding; we normalise program/type/dest/amount so the check runs on real
+ * on-chain txs. Never throws — undecodable input degrades to an unknown program (→ halt).
+ */
+export function normalizeParsedTransaction(
+  parsedTx: any,
+  owner = "",
+): TxToCheck {
+  const tx: TxToCheck = {
+    fee_payer: "",
+    owned_accounts: owner ? [owner] : [],
+    instructions: [],
+  };
+  try {
+    const msg = parsedTx.transaction.message;
+    const keys = msg.accountKeys ?? [];
+    if (keys.length) {
+      const k0 = keys[0];
+      tx.fee_payer = typeof k0 === "object" && k0 !== null ? k0.pubkey : k0;
+    }
+    if (!owner && tx.fee_payer) {
+      tx.owned_accounts = [tx.fee_payer];
+    }
+    for (const ix of msg.instructions ?? []) {
+      const program =
+        ix.programId?.toString?.() ?? ix.program ?? ix.programId ?? "";
+      const parsed = ix.parsed;
+      const row: DecodedInstruction = { program };
+      if (parsed && typeof parsed === "object") {
+        row.type = parsed.type;
+        const info = parsed.info ?? {};
+        row.dest = info.destination ?? info.newAuthority ?? info.delegate;
+        row.delegate = info.delegate;
+        row.new_authority = info.newAuthority;
+        const rawAmt =
+          info.lamports ??
+          (typeof info.tokenAmount === "object" && info.tokenAmount !== null
+            ? info.tokenAmount.amount
+            : undefined) ??
+          info.amount;
+        row.amount = rawAmt ?? null;
+      } else {
+        row.type = "invoke"; // unparsed → flagged if program unknown
+      }
+      tx.instructions!.push(row);
+    }
+  } catch {
+    tx.instructions!.push({ program: "UNDECODABLE", type: "invoke" }); // fail-safe → halt
+  }
+  return tx;
+}
+
+/** One call: adapt an RPC `getParsedTransaction` result and return the safety verdict. */
+export function checkTransactionFromRpc(
+  parsedTx: any,
+  owner = "",
+): SafetyVerdict {
+  return checkTransactionSafety(normalizeParsedTransaction(parsedTx, owner));
+}

--- a/packages/plugin-misc/src/txguard/tools/index.ts
+++ b/packages/plugin-misc/src/txguard/tools/index.ts
@@ -1,0 +1,2 @@
+export * from "./check_transaction_safety";
+export * from "./check_transaction_by_signature";


### PR DESCRIPTION
## What

Adds **txguard** to `plugin-misc`: a deterministic, dependency-free safety screen an agent can call **before it signs** a Solana transaction. No model, no API key, no network — pure structural analysis returning `allow | warn | halt` with per-rule reasons.

An autonomous signer (any Solana Agent Kit agent that can sign) can be fed a crafted tx that drains or seizes its wallet. The kit has program-verification (OtterSec) but no *pre-sign drain check*. This fills that gap with a fail-safe default: anything unrecognised escalates toward `halt`, never a false `allow`.

## Detects

- **unknown-program invoke** — program not on the known-good allowlist ⇒ `halt`
- **full-balance & cumulative split-drain** — SOL transfers (single or summed ≥90%) to a non-owned dest
- **setAuthority / closeAccount seizure** — authority/close to a foreign account ⇒ `halt`
- **System `assign`** reassigning account ownership to a foreign program ⇒ `halt`
- **unlimited token approve/delegate** (`2^64-1` / `"unlimited"`) — drain-later ⇒ `halt`

## API

Methods (programmatic) + one agent action:

```ts
import { checkTransactionSafety } from "@solana-agent-kit/plugin-misc";

const v = checkTransactionSafety({
  fee_payer: wallet,
  owned_accounts: [wallet],
  instructions: decoded,            // [{ program, type, dest, amount, ... }]
});
// { verdict: "halt", safe_to_sign: false, risk, flags: [...], summary }
```

- `checkTransactionSafety(tx)` — pure verdict on a decoded tx
- `checkTransactionFromRpc(parsedTx, owner)` — adapts a `getParsedTransaction` result
- `checkTransactionBySignature(agent, signature, owner?)` — fetch by signature (read-only) and screen
- Action `CHECK_TRANSACTION_SAFETY` — zod-schema'd tool for AI frameworks

## Verification

- `pnpm run build:plugin-misc` — clean (tsup CJS + ESM + DTS, types resolve)
- `pnpm run lint` (biome) — clean on the new files
- Logic verified at runtime against 8 cases (clean allow, unknown program, setAuthority, unlimited delegate, full-balance drain, bounded-approve warn, cumulative split-drain, RPC fail-safe) — **8/8 pass**

## Notes

- Lives under `packages/plugin-misc/src/txguard/`, registered in the misc plugin's `methods` + `actions` following the existing per-integration `tools/` + `actions/` pattern.
- Zero new dependencies; stdlib + existing `zod`.
