### PR TITLE
fix(adapter-mcp): keep optional tool params optional

### DIFF
--- a/packages/adapter-mcp/src/index.ts
+++ b/packages/adapter-mcp/src/index.ts
@@ -11,10 +11,6 @@ export type MCPSchemaShape = {
 };
 
 // Type guards for Zod schema types
-function isZodOptional(schema: z.ZodTypeAny): schema is z.ZodOptional<any> {
-  return schema instanceof z.ZodOptional;
-}
-
 function isZodObject(schema: z.ZodTypeAny): schema is z.ZodObject<any> {
   // Check both instanceof and the typeName property
   return (
@@ -40,7 +36,11 @@ export function zodToMCPShape(schema: z.ZodTypeAny): {
   const result: MCPSchemaShape = {};
 
   for (const [key, value] of Object.entries(shape)) {
-    result[key] = isZodOptional(value) ? value.unwrap() : value;
+    // Keep the schema as authored. Calling .unwrap() on a ZodOptional returns the
+    // inner type, which drops the optionality: z.string().optional() would become
+    // z.string(), and the tool would advertise an optional argument as required.
+    // MCP accepts ZodOptional in a raw shape, so no unwrapping is needed.
+    result[key] = value;
   }
 
   return {
@@ -114,12 +114,21 @@ export function createMcpServer(
             .describe("Example index to show (number)"),
         },
         (args) => {
-          const showIndex = args.showIndex
-            ? parseInt(args.showIndex)
-            : undefined;
           const examples = action.examples.flat();
-          const selectedExamples =
-            typeof showIndex === "number" ? [examples[showIndex]] : examples;
+          const requestedIndex = args.showIndex
+            ? Number.parseInt(args.showIndex, 10)
+            : undefined;
+          // parseInt("abc") is NaN, and typeof NaN === "number", so a plain
+          // typeof check let bad input through and produced [undefined] —
+          // rendering "Input: undefined". Fall back to showing every example.
+          const isValidIndex =
+            requestedIndex !== undefined &&
+            Number.isInteger(requestedIndex) &&
+            requestedIndex >= 0 &&
+            requestedIndex < examples.length;
+          const selectedExamples = isValidIndex
+            ? [examples[requestedIndex]]
+            : examples;
 
           const exampleText = selectedExamples
             .map(


### PR DESCRIPTION
Fixes items 2 and 3 of #600. Deliberately scoped to the two small, self-contained bugs — the SDK 2026-07-28 migration (item 1) is a breaking change and I'd rather agree the approach with you before submitting that one.

## 1. Optional parameters were advertised as required

`zodToMCPShape` flattened the schema with:

```ts
result[key] = isZodOptional(value) ? value.unwrap() : value;
```

`.unwrap()` on a `ZodOptional` returns the **inner** type, so `z.string().optional()` becomes `z.string()`. Every action with optional arguments told the model those arguments were mandatory — so the model either invents a value it was never given, or skips a tool call it could have made. Neither surfaces as an error.

MCP accepts `ZodOptional` inside a raw shape, so the unwrap was not needed. The schema now passes through as authored.

Before/after, using the exact loop from the file:

```js
const shape = { required: z.string(), maybe: z.string().optional() };

// before: unwrap optionals
console.log(z.object(before).safeParse({ required: 'x' }).success);  // false  ← bug

// after: pass through
console.log(z.object(after).safeParse({ required: 'x' }).success);   // true
console.log(z.object(after).safeParse({ maybe: 'y' }).success);      // false  ← required still enforced
```

## 2. Out-of-range examples index rendered `undefined`

```ts
const selectedExamples = typeof showIndex === "number" ? [examples[showIndex]] : examples;
```

`parseInt("abc")` is `NaN`, and `typeof NaN === "number"`, so invalid input passed the check and reached `examples[NaN]` → `[undefined]` → a prompt reading `Input: undefined / Output: undefined`. Same for any index past the end. Now bounds-checked, falling back to showing all examples.

## Notes

- No API change; `zodToMCPShape` keeps its signature and return shape.
- The now-unused `isZodOptional` type guard is removed. It was not exported.
- `packages/adapter-mcp` has `"test": "jest"` but no test files, so I have not added any rather than introduce a test setup in a bugfix PR. Happy to add coverage for both cases if you'd like it — say the word and I'll push.

I'm on the other side of this as a consumer: we hit item 1 and ended up writing our own adapter to unblock, which is how these two turned up.