### PR TITLE
fix plugin-defi load failure from jito-ts nested web3.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,10 @@
     "typescript": "^5.7.2"
   },
   "packageManager": "pnpm@9.15.3",
-  "version": "2.0.7"
+  "version": "2.0.7",
+  "pnpm": {
+    "overrides": {
+      "jito-ts>@solana/web3.js": "^1.98.2"
+    }
+  }
 }

--- a/packages/plugin-defi/README.md
+++ b/packages/plugin-defi/README.md
@@ -109,6 +109,28 @@ This plugin provides a comprehensive suite of tools and actions to interact with
 - **`sanctumGetLSTTVL`**: Get the TVL for LSTs on Sanctum.
 - **`sanctumGetOwnedLST`**: Get owned LSTs on Sanctum.
 
+## Dependency note: `jito-ts` / `rpc-websockets`
+
+Drift pulls `jito-ts`, which nests an old `@solana/web3.js` that deep-imports
+`rpc-websockets/dist/lib/client`. With npm, that path often resolves to the
+plugin's `rpc-websockets@10` and fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`.
+
+This monorepo forces a newer web3.js under `jito-ts` via `pnpm.overrides`.
+If you install with npm in your own app, add the same pin at the app root:
+
+```json
+{
+  "overrides": {
+    "jito-ts": {
+      "@solana/web3.js": "^1.98.2"
+    }
+  }
+}
+```
+
+Then reinstall. `require("@solana-agent-kit/plugin-defi")` should load without
+the missing `dist/lib/client` error.
+
 ## Full Documentation
 
 For more detailed information, please refer to the full documentation at [docs.sendai.fun](https://docs.sendai.fun).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  jito-ts>@solana/web3.js: ^1.98.2
+
 importers:
 
   .:
@@ -2815,9 +2818,6 @@ packages:
   '@solana/wallet-standard-features@1.3.0':
     resolution: {integrity: sha512-ZhpZtD+4VArf6RPitsVExvgkF+nGghd1rzPjd97GmBximpnt1rsUxMOEyoIEuH3XBxPyNB6Us7ha7RHWQR+abg==}
     engines: {node: '>=16'}
-
-  '@solana/web3.js@1.77.4':
-    resolution: {integrity: sha512-XdN0Lh4jdY7J8FYMyucxCwzn6Ga2Sr1DHDWRbqVzk7ZPmmpSPOVWHzO67X1cVT+jNi1D6gZi2tgjHgDPuj6e9Q==}
 
   '@solana/web3.js@1.92.3':
     resolution: {integrity: sha512-NVBWvb9zdJIAx6X+caXaIICCEQfQaQ8ygykCjJW4u2z/sIKcvPj3ZIIllnx0MWMc3IxGq15ozGYDOQIMbwUcHw==}
@@ -6145,9 +6145,6 @@ packages:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
-
-  superstruct@0.14.2:
-    resolution: {integrity: sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ==}
 
   superstruct@0.15.5:
     resolution: {integrity: sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ==}
@@ -10098,7 +10095,7 @@ snapshots:
       '@coral-xyz/anchor': 0.29.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.6.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.6.3)(utf-8-validate@5.0.10)
       bs58: 5.0.0
-      jito-ts: 3.0.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      jito-ts: 3.0.1(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.6.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -10110,7 +10107,7 @@ snapshots:
       '@coral-xyz/anchor': 0.29.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
       bs58: 5.0.0
-      jito-ts: 3.0.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      jito-ts: 3.0.1(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -11169,28 +11166,6 @@ snapshots:
     dependencies:
       '@wallet-standard/base': 1.1.0
       '@wallet-standard/features': 1.1.0
-
-  '@solana/web3.js@1.77.4(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@babel/runtime': 7.27.1
-      '@noble/curves': 1.8.2
-      '@noble/hashes': 1.7.2
-      '@solana/buffer-layout': 4.0.1
-      agentkeepalive: 4.6.0
-      bigint-buffer: 1.1.5
-      bn.js: 5.2.2
-      borsh: 0.7.0
-      bs58: 4.0.1
-      buffer: 6.0.3
-      fast-stable-stringify: 1.0.0
-      jayson: 4.1.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      node-fetch: 2.7.0(encoding@0.1.13)
-      rpc-websockets: 7.5.1
-      superstruct: 0.14.2
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - utf-8-validate
 
   '@solana/web3.js@1.92.3(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)':
     dependencies:
@@ -13950,11 +13925,11 @@ snapshots:
   jiti@2.4.2:
     optional: true
 
-  jito-ts@3.0.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10):
+  jito-ts@3.0.1(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.6.3)(utf-8-validate@5.0.10):
     dependencies:
       '@grpc/grpc-js': 1.12.5
       '@noble/ed25519': 1.7.3
-      '@solana/web3.js': 1.77.4(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.6.3)(utf-8-validate@5.0.10)
       agentkeepalive: 4.6.0
       dotenv: 16.5.0
       jayson: 4.1.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -13963,6 +13938,23 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - encoding
+      - typescript
+      - utf-8-validate
+
+  jito-ts@3.0.1(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10):
+    dependencies:
+      '@grpc/grpc-js': 1.12.5
+      '@noble/ed25519': 1.7.3
+      '@solana/web3.js': 1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      agentkeepalive: 4.6.0
+      dotenv: 16.5.0
+      jayson: 4.1.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      node-fetch: 2.7.0(encoding@0.1.13)
+      superstruct: 1.0.4
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
       - utf-8-validate
 
   joi@17.13.3:
@@ -15441,8 +15433,6 @@ snapshots:
       mz: 2.7.0
       pirates: 4.0.7
       ts-interface-checker: 0.1.13
-
-  superstruct@0.14.2: {}
 
   superstruct@0.15.5: {}
 


### PR DESCRIPTION
## Summary
- Force `@solana/web3.js@^1.98.2` under `jito-ts` via root `pnpm.overrides` so DefiPlugin no longer hits the broken `rpc-websockets/dist/lib/client` deep import.
- Refresh the lockfile so `jito-ts` resolves to the newer web3.js.
- Document the matching npm `overrides` snippet for app consumers in `packages/plugin-defi/README.md`.

Fixes #466.

## Motivation
`@solana-agent-kit/plugin-defi` pulls Drift → Pyth → `jito-ts`, which nests an old `@solana/web3.js` that deep-imports `rpc-websockets/dist/lib/client`. With npm, that path often resolves to the plugin's `rpc-websockets@10` and fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`, so the plugin never loads.

Newer web3.js uses a package-root `rpc-websockets` import instead, so overriding only the nested copy under `jito-ts` unblocks load without a Drift rewrite.

## Test plan
- [x] Fresh npm install of `@solana-agent-kit/plugin-defi@2.0.8` without override → fails on `rpc-websockets/dist/lib/client`
- [x] Same install with the documented npm override → `require("@solana-agent-kit/plugin-defi")` succeeds
- [x] `pnpm install` in this repo applies the override (`jito-ts` → `@solana/web3.js@1.98.2`)
- [x] `pnpm build:plugin-defi` succeeds
- [x] Local CJS/ESM load from `packages/plugin-defi/dist` succeeds
- [ ] CI lint/build green