### PR TITLE
feat(plugin-misc): add transaction destination safety check

### DIFF
--- a/packages/plugin-misc/src/index.ts
+++ b/packages/plugin-misc/src/index.ts
@@ -212,6 +212,10 @@ import getVerificationJobStatusAction from "./ottersec/actions/getVerificationJo
 import getVerifiedProgramsAction from "./ottersec/actions/getVerifiedPrograms";
 import verifyProgramAction from "./ottersec/actions/verifyProgram";
 
+import { checkDestination, checkDestinationOnChain } from "./txdest/tools";
+
+import { checkDestinationAction } from "./txdest/actions";
+
 // Define and export the plugin
 const MiscPlugin = {
   name: "misc",
@@ -300,6 +304,8 @@ const MiscPlugin = {
     get_verification_job_status,
     get_verified_programs,
     verify_program,
+    checkDestination,
+    checkDestinationOnChain,
   },
 
   // Combine all actions
@@ -379,6 +385,7 @@ const MiscPlugin = {
     getVerificationJobStatusAction,
     getVerifiedProgramsAction,
     verifyProgramAction,
+    checkDestinationAction,
   ],
 
   // Initialize function

--- a/packages/plugin-misc/src/txdest/actions/checkDestination.ts
+++ b/packages/plugin-misc/src/txdest/actions/checkDestination.ts
@@ -1,0 +1,121 @@
+import { Action, SolanaAgentKit } from "solana-agent-kit";
+import { z } from "zod";
+import { checkDestination, checkDestinationOnChain } from "../tools";
+
+const checkDestinationAction: Action = {
+  name: "CHECK_DESTINATION_SAFETY",
+  description:
+    "Validate a transfer destination address before sending SOL or SPL tokens to it. Catches costly, unrecoverable mistakes: invalid / non-canonical pubkeys, addresses not on the ed25519 curve (no signer can ever move the funds), known program / system / burn addresses, and — when on-chain checks are enabled — non-existent destinations or sending to an SPL mint account. Returns a structured verdict (allow/warn/halt). Fail-safe: unparseable or unknown input never returns a clean allow. Use this as a pre-flight before any transfer.",
+  similes: [
+    "is this address safe to send to",
+    "validate a recipient address before transfer",
+    "check transfer destination",
+    "pre-flight a payout address",
+    "verify wallet address before sending SOL",
+  ],
+  examples: [
+    [
+      {
+        input: {
+          address: "7oDgMfFRHyVVP7YQT6Kywe2Uj37rKWkpThFMpGQBzxyG",
+        },
+        output: {
+          status: "success",
+          ok: true,
+          verdict: "allow",
+          flags: [],
+          summary:
+            "✅ 7oDgMfFRHyVVP7YQT6Kywe2Uj37rKWkpThFMpGQBzxyG looks like a normal, signable wallet address",
+        },
+        explanation:
+          "A normal wallet address with no on-chain lookup passes the static safety check",
+      },
+    ],
+    [
+      {
+        input: {
+          address: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+        },
+        output: {
+          status: "success",
+          ok: false,
+          verdict: "halt",
+          flags: [
+            {
+              code: "KNOWN_PROGRAM_ADDRESS",
+              severity: "halt",
+              message:
+                "destination is the SPL Token Program; transferring funds here is almost certainly a mistake and likely unrecoverable",
+            },
+          ],
+          summary: "⛔ unsafe destination (1 issue) — do not send",
+        },
+        explanation:
+          "Transferring to a well-known program address is flagged as a halt",
+      },
+    ],
+    [
+      {
+        input: {
+          address: "So11111111111111111111111111111111111111112",
+          onChain: true,
+        },
+        output: {
+          status: "success",
+          ok: false,
+          verdict: "halt",
+          flags: [
+            {
+              code: "DESTINATION_IS_MINT",
+              severity: "halt",
+              message:
+                "destination is an SPL token MINT account; sending SOL or tokens to a mint is a classic, unrecoverable loss",
+            },
+          ],
+          summary: "⛔ unsafe destination (1 issue) — do not send",
+        },
+        explanation:
+          "With on-chain checks enabled, sending to a mint account is halted",
+      },
+    ],
+  ],
+  schema: z.object({
+    address: z
+      .string()
+      .describe("The destination wallet address (base58) to validate"),
+    isNativeSol: z
+      .boolean()
+      .optional()
+      .describe(
+        "Whether the planned transfer is native SOL (vs an SPL token). Defaults to true.",
+      ),
+    onChain: z
+      .boolean()
+      .optional()
+      .describe(
+        "If true, also run RPC enrichment (mint / non-existent / token-account checks) using the agent connection. Defaults to false (offline static check only).",
+      ),
+  }),
+  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+    try {
+      const { address, isNativeSol, onChain } = input;
+      const opts = { isNativeSol };
+      const result = onChain
+        ? await checkDestinationOnChain(agent, address, opts)
+        : checkDestination(address, opts);
+
+      return {
+        status: "success",
+        ...result,
+      };
+    } catch (error: any) {
+      return {
+        status: "error",
+        message: `Failed to check destination safety: ${error.message}`,
+        code: error.code || "CHECK_DESTINATION_SAFETY_FAILED",
+      };
+    }
+  },
+};
+
+export default checkDestinationAction;

--- a/packages/plugin-misc/src/txdest/actions/index.ts
+++ b/packages/plugin-misc/src/txdest/actions/index.ts
@@ -1,0 +1,1 @@
+export { default as checkDestinationAction } from "./checkDestination";

--- a/packages/plugin-misc/src/txdest/tools/check_destination.ts
+++ b/packages/plugin-misc/src/txdest/tools/check_destination.ts
@@ -1,0 +1,281 @@
+import { PublicKey } from "@solana/web3.js";
+import type { SolanaAgentKit } from "solana-agent-kit";
+
+/**
+ * A single thing that looks wrong about a destination address.
+ */
+export interface DestinationFlag {
+  /** Stable machine-readable code, e.g. "INVALID_PUBKEY". */
+  code: string;
+  /** Severity that drives the overall verdict. */
+  severity: "warn" | "halt";
+  /** Human-readable explanation of the risk. */
+  message: string;
+}
+
+/**
+ * Structured, fail-safe verdict for a transfer destination.
+ *
+ * `ok` is only `true` for a clean `allow` — any `warn` or `halt` sets it
+ * `false` so a caller that only checks `ok` never silently proceeds.
+ */
+export interface DestinationVerdict {
+  ok: boolean;
+  verdict: "allow" | "warn" | "halt";
+  flags: DestinationFlag[];
+  summary: string;
+}
+
+/** Options for the deterministic destination check. */
+export interface CheckDestinationOptions {
+  /**
+   * Whether the transfer being guarded is native SOL (as opposed to an SPL
+   * token). Used to refine on-curve / system-account warnings. Defaults to
+   * `true` because plain SOL transfers are the most common foot-gun.
+   */
+  isNativeSol?: boolean;
+}
+
+/**
+ * Well-known on-chain program / system addresses. Transferring funds *to* any
+ * of these is almost always a mistake (the value becomes unrecoverable or is
+ * simply lost), so we surface them by name.
+ */
+const KNOWN_ADDRESSES: Record<string, string> = {
+  "11111111111111111111111111111111": "System Program",
+  TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA: "SPL Token Program",
+  TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb: "SPL Token-2022 Program",
+  ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL:
+    "Associated Token Account Program",
+  MemoSq4gq4W8V86CFiK2yPPwj6Wb8gT1n1z4Bz2EHrx: "SPL Memo Program",
+  Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo: "SPL Memo Program (v1)",
+  ComputeBudget111111111111111111111111111111: "Compute Budget Program",
+  Sysvar1111111111111111111111111111111111111: "Sysvar (system variable)",
+  Stake11111111111111111111111111111111111111: "Stake Program",
+  Vote111111111111111111111111111111111111111: "Vote Program",
+  BPFLoaderUpgradeab1e11111111111111111111111: "BPF Upgradeable Loader",
+  metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s: "Metaplex Token Metadata",
+};
+
+/**
+ * Burn-shaped addresses: structurally valid-looking but no one holds the key,
+ * so funds sent here are gone forever. The all-zeros address is the System
+ * Program (handled above); the all-ones address is the canonical "incinerator"
+ * shape that agents sometimes produce from a default/placeholder value.
+ */
+const BURN_SHAPED = new Set<string>([
+  "1nc1nerator11111111111111111111111111111111", // SOL incinerator
+]);
+
+const failSafe = (message: string): DestinationVerdict => ({
+  ok: false,
+  verdict: "halt",
+  flags: [{ code: "UNPARSEABLE", severity: "halt", message }],
+  summary: `⛔ ${message} — refusing to treat destination as safe`,
+});
+
+/**
+ * @name        checkDestination
+ * @description Deterministic, offline safety check for a transfer destination
+ *              address. Catches the costly mistakes that happen *before* any
+ *              RPC call is even needed: a malformed pubkey, an address that is
+ *              not on the ed25519 curve (so no one can ever sign for it), a
+ *              known program / system address, or a burn-shaped address.
+ *
+ *              Never throws. An unparseable address resolves to a `halt`
+ *              verdict rather than an exception, so callers that only inspect
+ *              the result can never accidentally proceed on bad input.
+ * @param       address  The candidate destination address (base58 string).
+ * @param       opts     Optional {@link CheckDestinationOptions}.
+ * @returns     A structured {@link DestinationVerdict}.
+ */
+export function checkDestination(
+  address: string,
+  opts: CheckDestinationOptions = {},
+): DestinationVerdict {
+  const isNativeSol = opts.isNativeSol ?? true;
+
+  if (typeof address !== "string" || address.trim().length === 0) {
+    return failSafe("empty destination address");
+  }
+  const trimmed = address.trim();
+
+  let pubkey: PublicKey;
+  try {
+    pubkey = new PublicKey(trimmed);
+  } catch (error: any) {
+    return failSafe(
+      `invalid base58 / not a valid Solana address: ${error?.message ?? error}`,
+    );
+  }
+
+  // PublicKey accepts some inputs that re-serialize differently (e.g. wrong
+  // length decoded leniently). Require a canonical round-trip.
+  if (pubkey.toBase58() !== trimmed) {
+    return failSafe(
+      `address is not in canonical base58 form (got "${trimmed}", canonical "${pubkey.toBase58()}")`,
+    );
+  }
+
+  const flags: DestinationFlag[] = [];
+  const base58 = pubkey.toBase58();
+
+  // 1. Known program / system address.
+  const knownName = KNOWN_ADDRESSES[base58];
+  if (knownName) {
+    flags.push({
+      code: "KNOWN_PROGRAM_ADDRESS",
+      severity: "halt",
+      message: `destination is the ${knownName}; transferring funds here is almost certainly a mistake and likely unrecoverable`,
+    });
+  }
+
+  // 2. Burn-shaped address.
+  if (BURN_SHAPED.has(base58)) {
+    flags.push({
+      code: "BURN_ADDRESS",
+      severity: "halt",
+      message:
+        "destination is a burn / incinerator address; funds sent here are permanently destroyed",
+    });
+  }
+
+  // 3. Off-curve address. An address not on the ed25519 curve has no
+  //    corresponding private key, so for a *native SOL* transfer the recipient
+  //    can never move the funds. This is exactly the shape of a PDA / ATA
+  //    pasted where a wallet was expected.
+  if (!PublicKey.isOnCurve(pubkey.toBytes())) {
+    flags.push({
+      code: "OFF_CURVE_ADDRESS",
+      severity: isNativeSol ? "halt" : "warn",
+      message: isNativeSol
+        ? "destination is off the ed25519 curve (a program-derived / non-wallet address); a native SOL transfer here would be unrecoverable. If you meant a token account, verify it is the correct ATA."
+        : "destination is off the ed25519 curve (likely a token account or PDA); confirm this is the intended account and not a wallet address",
+    });
+  }
+
+  return verdictFromFlags(flags, base58);
+}
+
+/**
+ * Collapse a set of flags into a final verdict. `halt` dominates `warn`, which
+ * dominates `allow`.
+ */
+function verdictFromFlags(
+  flags: DestinationFlag[],
+  base58: string,
+): DestinationVerdict {
+  if (flags.some((f) => f.severity === "halt")) {
+    return {
+      ok: false,
+      verdict: "halt",
+      flags,
+      summary: `⛔ unsafe destination (${flags.length} issue${flags.length === 1 ? "" : "s"}) — do not send`,
+    };
+  }
+  if (flags.length > 0) {
+    return {
+      ok: false,
+      verdict: "warn",
+      flags,
+      summary: `⚠️ destination needs review (${flags.length} warning${flags.length === 1 ? "" : "s"}) — confirm before sending`,
+    };
+  }
+  return {
+    ok: true,
+    verdict: "allow",
+    flags: [],
+    summary: `✅ ${base58} looks like a normal, signable wallet address`,
+  };
+}
+
+/**
+ * @name        checkDestinationOnChain
+ * @description The deterministic {@link checkDestination} check *plus* RPC
+ *              enrichment using the agent's connection. Adds checks that need
+ *              chain state: a non-existent / zero-lamport destination (warn),
+ *              and — the classic loss — a destination that is itself an SPL
+ *              **mint** account (halt; sending SOL or tokens to a mint burns
+ *              them). Also warns when sending native SOL to an address owned by
+ *              the Token program.
+ *
+ *              Never throws. If the static check already halts, or if the RPC
+ *              call fails, the result stays fail-safe (no silent upgrade to a
+ *              clean allow on RPC failure).
+ * @param       agent    SolanaAgentKit instance (provides the RPC connection).
+ * @param       address  The candidate destination address (base58 string).
+ * @param       opts     Optional {@link CheckDestinationOptions}.
+ * @returns     A structured {@link DestinationVerdict}.
+ */
+export async function checkDestinationOnChain(
+  agent: SolanaAgentKit,
+  address: string,
+  opts: CheckDestinationOptions = {},
+): Promise<DestinationVerdict> {
+  const isNativeSol = opts.isNativeSol ?? true;
+  const staticVerdict = checkDestination(address, opts);
+
+  // If the address is already unparseable or a known program/burn address,
+  // there is nothing useful (or safe) to add from RPC.
+  if (staticVerdict.verdict === "halt") {
+    return staticVerdict;
+  }
+
+  const flags: DestinationFlag[] = [...staticVerdict.flags];
+  const pubkey = new PublicKey(address.trim());
+
+  let info: Awaited<
+    ReturnType<typeof agent.connection.getParsedAccountInfo>
+  >["value"];
+  try {
+    const resp = await agent.connection.getParsedAccountInfo(pubkey);
+    info = resp.value;
+  } catch (error: any) {
+    flags.push({
+      code: "RPC_LOOKUP_FAILED",
+      severity: "warn",
+      message: `could not verify destination on-chain (${error?.message ?? error}); proceeding only after manual confirmation`,
+    });
+    return verdictFromFlags(flags, pubkey.toBase58());
+  }
+
+  if (info === null) {
+    // Non-existent account. Legal for a first SOL transfer (it gets created),
+    // but a frequent symptom of a typo'd address, so warn rather than halt.
+    flags.push({
+      code: "DESTINATION_NOT_FOUND",
+      severity: "warn",
+      message:
+        "destination account does not exist yet / holds 0 lamports; valid for a first SOL transfer but a common symptom of a mistyped address — double-check it",
+    });
+    return verdictFromFlags(flags, pubkey.toBase58());
+  }
+
+  const owner = info.owner.toBase58();
+  const isTokenOwned =
+    owner === "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA" ||
+    owner === "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
+
+  // Detect a mint account via the parsed data shape.
+  const parsed =
+    info.data && "parsed" in info.data ? (info.data.parsed as any) : null;
+  const isMint = parsed?.type === "mint";
+
+  if (isMint) {
+    flags.push({
+      code: "DESTINATION_IS_MINT",
+      severity: "halt",
+      message:
+        "destination is an SPL token MINT account; sending SOL or tokens to a mint is a classic, unrecoverable loss",
+    });
+  } else if (isTokenOwned && isNativeSol) {
+    flags.push({
+      code: "NATIVE_SOL_TO_TOKEN_ACCOUNT",
+      severity: "warn",
+      message:
+        "destination is owned by the Token program (a token account), but you are sending native SOL; confirm you do not mean the owning wallet instead",
+    });
+  }
+
+  return verdictFromFlags(flags, pubkey.toBase58());
+}

--- a/packages/plugin-misc/src/txdest/tools/index.ts
+++ b/packages/plugin-misc/src/txdest/tools/index.ts
@@ -1,0 +1,1 @@
+export * from "./check_destination";


### PR DESCRIPTION
## What

Adds a deterministic, fail-safe **destination/recipient safety check** for transfers, registered in `plugin-misc` as the tool methods `checkDestination` / `checkDestinationOnChain` and the AI action `CHECK_DESTINATION_SAFETY`.

Before an agent sends SOL or SPL tokens to an address, this catches the common, costly, and often **unrecoverable** mistakes:

**Offline (deterministic, no RPC):**
- Invalid / non-canonical base58 pubkey → `halt`
- Address **not on the ed25519 curve** (`PublicKey.isOnCurve`) — a PDA/ATA pasted where a wallet was expected; a native SOL transfer there can never be signed for → `halt` (SOL) / `warn` (token)
- Known **program / system addresses** (System, SPL Token, Token-2022, ATA, Memo, ComputeBudget, Sysvar, Stake, Vote, BPF Loader, Metaplex) → `halt`
- Burn / incinerator-shaped address → `halt`

**On-chain (optional, via `agent.connection`):**
- Destination account does not exist / 0 lamports → `warn` (valid for a first SOL transfer, but a frequent typo symptom)
- Destination **is an SPL mint** account (sending SOL/tokens to a mint is a classic loss) → `halt`
- Sending **native SOL to a token-program-owned account** → `warn`

## Why

Mis-sends to programs, mints, or off-curve addresses are silent and permanent — the agent pays the fee and the funds are gone. A cheap pre-flight check turns an unrecoverable loss into a structured refusal.

## API

```ts
// deterministic, offline
checkDestination(address: string, opts?: { isNativeSol?: boolean }): DestinationVerdict

// + RPC enrichment using agent.connection
checkDestinationOnChain(agent, address, opts?): Promise<DestinationVerdict>

// verdict shape
{ ok: boolean; verdict: "allow" | "warn" | "halt"; flags: { code, severity, message }[]; summary: string }
```

Fail-safe by construction: unparseable / unknown / RPC-failure input never returns a clean `allow` — it degrades to `warn` or `halt`. `ok` is only `true` for a clean `allow`.

## Verification
- `pnpm run build:core` + `pnpm run build:plugin-misc` clean (CJS + ESM + DTS)
- `biome check` clean on the new files
- Runtime smoke verified: off-curve/invalid → halt, known program address → halt, burn address → halt, a normal valid wallet → allow; all 13 hardcoded program/burn addresses asserted to be canonical pubkeys (caught and fixed one bad constant before shipping)
- **Zero new dependencies** (uses the existing `@solana/web3.js` `PublicKey`)
- Follows the existing `ottersec` / plugin tool+action structure and registration

## Context

Completes a small **safety trilogy** alongside our other agent-safety skills (static drain check / runtime simulation): this one guards the *destination* of a transfer before signing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)