### PR TITLE
feat(plugin-misc): add Wealthville pool-scoring tools

### DIFF
--- a/docs/v2/plugins/misc/misc-plugin-intro.mdx
+++ b/docs/v2/plugins/misc/misc-plugin-intro.mdx
@@ -168,5 +168,12 @@ Configure Alchemy credentials only when using these tools. RPC, price, and portf
 | `get_verified_programs` | Get list of all verified programs |
 | `verify_program` | Verify a Solana program |
 
+### Wealthville
+| Tool Name | Description |
+|-----------|-------------|
+| `getWealthvillePoolScore` | Enter/Hold/Exit verdict + 0-100 scores for one liquidity pool |
+| `getWealthvilleTopPools` | Liquidity pools ranked by composite Wealthville Score |
+| `getWealthvilleTrackRecord` | Live signal hit rates and IL-adjusted PnL, misses included |
+
 
 For more detailed information, please refer to the full documentation at [docs.sendai.fun](https://docs.sendai.fun).

--- a/packages/plugin-misc/README.md
+++ b/packages/plugin-misc/README.md
@@ -56,6 +56,13 @@ These tools are additive to the existing Helius and RPC provider integrations an
 - `parseAccount` - Parse a Solana account.
 - `parseInstruction` - Parse a Solana instruction.
 
+### Wealthville
+- `getWealthvillePoolScore` - Enter/Hold/Exit verdict + 0-100 scores for one liquidity pool (Solana or EVM).
+- `getWealthvilleTopPools` - Pools ranked by composite Wealthville Score.
+- `getWealthvilleTrackRecord` - Live signal hit rates and IL-adjusted PnL, misses included.
+
+Optional config: set `OTHER_API_KEYS.WEALTHVILLE_API_KEY` for a higher rate limit (free partner keys at [wealthville.net/developers](https://wealthville.net/developers)); anonymous access works at 60 req/min.
+
 ### Squads
 - `transferFromMultisigTreasury` - Transfer funds from a multisig treasury.
 - `rejectMultisigProposal` - Reject a multisig proposal.

--- a/packages/plugin-misc/src/index.ts
+++ b/packages/plugin-misc/src/index.ts
@@ -81,6 +81,11 @@ import parseInstructionAction from "./solanafm/actions/parseInstruction";
 // messari
 import getMessariAiAction from "./messari/actions/askMessariAi";
 
+// wealthville
+import getWealthvillePoolScoreAction from "./wealthville/actions/getWealthvillePoolScore";
+import getWealthvilleTopPoolsAction from "./wealthville/actions/getWealthvilleTopPools";
+import getWealthvilleTrackRecordAction from "./wealthville/actions/getWealthvilleTrackRecord";
+
 import {
   alchemyCreateAddressActivityWebhook,
   alchemyCreateWebhook,
@@ -140,6 +145,11 @@ import {
   sendTransactionWithPriorityFee,
 } from "./helius/tools";
 import { askMessariAi } from "./messari/tools";
+import {
+  getWealthvillePoolScore,
+  getWealthvilleTopPools,
+  getWealthvilleTrackRecord,
+} from "./wealthville/tools";
 import {
   getAllRegisteredAllDomains,
   getMainAllDomainsDomain,
@@ -279,6 +289,9 @@ const MiscPlugin = {
     parseAccountUsingSolanaFM,
     parseInstructionUsingSolanaFM,
     askMessariAi,
+    getWealthvillePoolScore,
+    getWealthvilleTopPools,
+    getWealthvilleTrackRecord,
     checkout,
     confirmOrder,
     fetch_oldest_tokens,
@@ -358,6 +371,9 @@ const MiscPlugin = {
     parseAccountAction,
     parseInstructionAction,
     getMessariAiAction,
+    getWealthvillePoolScoreAction,
+    getWealthvilleTopPoolsAction,
+    getWealthvilleTrackRecordAction,
     checkoutAction,
     confirmOrderAction,
     fetchOldestTokensAction,

--- a/packages/plugin-misc/src/wealthville/actions/getWealthvillePoolScore.ts
+++ b/packages/plugin-misc/src/wealthville/actions/getWealthvillePoolScore.ts
@@ -1,0 +1,58 @@
+import { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { getWealthvillePoolScore } from "../tools";
+import { WEALTHVILLE_DISCLAIMER } from "../utils";
+
+const getWealthvillePoolScoreAction: Action = {
+  name: "WEALTHVILLE_GET_POOL_SCORE",
+  similes: [
+    "check pool score",
+    "is this pool safe to LP",
+    "pool quality rating",
+    "should I provide liquidity to this pool",
+    "wealthville verdict for pool",
+  ],
+  description:
+    "Get the Wealthville verdict (ENTER/HOLD/EXIT/AVOID) and 0-100 action scores for one liquidity pool. " +
+    "Useful before opening or recommending any LP position. Accepts a Solana base58 pool address, " +
+    "an EVM 0x address, or a DefiLlama pool UUID. Scores are backed by a public, miss-inclusive " +
+    "track record at wealthville.net/track-record.",
+  examples: [
+    [
+      {
+        input: { poolAddress: "Czfq3xZZDmsdGdUyrNLtRhGc47cXcZtLG4crryfu44zE" },
+        output: {
+          status: "success",
+          pool_name: "SOL/USDC",
+          protocol: "orca-whirlpool",
+          verdict: "ENTER",
+          wealthville_score: 92,
+          enter_score: 91,
+          hold_score: 93,
+          exit_score: 6,
+        },
+        explanation:
+          "SOL/USDC on Orca is rated ENTER with a composite Wealthville Score of 92/100.",
+      },
+    ],
+  ],
+  schema: z.object({
+    poolAddress: z
+      .string()
+      .min(8)
+      .describe("Pool address: Solana base58, EVM 0x, or DefiLlama UUID"),
+  }),
+  handler: async (agent, input: Record<string, any>) => {
+    try {
+      const data = await getWealthvillePoolScore(
+        agent,
+        String(input.poolAddress),
+      );
+      return { status: "success", ...data, disclaimer: WEALTHVILLE_DISCLAIMER };
+    } catch (error: any) {
+      return { status: "error", message: error.message };
+    }
+  },
+};
+
+export default getWealthvillePoolScoreAction;

--- a/packages/plugin-misc/src/wealthville/actions/getWealthvilleTopPools.ts
+++ b/packages/plugin-misc/src/wealthville/actions/getWealthvilleTopPools.ts
@@ -1,0 +1,78 @@
+import { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { getWealthvilleTopPools } from "../tools";
+import { WEALTHVILLE_DISCLAIMER } from "../utils";
+
+const getWealthvilleTopPoolsAction: Action = {
+  name: "WEALTHVILLE_GET_TOP_POOLS",
+  similes: [
+    "best liquidity pools right now",
+    "top rated LP pools",
+    "where should I LP",
+    "highest scored pools on solana",
+    "top pools by wealthville score",
+  ],
+  description:
+    "List liquidity pools ranked by composite Wealthville Score (0-100), freshly scored within " +
+    "the last 6 hours. Covers Raydium, Orca and Meteora on Solana plus major EVM chains.",
+  examples: [
+    [
+      {
+        input: { limit: 3 },
+        output: {
+          status: "success",
+          scores: [
+            {
+              pool_name: "SOL/USDC",
+              protocol: "raydium-clmm",
+              verdict: "ENTER",
+              wealthville_score: 94,
+            },
+            {
+              pool_name: "SOL/USDC",
+              protocol: "meteora-dlmm",
+              verdict: "ENTER",
+              wealthville_score: 93,
+            },
+            {
+              pool_name: "SOL/USDC",
+              protocol: "orca-whirlpool",
+              verdict: "ENTER",
+              wealthville_score: 92,
+            },
+          ],
+        },
+        explanation: "The three highest-scored Solana pools right now.",
+      },
+    ],
+  ],
+  schema: z.object({
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe("How many pools to return (default 25)"),
+    chain: z
+      .string()
+      .optional()
+      .describe(
+        '"solana" (default), "evm" for all EVM chains, or one EVM chain name like "base"',
+      ),
+  }),
+  handler: async (agent, input: Record<string, any>) => {
+    try {
+      const data = await getWealthvilleTopPools(
+        agent,
+        input.limit ?? 25,
+        input.chain ?? "solana",
+      );
+      return { status: "success", ...data, disclaimer: WEALTHVILLE_DISCLAIMER };
+    } catch (error: any) {
+      return { status: "error", message: error.message };
+    }
+  },
+};
+
+export default getWealthvilleTopPoolsAction;

--- a/packages/plugin-misc/src/wealthville/actions/getWealthvilleTrackRecord.ts
+++ b/packages/plugin-misc/src/wealthville/actions/getWealthvilleTrackRecord.ts
@@ -1,0 +1,59 @@
+import { Action } from "solana-agent-kit";
+import { z } from "zod";
+import { getWealthvilleTrackRecord } from "../tools";
+import { WEALTHVILLE_DISCLAIMER } from "../utils";
+
+const getWealthvilleTrackRecordAction: Action = {
+  name: "WEALTHVILLE_GET_TRACK_RECORD",
+  similes: [
+    "wealthville score accuracy",
+    "can I trust these pool scores",
+    "LP signal hit rate",
+    "how has the ENTER signal performed",
+  ],
+  description:
+    "Get Wealthville's live signal track record: per-action hit rates and IL-adjusted 7-day PnL, " +
+    "misses included. Every published signal is immutable at publish time and outcome-labeled " +
+    "after the fact, so the numbers cannot be retro-edited.",
+  examples: [
+    [
+      {
+        input: { days: 30 },
+        output: {
+          status: "success",
+          window_days: 30,
+          by_action: [
+            {
+              final_action: "ENTER",
+              resolved: 3819,
+              hit_rate: "0.599",
+              avg_pnl_7d: "0.0197",
+            },
+            { final_action: "EXIT", resolved: 4039, hit_rate: "0.801" },
+          ],
+        },
+        explanation:
+          "Aggregated outcomes of every published signal over the last 30 days, misses included.",
+      },
+    ],
+  ],
+  schema: z.object({
+    days: z
+      .number()
+      .int()
+      .min(7)
+      .max(90)
+      .optional()
+      .describe("Window in days (default 30)"),
+  }),
+  handler: async (agent, input: Record<string, any>) => {
+    try {
+      const data = await getWealthvilleTrackRecord(agent, input.days ?? 30);
+      return { status: "success", ...data, disclaimer: WEALTHVILLE_DISCLAIMER };
+    } catch (error: any) {
+      return { status: "error", message: error.message };
+    }
+  },
+};
+
+export default getWealthvilleTrackRecordAction;

--- a/packages/plugin-misc/src/wealthville/tools/get_wealthville_pool_score.ts
+++ b/packages/plugin-misc/src/wealthville/tools/get_wealthville_pool_score.ts
@@ -1,0 +1,19 @@
+import { SolanaAgentKit } from "solana-agent-kit";
+import { WealthvilleScoreRow } from "../types";
+import { wealthvilleGet } from "../utils";
+
+/**
+ * Get the Wealthville verdict (ENTER/HOLD/EXIT/AVOID) and 0-100 action scores
+ * for one liquidity pool.
+ * @param agent SolanaAgentKit instance
+ * @param poolAddress Pool address — Solana base58, EVM 0x, or DefiLlama UUID
+ */
+export async function getWealthvillePoolScore(
+  agent: SolanaAgentKit,
+  poolAddress: string,
+): Promise<WealthvilleScoreRow> {
+  return wealthvilleGet(
+    agent,
+    `/api/v1/scores/${encodeURIComponent(poolAddress)}`,
+  );
+}

--- a/packages/plugin-misc/src/wealthville/tools/get_wealthville_top_pools.ts
+++ b/packages/plugin-misc/src/wealthville/tools/get_wealthville_top_pools.ts
@@ -1,0 +1,21 @@
+import { SolanaAgentKit } from "solana-agent-kit";
+import { WealthvilleTopPoolsResponse } from "../types";
+import { wealthvilleGet } from "../utils";
+
+/**
+ * List liquidity pools ranked by composite Wealthville Score (0-100),
+ * freshly scored within the last 6 hours.
+ * @param agent SolanaAgentKit instance
+ * @param limit How many pools to return (1-100, default 25)
+ * @param chain "solana" (default), "evm" for all EVM chains, or one EVM chain name
+ */
+export async function getWealthvilleTopPools(
+  agent: SolanaAgentKit,
+  limit: number = 25,
+  chain: string = "solana",
+): Promise<WealthvilleTopPoolsResponse> {
+  return wealthvilleGet(
+    agent,
+    `/api/v1/scores/top?limit=${limit}&chain=${encodeURIComponent(chain)}`,
+  );
+}

--- a/packages/plugin-misc/src/wealthville/tools/get_wealthville_track_record.ts
+++ b/packages/plugin-misc/src/wealthville/tools/get_wealthville_track_record.ts
@@ -1,0 +1,17 @@
+import { SolanaAgentKit } from "solana-agent-kit";
+import { WealthvilleTrackRecordResponse } from "../types";
+import { wealthvilleGet } from "../utils";
+
+/**
+ * Get Wealthville's live, outcome-labeled signal track record: per-action hit
+ * rates and IL-adjusted 7-day PnL, misses included. Every published signal is
+ * immutable at publish time and labeled after the fact.
+ * @param agent SolanaAgentKit instance
+ * @param days Window in days (7-90, default 30)
+ */
+export async function getWealthvilleTrackRecord(
+  agent: SolanaAgentKit,
+  days: number = 30,
+): Promise<WealthvilleTrackRecordResponse> {
+  return wealthvilleGet(agent, `/api/v1/track-record?days=${days}`);
+}

--- a/packages/plugin-misc/src/wealthville/tools/index.ts
+++ b/packages/plugin-misc/src/wealthville/tools/index.ts
@@ -1,0 +1,3 @@
+export * from "./get_wealthville_pool_score";
+export * from "./get_wealthville_top_pools";
+export * from "./get_wealthville_track_record";

--- a/packages/plugin-misc/src/wealthville/types.ts
+++ b/packages/plugin-misc/src/wealthville/types.ts
@@ -1,0 +1,49 @@
+export interface WealthvilleScoreRow {
+  pool_address: string;
+  pool_name: string;
+  protocol: string;
+  chain: string;
+  verdict:
+    | "ENTER"
+    | "INCREASE"
+    | "HOLD"
+    | "REDUCE"
+    | "EXIT"
+    | "AVOID"
+    | "INSUFFICIENT_DATA";
+  confidence: string;
+  enter_score: number | null;
+  hold_score: number | null;
+  exit_score: number | null;
+  wealthville_score: number | null;
+  computed_at: string;
+  reasons: string[];
+  data_tier?: number | null;
+}
+
+export interface WealthvilleTopPoolsResponse {
+  as_of: string;
+  methodology: string;
+  scores: WealthvilleScoreRow[];
+}
+
+export interface WealthvilleTrackRecordResponse {
+  as_of: string;
+  window_days: number;
+  methodology: string;
+  label_semantics: Record<string, string>;
+  by_action: Array<{
+    final_action: string;
+    signals: number;
+    resolved: number;
+    hit_rate: string | null;
+    avg_pnl_7d: string | null;
+    avg_il_7d: string | null;
+  }>;
+  weekly_enter_hit_rate: Array<{
+    week: string;
+    signals: number;
+    hit_rate: string;
+  }>;
+  recent_resolved: Array<Record<string, unknown>>;
+}

--- a/packages/plugin-misc/src/wealthville/utils.ts
+++ b/packages/plugin-misc/src/wealthville/utils.ts
@@ -1,0 +1,25 @@
+import { SolanaAgentKit } from "solana-agent-kit";
+
+export const WEALTHVILLE_DISCLAIMER =
+  "Wealthville data product, not financial advice. Methodology: https://www.wealthville.net/learn/wealthville-score";
+
+/**
+ * GET a Wealthville public API path. No key is required (anonymous tier is
+ * 60 req/min per IP); an optional free partner key raises the limit and is
+ * read from agent.config.OTHER_API_KEYS.WEALTHVILLE_API_KEY.
+ */
+export async function wealthvilleGet(
+  agent: SolanaAgentKit,
+  path: string,
+): Promise<any> {
+  const headers: Record<string, string> = { accept: "application/json" };
+  const apiKey = agent.config?.OTHER_API_KEYS?.WEALTHVILLE_API_KEY;
+  if (apiKey) {
+    headers["x-api-key"] = apiKey;
+  }
+  const response = await fetch(`https://wealthville.net${path}`, { headers });
+  if (!response.ok) {
+    throw new Error(`Wealthville API returned ${response.status} for ${path}`);
+  }
+  return response.json();
+}


### PR DESCRIPTION
### Related Issue
N/A — new read-only data integration.

### Changes Made
Adds Wealthville liquidity-pool intelligence to `plugin-misc`: 3 tools + 3 actions under `packages/plugin-misc/src/wealthville/`, registered in the plugin index, with README and docs-table entries.

- `getWealthvillePoolScore` / `WEALTHVILLE_GET_POOL_SCORE` — Enter/Hold/Exit verdict + 0–100 scores for one pool (Solana base58, EVM 0x, or DefiLlama UUID)
- `getWealthvilleTopPools` / `WEALTHVILLE_GET_TOP_POOLS` — pools ranked by composite Wealthville Score (Raydium/Orca/Meteora + EVM)
- `getWealthvilleTrackRecord` / `WEALTHVILLE_GET_TRACK_RECORD` — live outcome-labeled hit rates and IL-adjusted PnL, misses included

### Implementation Details
- Read-only: public `GET` endpoints only — no wallet access, nothing signed, and **no new dependencies** (bare `fetch`; `zod` already in plugin-misc).
- No key required (60 req/min anonymous). Optional free partner key read from `config.OTHER_API_KEYS.WEALTHVILLE_API_KEY` — no `Config` interface changes needed.
- Every action result carries a `disclaimer` field (data product, not financial advice) plus the methodology link, so agents relay provenance.
- Why agents want this: a pre-trade quality gate — `if ((await agent.methods.getWealthvillePoolScore(agent, pool)).verdict !== 'ENTER') skip(pool)`. Scores are backed by a public, immutable, miss-inclusive track record (https://www.wealthville.net/track-record) and the same engine allocates Wealthville's own on-chain vault capital.

### Transaction executed by agent
Read-only tools — no transaction. Example real output from the built plugin (run against the live API):

```json
{ "status": "success", "pool_name": "SOL/USDC", "protocol": "raydium-clmm",
  "verdict": "ENTER", "wealthville_score": 93, "enter_score": 94,
  "hold_score": 93, "exit_score": 6, "confidence": "0.645" }
```

### Prompt used to test
> "Check whether Czfq3xZZDmsdGdUyrNLtRhGc47cXcZtLG4crryfu44zE is safe to LP into, then show me the top 5 Solana pools and Wealthville's track record for the last 30 days."

### Checklist
- [x] Tested locally (`pnpm build` incl. DTS, `biome check` clean, runtime calls against the live API)
- [x] Updated documentation (`plugin-misc/README.md` + `docs/v2/plugins/misc/misc-plugin-intro.mdx`)

---
Free API for your users, keyless. Docs: https://wealthville.net/developers · MCP variant: https://wealthville.net/mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)
