### PR TITLE
feat(plugin-misc): add transaction simulation pre-flight skill

### DIFF
--- a/packages/plugin-misc/src/index.ts
+++ b/packages/plugin-misc/src/index.ts
@@ -204,6 +204,10 @@ import {
   verify_program,
 } from "./ottersec/tools";
 
+import { simulateTransactionPreflight } from "./txsim/tools";
+
+import { simulateTransactionAction } from "./txsim/actions";
+
 import createVerificationPdaAction from "./ottersec/actions/createVerificationPda";
 import decodeVerificationPdaDataAction from "./ottersec/actions/decodeVerificationPdaData";
 import getProgramBuildLogAction from "./ottersec/actions/getProgramBuildLog";
@@ -300,6 +304,7 @@ const MiscPlugin = {
     get_verification_job_status,
     get_verified_programs,
     verify_program,
+    simulateTransactionPreflight,
   },
 
   // Combine all actions
@@ -379,6 +384,7 @@ const MiscPlugin = {
     getVerificationJobStatusAction,
     getVerifiedProgramsAction,
     verifyProgramAction,
+    simulateTransactionAction,
   ],
 
   // Initialize function

--- a/packages/plugin-misc/src/txsim/actions/index.ts
+++ b/packages/plugin-misc/src/txsim/actions/index.ts
@@ -1,0 +1,1 @@
+export { default as simulateTransactionAction } from "./simulateTransaction";

--- a/packages/plugin-misc/src/txsim/actions/simulateTransaction.ts
+++ b/packages/plugin-misc/src/txsim/actions/simulateTransaction.ts
@@ -1,0 +1,58 @@
+import { Action, SolanaAgentKit } from "solana-agent-kit";
+import { z } from "zod";
+import { simulateTransactionPreflight } from "../tools";
+
+const simulateTransaction: Action = {
+  name: "SIMULATE_TRANSACTION",
+  description:
+    "Simulate a serialized (base64) Solana transaction against current chain state before signing or sending it. Returns whether it would succeed, the compute units it would consume, and the program logs. Use this as a pre-flight check to avoid paying fees on transactions that would fail. Fail-safe: any deserialize or RPC error returns willSucceed=false.",
+  similes: [
+    "simulate a transaction before sending",
+    "dry run a solana transaction",
+    "pre-flight check a transaction",
+    "will this transaction succeed",
+  ],
+  examples: [
+    [
+      {
+        input: {
+          transaction: "AQAAAAAAAAAAAA...base64SerializedTx...",
+        },
+        output: {
+          status: "success",
+          willSucceed: true,
+          error: null,
+          unitsConsumed: 4521,
+          logs: ["Program 11111111111111111111111111111111 invoke [1]"],
+          summary: "✅ transaction would succeed (4521 compute units)",
+        },
+        explanation:
+          "Simulate a base64-serialized transaction to confirm it would succeed before signing and sending it",
+      },
+    ],
+  ],
+  schema: z.object({
+    transaction: z
+      .string()
+      .describe("Base64-encoded serialized transaction to simulate"),
+  }),
+  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+    try {
+      const { transaction } = input;
+      const result = await simulateTransactionPreflight(agent, transaction);
+
+      return {
+        status: "success",
+        ...result,
+      };
+    } catch (error: any) {
+      return {
+        status: "error",
+        message: `Failed to simulate transaction: ${error.message}`,
+        code: error.code || "SIMULATE_TRANSACTION_FAILED",
+      };
+    }
+  },
+};
+
+export default simulateTransaction;

--- a/packages/plugin-misc/src/txsim/tools/index.ts
+++ b/packages/plugin-misc/src/txsim/tools/index.ts
@@ -1,0 +1,1 @@
+export * from "./simulate_transaction";

--- a/packages/plugin-misc/src/txsim/tools/simulate_transaction.ts
+++ b/packages/plugin-misc/src/txsim/tools/simulate_transaction.ts
@@ -1,0 +1,109 @@
+import { Transaction, VersionedTransaction } from "@solana/web3.js";
+import type { SolanaAgentKit } from "solana-agent-kit";
+
+/**
+ * Structured, fail-safe result of a transaction simulation.
+ */
+export interface SimulateTransactionResult {
+  willSucceed: boolean;
+  error: string | null;
+  unitsConsumed: number | null;
+  logs: string[];
+  summary: string;
+}
+
+/**
+ * @name        simulateTransactionPreflight
+ * @description Simulate a serialized transaction against the current chain
+ *              state before signing or sending it. Supports both legacy
+ *              `Transaction` and `VersionedTransaction`. Never throws: any
+ *              deserialize or RPC failure resolves to a fail-safe result with
+ *              `willSucceed: false` so callers never assume an unsimulated
+ *              transaction is safe.
+ * @param       agent     SolanaAgentKit instance (provides the RPC connection)
+ * @param       base64Tx  Base64-encoded serialized transaction
+ * @param       opts      Optional flags (e.g. include logs, default true)
+ * @returns     A structured {@link SimulateTransactionResult}
+ */
+export async function simulateTransactionPreflight(
+  agent: SolanaAgentKit,
+  base64Tx: string,
+  opts?: { includeLogs?: boolean },
+): Promise<SimulateTransactionResult> {
+  const includeLogs = opts?.includeLogs ?? true;
+
+  const failSafe = (message: string): SimulateTransactionResult => {
+    return {
+      willSucceed: false,
+      error: message,
+      unitsConsumed: null,
+      logs: [],
+      summary: "⛔ could not simulate — do not assume safe",
+    };
+  };
+
+  let rawTx: Buffer;
+  try {
+    rawTx = Buffer.from(base64Tx, "base64");
+    if (rawTx.length === 0) {
+      return failSafe("empty or invalid base64 transaction");
+    }
+  } catch (error: any) {
+    return failSafe(`invalid base64 input: ${error?.message ?? error}`);
+  }
+
+  try {
+    let value: {
+      err: unknown;
+      logs: string[] | null;
+      unitsConsumed?: number;
+    };
+
+    try {
+      // Try versioned transaction first.
+      const versionedTx = VersionedTransaction.deserialize(rawTx);
+      const result = await agent.connection.simulateTransaction(versionedTx, {
+        sigVerify: false,
+        replaceRecentBlockhash: true,
+      });
+      value = result.value;
+    } catch {
+      // Fall back to a legacy transaction.
+      const legacyTx = Transaction.from(rawTx);
+      const result = await agent.connection.simulateTransaction(legacyTx);
+      value = result.value;
+    }
+
+    const logs = includeLogs ? (value.logs ?? []) : [];
+    const unitsConsumed =
+      typeof value.unitsConsumed === "number" ? value.unitsConsumed : null;
+
+    if (value.err) {
+      return {
+        willSucceed: false,
+        error:
+          typeof value.err === "string" ? value.err : JSON.stringify(value.err),
+        unitsConsumed,
+        logs,
+        summary: "❌ transaction would fail — sending it will likely cost fees",
+      };
+    }
+
+    return {
+      willSucceed: true,
+      error: null,
+      unitsConsumed,
+      logs,
+      summary:
+        unitsConsumed !== null
+          ? `✅ transaction would succeed (${unitsConsumed} compute units)`
+          : "✅ transaction would succeed",
+    };
+  } catch (error: any) {
+    return failSafe(
+      `could not deserialize or simulate transaction: ${
+        error?.message ?? error
+      }`,
+    );
+  }
+}


### PR DESCRIPTION
## What

Adds a new `SIMULATE_TRANSACTION` agent skill to `plugin-misc`: a transaction simulation **pre-flight** action.

Given a base64-encoded serialized transaction, it simulates it against current chain state and returns a clean structured result:

```ts
{
  willSucceed: boolean,
  error: string | null,
  unitsConsumed: number | null,
  logs: string[],
  summary: string
}
```

It supports **both** legacy `Transaction` and `VersionedTransaction` (tries `VersionedTransaction.deserialize` first, falls back to `Transaction.from`), and uses `{ sigVerify: false, replaceRecentBlockhash: true }` for versioned transactions so unsigned/about-to-be-built transactions can be checked.

## Why

This is the runtime complement to static safety checks: an agent can dry-run a transaction **before** signing or sending it.

- Avoids paying fees on transactions that would fail on-chain.
- Surfaces compute-unit usage and program logs for debugging/observability.
- Lets an agent reason about outcome before committing.

`core/src/utils/send_tx.ts` simulates internally as part of sending, but there was no standalone, agent-callable simulation skill — this fills that gap.

## API

- Tool: `simulateTransactionPreflight(agent, base64Tx, opts?)`
- Action: `SIMULATE_TRANSACTION` (zod schema `{ transaction: string }`)

Both are wired into the misc plugin's `methods` and `actions`, following the existing `ottersec` integration pattern (`tools/` + `actions/` + index registration).

## Fail-safe by design

The tool **never throws**. Any deserialize or RPC failure resolves to `willSucceed: false` with `summary: "⛔ could not simulate — do not assume safe"`, so a caller can never mistake an unsimulated transaction for a safe one.

## Verification done

- `pnpm run build:core` and `pnpm run build:plugin-misc` — clean (CJS + ESM + DTS).
- `biome check` on the new files + `index.ts` — clean (matches repo style).
- Runtime smoke test of the fail-safe path (garbage / empty base64 → `willSucceed: false`, never throws) — passes.
- **Zero new dependencies** (uses `@solana/web3.js`, already a dependency).
