### PR TITLE
feat(core): optional beforeSign hook on BaseWallet (refuse-before-sign)

### DIFF
--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -1,6 +1,7 @@
 import { Connection } from "@solana/web3.js";
 import type { Action, Config, Plugin } from "../types";
 import { BaseWallet, EvmWallet } from "../types/wallet";
+import { wrapWallet } from "../utils/wrapWallet";
 
 /**
  * Defines a type that merges all plugin methods into the `methods` object
@@ -64,7 +65,11 @@ export class SolanaAgentKit<TPlugins = Record<string, never>> {
     evmWallet?: EvmWallet,
   ) {
     this.connection = new Connection(rpc_url);
-    this.wallet = wallet;
+    // Refuse-before-sign seat: wrap at construction so plugin direct wallet
+    // calls (signAndSendTransaction etc.) cannot bypass the policy.
+    this.wallet = config?.beforeSign
+      ? wrapWallet(wallet, config.beforeSign)
+      : wallet;
     this.config = config;
     this.evmWallet = evmWallet;
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,3 +20,4 @@ export * from "./utils/send_tx";
 export * from "./utils/keypairWallet";
 export * from "./utils/owsWallet";
 export * from "./utils/getMintInfo";
+export * from "./utils/wrapWallet";

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,6 +1,7 @@
 import type { Transaction, VersionedTransaction } from "@solana/web3.js";
 import type { z } from "zod";
 import type { SolanaAgentKit } from "../agent";
+import type { BeforeSign } from "../utils/wrapWallet";
 
 export interface Plugin {
   name: string;
@@ -11,6 +12,14 @@ export interface Plugin {
 
 export interface Config {
   signOnly?: boolean;
+  /**
+   * Optional pre-sign policy. When set, SolanaAgentKit wraps the provided
+   * BaseWallet so every sign / signAndSend / send path invokes this hook first.
+   * Throw or reject to refuse the signature. Default (unset) = no-op.
+   *
+   * Policy is pluggable — not a vendor or network dependency of core.
+   */
+  beforeSign?: BeforeSign;
   OPENAI_API_KEY?: string;
   PERPLEXITY_API_KEY?: string;
   JUPITER_REFERRAL_ACCOUNT?: string;

--- a/packages/core/src/utils/wrapWallet.test.ts
+++ b/packages/core/src/utils/wrapWallet.test.ts
@@ -15,7 +15,7 @@ import {
 } from "@solana/web3.js";
 import { SolanaAgentKit } from "../agent";
 import type { BaseWallet } from "../types/wallet";
-import { wrapWallet, type BeforeSignContext } from "./wrapWallet";
+import { type BeforeSignContext, wrapWallet } from "./wrapWallet";
 
 function mockWallet(publicKey: PublicKey): BaseWallet & {
   signCalls: number;
@@ -43,7 +43,7 @@ function mockWallet(publicKey: PublicKey): BaseWallet & {
       state.signCalls += txs.length;
       return txs;
     },
-    async signAndSendTransaction(tx) {
+    async signAndSendTransaction(_tx) {
       state.signCalls += 1;
       state.sendCalls += 1;
       return { signature: "mock-sig" };

--- a/packages/core/src/utils/wrapWallet.test.ts
+++ b/packages/core/src/utils/wrapWallet.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Unit tests for wrapWallet / beforeSign.
+ * Run from packages/core:
+ *   npx tsx --test src/utils/wrapWallet.test.ts
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import { SolanaAgentKit } from "../agent";
+import type { BaseWallet } from "../types/wallet";
+import { wrapWallet, type BeforeSignContext } from "./wrapWallet";
+
+function mockWallet(publicKey: PublicKey): BaseWallet & {
+  signCalls: number;
+  sendCalls: number;
+} {
+  const state = { signCalls: 0, sendCalls: 0 };
+  const wallet: BaseWallet & {
+    signCalls: number;
+    sendCalls: number;
+  } = {
+    get publicKey() {
+      return publicKey;
+    },
+    get signCalls() {
+      return state.signCalls;
+    },
+    get sendCalls() {
+      return state.sendCalls;
+    },
+    async signTransaction(tx) {
+      state.signCalls += 1;
+      return tx;
+    },
+    async signAllTransactions(txs) {
+      state.signCalls += txs.length;
+      return txs;
+    },
+    async signAndSendTransaction(tx) {
+      state.signCalls += 1;
+      state.sendCalls += 1;
+      return { signature: "mock-sig" };
+    },
+    async sendTransaction(_tx) {
+      state.sendCalls += 1;
+      return "mock-send";
+    },
+    async signMessage(message) {
+      return message;
+    },
+  };
+  return wallet;
+}
+
+function dummyTx(from: PublicKey): Transaction {
+  const tx = new Transaction().add(
+    SystemProgram.transfer({
+      fromPubkey: from,
+      toPubkey: from,
+      lamports: 1,
+    }),
+  );
+  tx.feePayer = from;
+  tx.recentBlockhash = Keypair.generate().publicKey.toBase58().slice(0, 32);
+  // recentBlockhash must be valid base58 32-byte - use a real one from a dummy blockhash pattern
+  // web3.js accepts any string for unit tests that never serialize to chain
+  tx.recentBlockhash = "EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N";
+  return tx;
+}
+
+test("beforeSign is invoked on signTransaction with mode=sign", async () => {
+  const kp = Keypair.generate();
+  const inner = mockWallet(kp.publicKey);
+  const seen: BeforeSignContext[] = [];
+  const wrapped = wrapWallet(inner, (ctx) => {
+    seen.push(ctx);
+  });
+  const tx = dummyTx(kp.publicKey);
+  await wrapped.signTransaction(tx);
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].mode, "sign");
+  assert.equal(seen[0].publicKey.toBase58(), kp.publicKey.toBase58());
+  assert.equal(inner.signCalls, 1);
+});
+
+test("beforeSign throw aborts signAndSend (inner wallet never called)", async () => {
+  const kp = Keypair.generate();
+  const inner = mockWallet(kp.publicKey);
+  const wrapped = wrapWallet(inner, () => {
+    throw new Error("policy refuse");
+  });
+  const tx = dummyTx(kp.publicKey);
+  await assert.rejects(
+    () => wrapped.signAndSendTransaction(tx),
+    /policy refuse/,
+  );
+  assert.equal(inner.signCalls, 0);
+  assert.equal(inner.sendCalls, 0);
+});
+
+test("beforeSign throw aborts signAll before any sign", async () => {
+  const kp = Keypair.generate();
+  const inner = mockWallet(kp.publicKey);
+  let calls = 0;
+  const wrapped = wrapWallet(inner, () => {
+    calls += 1;
+    throw new Error("blocked");
+  });
+  const txs = [dummyTx(kp.publicKey), dummyTx(kp.publicKey)];
+  await assert.rejects(() => wrapped.signAllTransactions(txs), /blocked/);
+  assert.equal(calls, 1);
+  assert.equal(inner.signCalls, 0);
+});
+
+test("sendTransaction path is guarded when present", async () => {
+  const kp = Keypair.generate();
+  const inner = mockWallet(kp.publicKey);
+  const modes: string[] = [];
+  const wrapped = wrapWallet(inner, (ctx) => {
+    modes.push(ctx.mode);
+  });
+  assert.ok(wrapped.sendTransaction);
+  await wrapped.sendTransaction!(dummyTx(kp.publicKey));
+  assert.deepEqual(modes, ["send"]);
+  assert.equal(inner.sendCalls, 1);
+});
+
+test("signMessage is not guarded (not a spend path)", async () => {
+  const kp = Keypair.generate();
+  const inner = mockWallet(kp.publicKey);
+  let hookCalls = 0;
+  const wrapped = wrapWallet(inner, () => {
+    hookCalls += 1;
+  });
+  const msg = new Uint8Array([1, 2, 3]);
+  const out = await wrapped.signMessage(msg);
+  assert.deepEqual(out, msg);
+  assert.equal(hookCalls, 0);
+});
+
+test("async beforeSign reject aborts sign", async () => {
+  const kp = Keypair.generate();
+  const inner = mockWallet(kp.publicKey);
+  const wrapped = wrapWallet(inner, async () => {
+    throw new Error("async refuse");
+  });
+  await assert.rejects(
+    () => wrapped.signTransaction(dummyTx(kp.publicKey)),
+    /async refuse/,
+  );
+  assert.equal(inner.signCalls, 0);
+});
+
+test("VersionedTransaction is accepted by the guard", async () => {
+  const kp = Keypair.generate();
+  const inner = mockWallet(kp.publicKey);
+  let mode = "";
+  const wrapped = wrapWallet(inner, (ctx) => {
+    mode = ctx.mode;
+  });
+  const msg = new TransactionMessage({
+    payerKey: kp.publicKey,
+    recentBlockhash: "EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N",
+    instructions: [
+      SystemProgram.transfer({
+        fromPubkey: kp.publicKey,
+        toPubkey: kp.publicKey,
+        lamports: 1,
+      }),
+    ],
+  }).compileToV0Message();
+  const vtx = new VersionedTransaction(msg);
+  await wrapped.signTransaction(vtx);
+  assert.equal(mode, "sign");
+  assert.equal(inner.signCalls, 1);
+});
+
+test("SolanaAgentKit constructor wires beforeSign onto agent.wallet", async () => {
+  const kp = Keypair.generate();
+  const inner = mockWallet(kp.publicKey);
+  const agent = new SolanaAgentKit(inner, "http://127.0.0.1:8899", {
+    beforeSign: () => {
+      throw new Error("constructor-wired refuse");
+    },
+  });
+  await assert.rejects(
+    () => agent.wallet.signAndSendTransaction(dummyTx(kp.publicKey)),
+    /constructor-wired refuse/,
+  );
+  assert.equal(inner.signCalls, 0);
+});
+
+test("SolanaAgentKit without beforeSign leaves wallet unwrapped", async () => {
+  const kp = Keypair.generate();
+  const inner = mockWallet(kp.publicKey);
+  const agent = new SolanaAgentKit(inner, "http://127.0.0.1:8899", {});
+  assert.equal(agent.wallet, inner);
+  await agent.wallet.signTransaction(dummyTx(kp.publicKey));
+  assert.equal(inner.signCalls, 1);
+});

--- a/packages/core/src/utils/wrapWallet.ts
+++ b/packages/core/src/utils/wrapWallet.ts
@@ -25,9 +25,7 @@ export type BeforeSignContext = {
   mode: BeforeSignMode;
 };
 
-export type BeforeSign = (
-  ctx: BeforeSignContext,
-) => void | Promise<void>;
+export type BeforeSign = (ctx: BeforeSignContext) => void | Promise<void>;
 
 /**
  * Wrap a BaseWallet so every sign / send path runs `beforeSign` first.

--- a/packages/core/src/utils/wrapWallet.ts
+++ b/packages/core/src/utils/wrapWallet.ts
@@ -1,0 +1,102 @@
+import type {
+  PublicKey,
+  SendOptions,
+  Transaction,
+  TransactionSignature,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import type { BaseWallet } from "../types/wallet";
+
+/**
+ * Why the wallet was about to sign / send.
+ * Covers every BaseWallet path plugins actually use (not only signOrSendTX).
+ */
+export type BeforeSignMode = "sign" | "signAndSend" | "signAll" | "send";
+
+/**
+ * Context for an optional pre-sign policy hook.
+ *
+ * Hosts may throw / reject to refuse the signature. Core never calls the network
+ * on their behalf — policy is pluggable and dependency-free.
+ */
+export type BeforeSignContext = {
+  publicKey: PublicKey;
+  transaction: Transaction | VersionedTransaction;
+  mode: BeforeSignMode;
+};
+
+export type BeforeSign = (
+  ctx: BeforeSignContext,
+) => void | Promise<void>;
+
+/**
+ * Wrap a BaseWallet so every sign / send path runs `beforeSign` first.
+ *
+ * This is the only complete refuse-before-sign seat in SAK: many plugins call
+ * `agent.wallet.signAndSendTransaction` directly and bypass `signOrSendTX`.
+ *
+ * `signMessage` is intentionally not guarded (not a spend path).
+ */
+export function wrapWallet(
+  wallet: BaseWallet,
+  beforeSign: BeforeSign,
+): BaseWallet {
+  const guard = async (
+    transaction: Transaction | VersionedTransaction,
+    mode: BeforeSignMode,
+  ): Promise<void> => {
+    await beforeSign({
+      publicKey: wallet.publicKey,
+      transaction,
+      mode,
+    });
+  };
+
+  const wrapped: BaseWallet = {
+    get publicKey() {
+      return wallet.publicKey;
+    },
+
+    async signTransaction<T extends Transaction | VersionedTransaction>(
+      transaction: T,
+    ): Promise<T> {
+      await guard(transaction, "sign");
+      return wallet.signTransaction(transaction);
+    },
+
+    async signAllTransactions<T extends Transaction | VersionedTransaction>(
+      transactions: T[],
+    ): Promise<T[]> {
+      for (const transaction of transactions) {
+        await guard(transaction, "signAll");
+      }
+      return wallet.signAllTransactions(transactions);
+    },
+
+    async signAndSendTransaction<T extends Transaction | VersionedTransaction>(
+      transaction: T,
+      options?: SendOptions,
+    ): Promise<{ signature: TransactionSignature }> {
+      await guard(transaction, "signAndSend");
+      return wallet.signAndSendTransaction(transaction, options);
+    },
+
+    signMessage(message: Uint8Array): Promise<Uint8Array> {
+      return wallet.signMessage(message);
+    },
+  };
+
+  if (wallet.sendTransaction) {
+    const send = wallet.sendTransaction.bind(wallet);
+    wrapped.sendTransaction = async <
+      T extends Transaction | VersionedTransaction,
+    >(
+      transaction: T,
+    ): Promise<string> => {
+      await guard(transaction, "send");
+      return send(transaction);
+    };
+  }
+
+  return wrapped;
+}


### PR DESCRIPTION
## Problem

SAK actions spend through `BaseWallet` (`signTransaction` / `signAndSendTransaction` / `signAllTransactions`, plus optional `sendTransaction`). Once an agent can sign, the expensive failure mode is sending to a bad counterparty.

Today there is no first-class place for a host to refuse *before* sign without forking N plugins. Hooking only `signOrSendTX` is incomplete: many plugins call `agent.wallet.signAndSendTransaction` directly.

## Proposal (minimal, zero default behavior change)

1. Add optional `config.beforeSign?: (ctx) => void | Promise<void>`.
2. When set, `SolanaAgentKit` wraps the provided `BaseWallet` at construction so every sign/send path invokes the hook first; throw/reject aborts sign.
3. Unset = no behavior change (`agent.wallet ===` the original wallet).
4. `signMessage` is intentionally **not** guarded (not a spend path).
5. No network calls in core. No vendor SDK in core. Policy is pluggable.

```ts
const agent = new SolanaAgentKit(wallet, rpcUrl, {
  beforeSign: async ({ publicKey, transaction, mode }) => {
    // throw to refuse — allowlist, velocity, external observation, etc.
  },
});
```

Also exported: `wrapWallet(wallet, beforeSign)` for hosts that want to wrap without going through the constructor.

## Why wallet wrap (not only `signOrSendTX`)

This is the only complete refuse-before-sign seat: plugins that call the wallet directly cannot bypass the policy.

## What this is not

- Not a facilitator
- Not a ranking / “trusted seller” marketplace
- Not a required network dependency
- Not a new skill or chat action

## Tests

9 unit tests in `packages/core/src/utils/wrapWallet.test.ts`:

```bash
cd packages/core && npx tsx --test src/utils/wrapWallet.test.ts
```

Covers: hook invocation, throw/async reject aborts, signAll, send path, VersionedTransaction, constructor wiring, identity when unset.

## Files

- `packages/core/src/utils/wrapWallet.ts` (new)
- `packages/core/src/utils/wrapWallet.test.ts` (new)
- `packages/core/src/types/index.ts` — `Config.beforeSign`
- `packages/core/src/agent/index.ts` — constructor wrap
- `packages/core/src/index.ts` — export

Happy to adjust the type shape or naming if maintainers prefer a different surface.