### PR TITLE
Add SVS verified action example

### DIFF
--- a/examples/misc/svs-verified-action/.env.example
+++ b/examples/misc/svs-verified-action/.env.example
@@ -1,0 +1,9 @@
+SVS_SERVER_URL=https://your-svs-api.example.com
+SVS_BOT_ID=your-svs-bot-id
+SVS_BOT_POLICY_ID=memo-human-approved-v1
+SVS_BOT_API_KEY=replace-with-svs-issued-api-key
+SVS_BOT_REQUEST_SIGNING_SECRET=replace-with-svs-issued-request-signing-secret
+SVS_BOT_EXPECTED_INTEGRATION_CONTRACT_HASH=replace-with-current-contract-hash
+SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
+SVS_SERIALIZED_TRANSACTION_BASE64=replace-with-prepared-serialized-transaction
+SVS_RUN_LIVE_SUBMIT=false

--- a/examples/misc/svs-verified-action/README.md
+++ b/examples/misc/svs-verified-action/README.md
@@ -1,0 +1,108 @@
+# SVS Verified Action Example For Solana Agent Kit
+
+This directory is a PR-ready example package for
+`sendaifun/solana-agent-kit`. It is intentionally small so a framework
+maintainer can review it without private SVS implementation details.
+
+## What The Example Shows
+
+The example adds one Solana Agent Kit compatible tool:
+
+```text
+svs_verify_and_submit_solana_action
+```
+
+The tool is created from the public SVS package export:
+
+```sh
+npm install @svsprotocol/solana
+```
+
+```js
+import { createSvsSolanaAgentKitAdapter } from "@svsprotocol/solana/solana-agent-kit";
+```
+
+It routes a prepared Solana action through SVS so the action is not trusted
+until SVS proves signed bot identity, production certification, human wallet
+approval, policy enforcement, custom receipt-registry proof, and portable audit
+evidence.
+
+## Proposed Upstream Placement
+
+Suggested destination in a Solana Agent Kit PR:
+
+```text
+examples/misc/svs-verified-action/
+```
+
+The package is safe to copy because it uses only public dependencies and
+placeholder environment values.
+
+## Local Review
+
+From this directory:
+
+```sh
+npm install
+npm run validate
+```
+
+## Run Modes
+
+The default run is import validation only. It does not require SVS credentials,
+read your config, or submit an action:
+
+```sh
+node ./svs-verified-action.mjs
+```
+
+Run `npm run validate` to check the package files and placeholder env template
+before wiring the example into a live agent.
+
+## Protocol Or Wallet Gate
+
+Apps that consume agent output can reject unverified automation by pinning the
+public SVS registry and requiring the agent to be listed before accepting the
+request:
+
+```js
+import { createHostedVerifiedAgentRegistryMiddleware } from "@svsprotocol/solana/protocol";
+
+const requireVerifiedAgent = createHostedVerifiedAgentRegistryMiddleware({
+  registryUrl: "https://registry.svsprotocol.com/registry.json",
+  expectedRegistryHash: "replace-with-pinned-registry-hash",
+  trustPolicy: "standard"
+});
+
+await requireVerifiedAgent({
+  botId: "svs-demo-devnet-agent",
+  protocolId: "your-protocol-or-wallet"
+});
+```
+
+If the registry hash, linked profile, trust manifest, freshness policy, or bot
+listing does not verify, the middleware throws and the app should reject the
+agent-submitted action.
+
+Live submission is opt-in:
+
+```sh
+SVS_RUN_LIVE_SUBMIT=true node ./svs-verified-action.mjs
+```
+
+Live mode requires an SVS endpoint, bot API key, request-signing secret, current
+integration-contract hash, and a prepared serialized transaction. Do not commit
+those values.
+
+## Public SVS References
+
+- Docs: <https://svsprotocol.com/docs>
+- Registry: <https://registry.svsprotocol.com/registry.json>
+- Verified Agent Standard: <https://svsprotocol.com/docs#verified-agent-standard>
+- Public verifier: <https://svsprotocol.com/verify>
+
+## Boundary
+
+This package must contain no API keys, request-signing secrets, local generated
+evidence, private implementation source, privileged routes, or private
+operational artifacts.

--- a/examples/misc/svs-verified-action/package.json
+++ b/examples/misc/svs-verified-action/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "svs-solana-agent-kit-verified-action-example",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "PR-ready Solana Agent Kit example for routing agent actions through SVS human approval and proof verification.",
+  "scripts": {
+    "validate": "node ./validate.mjs",
+    "demo": "node ./svs-verified-action.mjs"
+  },
+  "dependencies": {
+    "@svsprotocol/solana": "^0.1.0",
+    "solana-agent-kit": "^2.0.10"
+  }
+}

--- a/examples/misc/svs-verified-action/svs-verified-action.mjs
+++ b/examples/misc/svs-verified-action/svs-verified-action.mjs
@@ -1,0 +1,136 @@
+import * as SolanaAgentKit from "solana-agent-kit";
+import {
+  SOLANA_AGENT_KIT_ADAPTER_VERSION,
+  SOLANA_AGENT_KIT_TOOL_NAME,
+  createSvsSolanaAgentKitAdapter
+} from "@svsprotocol/solana/solana-agent-kit";
+
+const REQUIRED_ENV = [
+  "SVS_SERVER_URL",
+  "SVS_BOT_ID",
+  "SVS_BOT_POLICY_ID",
+  "SVS_BOT_API_KEY",
+  "SVS_BOT_REQUEST_SIGNING_SECRET",
+  "SVS_BOT_EXPECTED_INTEGRATION_CONTRACT_HASH",
+  "SOLANA_RPC_URL"
+];
+
+const LIVE_SUBMIT_REQUIRED_ENV = [
+  ...REQUIRED_ENV,
+  "SVS_SERIALIZED_TRANSACTION_BASE64"
+];
+
+export function createSvsVerifiedSolanaAgentKitTool(env = process.env) {
+  assertRequiredEnv(env);
+
+  const svsTool = createSvsSolanaAgentKitAdapter({
+    baseUrl: env.SVS_SERVER_URL,
+    apiKey: env.SVS_BOT_API_KEY,
+    requestSigningSecret: env.SVS_BOT_REQUEST_SIGNING_SECRET,
+    expectedIntegrationContractHash: env.SVS_BOT_EXPECTED_INTEGRATION_CONTRACT_HASH,
+    botId: env.SVS_BOT_ID,
+    policyId: env.SVS_BOT_POLICY_ID,
+    rpcUrl: env.SOLANA_RPC_URL,
+    waitForProof: env.SVS_WAIT_FOR_PROOF === "true",
+    fetchProof: true,
+    checkReceiptRegistryChain: true
+  });
+
+  return svsTool;
+}
+
+export async function requireSvsVerifiedAgentReady(env = process.env) {
+  const svsTool = createSvsVerifiedSolanaAgentKitTool(env);
+
+  return svsTool.requireSvsProductionReady({
+    requireNoExpiredPreviousSigningSecrets: true
+  });
+}
+
+export async function submitSvsVerifiedSolanaAction({
+  requestId,
+  intent,
+  serializedTransaction,
+  simulation,
+  metadata = {}
+}, env = process.env) {
+  const svsTool = createSvsVerifiedSolanaAgentKitTool(env);
+
+  await svsTool.requireSvsProductionReady({
+    requireNoExpiredPreviousSigningSecrets: true
+  });
+
+  return svsTool.verifyAndSubmitSolanaAction({
+    requestId,
+    idempotencyKey: requestId,
+    intent,
+    serializedTransaction,
+    simulation,
+    metadata,
+    source: {
+      agentFramework: "solana-agent-kit",
+      adapter: SOLANA_AGENT_KIT_ADAPTER_VERSION,
+      example: "svs-verified-action"
+    }
+  });
+}
+
+export function getSvsSolanaAgentKitExampleInfo() {
+  return {
+    ok: true,
+    runtime: "Solana Agent Kit",
+    hostPackageImported: typeof SolanaAgentKit === "object",
+    hostExportCount: Object.keys(SolanaAgentKit).length,
+    adapterVersion: SOLANA_AGENT_KIT_ADAPTER_VERSION,
+    toolName: SOLANA_AGENT_KIT_TOOL_NAME,
+    packageExport: "@svsprotocol/solana/solana-agent-kit",
+    liveSubmitOptIn: "SVS_RUN_LIVE_SUBMIT=true"
+  };
+}
+
+function assertRequiredEnv(env) {
+  const missing = REQUIRED_ENV.filter((name) => !env[name]);
+
+  if (missing.length > 0) {
+    throw new Error(`Missing required SVS env values: ${missing.join(", ")}`);
+  }
+}
+
+function assertLiveSubmitEnv(env) {
+  const missing = LIVE_SUBMIT_REQUIRED_ENV.filter((name) => !env[name]);
+
+  if (missing.length > 0) {
+    throw new Error(`Missing required SVS live-submit env values: ${missing.join(", ")}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const info = getSvsSolanaAgentKitExampleInfo();
+
+  if (process.env.SVS_RUN_LIVE_SUBMIT !== "true") {
+    console.log(JSON.stringify({
+      ...info,
+      status: "dry_run",
+      nextAction: "Set SVS_RUN_LIVE_SUBMIT=true only after filling real SVS credentials and a prepared transaction."
+    }, null, 2));
+    process.exit(0);
+  }
+
+  assertLiveSubmitEnv(process.env);
+
+  const result = await submitSvsVerifiedSolanaAction({
+    requestId: `svs-solana-agent-kit-${Date.now()}`,
+    intent: {
+      botId: process.env.SVS_BOT_ID,
+      type: "memo",
+      summary: "Submit a Solana Agent Kit action through SVS human approval."
+    },
+    serializedTransaction: process.env.SVS_SERIALIZED_TRANSACTION_BASE64,
+    simulation: {
+      ok: true,
+      source: "provided-by-agent"
+    }
+  });
+
+  console.log(JSON.stringify(result, null, 2));
+}

--- a/examples/misc/svs-verified-action/validate.mjs
+++ b/examples/misc/svs-verified-action/validate.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const files = {
+  readme: await readFile(new URL("./README.md", import.meta.url), "utf8"),
+  packageJson: JSON.parse(await readFile(new URL("./package.json", import.meta.url), "utf8")),
+  envExample: await readFile(new URL("./.env.example", import.meta.url), "utf8"),
+  example: await readFile(new URL("./svs-verified-action.mjs", import.meta.url), "utf8")
+};
+
+assert.equal(files.packageJson.private, true);
+assert.equal(files.packageJson.type, "module");
+assert.equal(files.packageJson.dependencies["@svsprotocol/solana"], "^0.1.0");
+assert.equal(files.packageJson.dependencies["solana-agent-kit"], "^2.0.10");
+assert.equal(files.packageJson.scripts.validate, "node ./validate.mjs");
+
+for (const required of [
+  "sendaifun/solana-agent-kit",
+  "examples/misc/svs-verified-action/",
+  "npm install @svsprotocol/solana",
+  "createHostedVerifiedAgentRegistryMiddleware",
+  "https://svsprotocol.com/docs",
+  "https://registry.svsprotocol.com/registry.json",
+  "https://svsprotocol.com/docs#verified-agent-standard",
+  "SVS_RUN_LIVE_SUBMIT=true",
+  "no API keys"
+]) {
+  assert.match(files.readme, new RegExp(escapeRegExp(required)));
+}
+
+assert.match(files.readme, /The default run is import validation only/);
+assert.doesNotMatch(files.readme, /import\/config validation only/);
+
+for (const required of [
+  "SVS_SERVER_URL",
+  "SVS_BOT_ID",
+  "SVS_BOT_POLICY_ID",
+  "SVS_BOT_API_KEY",
+  "SVS_BOT_REQUEST_SIGNING_SECRET",
+  "SVS_BOT_EXPECTED_INTEGRATION_CONTRACT_HASH",
+  "SOLANA_RPC_URL",
+  "SVS_SERIALIZED_TRANSACTION_BASE64",
+  "SVS_RUN_LIVE_SUBMIT=false"
+]) {
+  assert.match(files.envExample, new RegExp(escapeRegExp(required)));
+}
+
+for (const required of [
+  "solana-agent-kit",
+  "@svsprotocol/solana/solana-agent-kit",
+  "SOLANA_AGENT_KIT_ADAPTER_VERSION",
+  "SOLANA_AGENT_KIT_TOOL_NAME",
+  "createSvsSolanaAgentKitAdapter",
+  "requireSvsProductionReady",
+  "verifyAndSubmitSolanaAction",
+  "assertLiveSubmitEnv",
+  "SVS_SERIALIZED_TRANSACTION_BASE64",
+  "SVS_RUN_LIVE_SUBMIT"
+]) {
+  assert.match(files.example, new RegExp(escapeRegExp(required)));
+}
+
+for (const [name, text] of Object.entries({
+  readme: files.readme,
+  envExample: files.envExample,
+  example: files.example
+})) {
+  assertNoCommittedSecret(name, text);
+}
+
+console.log(JSON.stringify({
+  ok: true,
+  package: files.packageJson.name,
+  target: "sendaifun/solana-agent-kit",
+  packageExport: "@svsprotocol/solana/solana-agent-kit",
+  toolName: "svs_verify_and_submit_solana_action"
+}, null, 2));
+
+function assertNoCommittedSecret(name, text) {
+  const secretPatterns = [
+    /svs_live_[A-Za-z0-9_-]{8,}/,
+    /svs_req_live_[A-Za-z0-9_-]{8,}/,
+    /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/,
+    /\[[\d,\s]{80,}\]/
+  ];
+
+  for (const pattern of secretPatterns) {
+    assert.doesNotMatch(text, pattern, `${name} includes secret-looking material`);
+  }
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
## Summary
Adds a small example under `examples/misc/svs-verified-action/` showing how a Solana Agent Kit agent can route sensitive actions through SVS before execution.

The example covers:
- installing `@svsprotocol/solana`
- creating one Solana Agent Kit compatible SVS verification/submission tool
- checking SVS production readiness before submitting an action
- requiring a hosted SVS registry gate so protocols/wallets can reject unverified automation
- linking public SVS docs, registry, verifier, and Verified Agent Standard

## Why
Agents that can prepare Solana actions still need an application-level trust path before execution. This example shows a minimal pattern for signed bot identity, human approval, registry proof, and portable verification without changing Solana Agent Kit core.

## Scope
This is an isolated example/docs package only. It does not change core framework behavior.

## Public References
- Docs: https://svsprotocol.com/docs
- Registry: https://registry.svsprotocol.com/registry.json
- Verified Agent Standard: https://svsprotocol.com/docs#verified-agent-standard
- Verifier: https://svsprotocol.com/verify

## Validation
From `examples/misc/svs-verified-action/`:
- `npm run validate`
- `node ./svs-verified-action.mjs`

Note: installing the isolated example currently reports transitive npm audit warnings from the example dependency tree; this PR does not claim audit-clean dependency status.