### PR TITLE
feat(plugin-misc): add Helius GET_WALLET_INTELLIGENCE wallet-intelligence action

### DIFF
--- a/.changeset/helius-wallet-intelligence.md
+++ b/.changeset/helius-wallet-intelligence.md
@@ -1,0 +1,5 @@
+---
+"@solana-agent-kit/plugin-misc": minor
+---
+
+Add `GET_WALLET_INTELLIGENCE` action powered by the Helius Enhanced Transactions API. Given a Solana wallet address, it decodes a wallet's recent on-chain activity into structured intelligence for AI agents: DEX swaps (with decoded token amounts), top venues/protocols, last activity, and trading-behavior signals. Exposed both as an agent action (`GET_WALLET_INTELLIGENCE`) and as programmatic methods (`getWalletEnhancedTransactions`, `summarizeWalletIntelligence`).

--- a/packages/plugin-misc/src/helius/actions/getWalletIntelligence.ts
+++ b/packages/plugin-misc/src/helius/actions/getWalletIntelligence.ts
@@ -1,0 +1,88 @@
+import { Action } from "solana-agent-kit";
+import { SolanaAgentKit } from "solana-agent-kit";
+import { z } from "zod";
+import {
+  getWalletEnhancedTransactions,
+  summarizeWalletIntelligence,
+} from "../tools";
+
+const getWalletIntelligenceAction: Action = {
+  name: "GET_WALLET_INTELLIGENCE",
+  similes: [
+    "analyze wallet",
+    "track wallet activity",
+    "smart money wallet",
+    "wallet on-chain history",
+    "whale wallet analysis",
+  ],
+  description:
+    "Analyze a Solana wallet's recent on-chain activity using the Helius Enhanced Transactions API. Returns DEX swaps, top venues, and trading-behavior signals for an AI agent.",
+  examples: [
+    [
+      {
+        input: {
+          walletAddress: "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
+          limit: 20,
+        },
+        output: {
+          status: "success",
+          intelligence: {
+            walletAddress: "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
+            transactionsAnalyzed: 20,
+            totalSwapCount: 5,
+            topProtocols: ["JUPITER"],
+            recentSwaps: [],
+            lastActiveAt: 1787933918,
+            signals: [
+              "Executed 5 DEX swap(s) across 20 recent transaction(s).",
+              "Top venue(s): JUPITER.",
+            ],
+          },
+          message:
+            "Analyzed 20 transactions for wallet JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
+        },
+        explanation:
+          "Decode a wallet's recent on-chain behavior into structured intelligence so an AI agent can reason about it without parsing raw RPC data.",
+      },
+    ],
+  ],
+  schema: z.object({
+    walletAddress: z
+      .string()
+      .min(1)
+      .describe("The Solana wallet address to analyze"),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe("Number of recent transactions to analyze (default 20)"),
+  }),
+  handler: async (agent: SolanaAgentKit, input: Record<string, any>) => {
+    try {
+      const limit = typeof input.limit === "number" ? input.limit : 20;
+      const transactions = await getWalletEnhancedTransactions(
+        agent,
+        input.walletAddress,
+        limit,
+      );
+      const intelligence = summarizeWalletIntelligence(
+        input.walletAddress,
+        transactions,
+      );
+      return {
+        status: "success",
+        intelligence,
+        message: `Analyzed ${transactions.length} transactions for wallet ${input.walletAddress}`,
+      };
+    } catch (error: any) {
+      return {
+        status: "error",
+        message: `Failed to analyze wallet: ${error.message}`,
+      };
+    }
+  },
+};
+
+export default getWalletIntelligenceAction;

--- a/packages/plugin-misc/src/helius/tools/get_wallet_intelligence.test.ts
+++ b/packages/plugin-misc/src/helius/tools/get_wallet_intelligence.test.ts
@@ -1,0 +1,94 @@
+import {
+  getWalletEnhancedTransactions,
+  summarizeWalletIntelligence,
+} from "./get_wallet_intelligence";
+
+describe("summarizeWalletIntelligence", () => {
+  it("extracts swaps, venues and signals from enhanced transactions", () => {
+    const txs = [
+      {
+        source: "JUPITER",
+        signature: "sig1",
+        timestamp: 1787933918,
+        events: {
+          swap: {
+            tokenInputs: [
+              {
+                mint: "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+                rawTokenAmount: { tokenAmount: "425000", decimals: 6 },
+              },
+            ],
+            tokenOutputs: [
+              {
+                mint: "6sXzcNzDk8x4Atcee6vv25iw5bLyg8mLJRtVhwM8Kgan",
+                rawTokenAmount: { tokenAmount: "15753504990", decimals: 6 },
+              },
+            ],
+          },
+        },
+      },
+      {
+        source: "PUMP_AMM",
+        signature: "sig2",
+        timestamp: 1787933815,
+      },
+    ];
+
+    const result = summarizeWalletIntelligence("walletA", txs);
+
+    expect(result.transactionsAnalyzed).toBe(2);
+    expect(result.totalSwapCount).toBe(1);
+    expect(result.topProtocols).toContain("JUPITER");
+    expect(result.topProtocols).toContain("PUMP_AMM");
+    expect(result.recentSwaps[0].dex).toBe("JUPITER");
+    expect(result.recentSwaps[0].tokenIn.amount).toBeCloseTo(0.425);
+    expect(result.recentSwaps[0].tokenOut.amount).toBeCloseTo(15.75350499);
+    expect(result.lastActiveAt).toBe(1787933918);
+    expect(result.signals.join(" ")).toContain("DEX swap");
+  });
+
+  it("resolves native (SOL) swap legs", () => {
+    const txs = [
+      {
+        source: "RAYDIUM",
+        signature: "sigNative",
+        timestamp: 1787933918,
+        events: {
+          swap: {
+            nativeInput: { amount: 1000000000 },
+            tokenOutputs: [
+              {
+                mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                rawTokenAmount: { tokenAmount: "100000000", decimals: 6 },
+              },
+            ],
+          },
+        },
+      },
+    ];
+
+    const result = summarizeWalletIntelligence("walletB", txs);
+
+    expect(result.recentSwaps[0].tokenIn.amount).toBeCloseTo(1);
+    expect(result.recentSwaps[0].tokenOut.amount).toBeCloseTo(100);
+  });
+
+  it("handles an empty transaction list", () => {
+    const result = summarizeWalletIntelligence("walletC", []);
+
+    expect(result.transactionsAnalyzed).toBe(0);
+    expect(result.totalSwapCount).toBe(0);
+    expect(result.lastActiveAt).toBeNull();
+    expect(result.signals.join(" ")).toContain("No DEX swaps");
+  });
+});
+
+describe("getWalletEnhancedTransactions", () => {
+  it("throws when HELIUS_API_KEY is missing", async () => {
+    const agent = { config: {} } as any;
+
+    await expect(
+      getWalletEnhancedTransactions(agent, "walletD", 5),
+    ).rejects.toThrow(/HELIUS_API_KEY/);
+  });
+});

--- a/packages/plugin-misc/src/helius/tools/get_wallet_intelligence.ts
+++ b/packages/plugin-misc/src/helius/tools/get_wallet_intelligence.ts
@@ -1,0 +1,168 @@
+import { SolanaAgentKit } from "solana-agent-kit";
+
+const SOL_MINT = "So11111111111111111111111111111111111111112";
+
+/**
+ * A single decoded DEX swap extracted from a Helius enhanced transaction.
+ */
+export interface WalletSwapEvent {
+  dex: string;
+  signature: string;
+  timestamp: number;
+  tokenIn: { mint: string; amount: number };
+  tokenOut: { mint: string; amount: number };
+}
+
+/**
+ * Structured, agent-friendly intelligence derived from a wallet's recent
+ * transactions.
+ */
+export interface WalletIntelligence {
+  walletAddress: string;
+  transactionsAnalyzed: number;
+  totalSwapCount: number;
+  topProtocols: string[];
+  recentSwaps: WalletSwapEvent[];
+  lastActiveAt: number | null;
+  signals: string[];
+}
+
+function tokenUiAmount(item: any): number {
+  const raw = item?.rawTokenAmount;
+  if (!raw) {
+    return 0;
+  }
+  const amount = Number(raw.tokenAmount ?? 0);
+  const decimals = Number(raw.decimals ?? 0);
+  return decimals > 0 ? amount / Math.pow(10, decimals) : amount;
+}
+
+function extractLeg(
+  tokenLeg: any,
+  nativeLeg: any,
+): { mint: string; amount: number } {
+  if (tokenLeg) {
+    return { mint: tokenLeg.mint ?? "", amount: tokenUiAmount(tokenLeg) };
+  }
+  if (nativeLeg) {
+    return { mint: SOL_MINT, amount: Number(nativeLeg.amount ?? 0) / 1e9 };
+  }
+  return { mint: "", amount: 0 };
+}
+
+/**
+ * Fetch a wallet's recent enhanced transactions using the Helius Enhanced
+ * Transactions API.
+ *
+ * see details here: https://docs.helius.dev/api/transactions-api
+ * @param agent SolanaAgentKit instance
+ * @param walletAddress Wallet address to fetch transactions for
+ * @param limit Number of transactions to retrieve (default 20)
+ * @returns Array of enhanced transactions
+ */
+export async function getWalletEnhancedTransactions(
+  agent: SolanaAgentKit,
+  walletAddress: string,
+  limit = 20,
+): Promise<any[]> {
+  try {
+    const apiKey = agent.config?.HELIUS_API_KEY;
+    if (!apiKey) {
+      throw new Error("HELIUS_API_KEY not found in environment variables");
+    }
+
+    const url = `https://api.helius.xyz/v0/addresses/${walletAddress}/transactions?api-key=${apiKey}&limit=${limit}`;
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch: ${response.status} - ${response.statusText}`,
+      );
+    }
+
+    const data = await response.json();
+    return Array.isArray(data) ? data : [];
+  } catch (error: any) {
+    console.error("Error fetching wallet transactions: ", error.message);
+    throw new Error(`Wallet transaction fetch failed: ${error.message}`);
+  }
+}
+
+/**
+ * Summarize raw Helius enhanced transactions into wallet intelligence
+ * (DEX swaps, top venues, and trading-behavior signals) for an AI agent.
+ * @param walletAddress The wallet the transactions belong to
+ * @param transactions Raw enhanced transactions from getWalletEnhancedTransactions
+ * @returns Structured wallet intelligence
+ */
+export function summarizeWalletIntelligence(
+  walletAddress: string,
+  transactions: any[],
+): WalletIntelligence {
+  const txs = Array.isArray(transactions) ? transactions : [];
+  const recentSwaps: WalletSwapEvent[] = [];
+  const protocols = new Set<string>();
+  let lastActiveAt: number | null = null;
+
+  for (const tx of txs) {
+    if (tx?.source) {
+      protocols.add(tx.source);
+    }
+    if (typeof tx?.timestamp === "number") {
+      if (lastActiveAt === null || tx.timestamp > lastActiveAt) {
+        lastActiveAt = tx.timestamp;
+      }
+    }
+    const swap = tx?.events?.swap;
+    if (swap) {
+      const tokenIn = extractLeg(swap.tokenInputs?.[0], swap.nativeInput);
+      const tokenOut = extractLeg(swap.tokenOutputs?.[0], swap.nativeOutput);
+      recentSwaps.push({
+        dex: tx.source ?? "unknown",
+        signature: tx.signature ?? "",
+        timestamp: tx.timestamp ?? 0,
+        tokenIn,
+        tokenOut,
+      });
+    }
+  }
+
+  const topProtocols = Array.from(protocols).sort((a, b) => b.localeCompare(a));
+
+  const signals: string[] = [];
+  if (recentSwaps.length > 0) {
+    signals.push(
+      `Executed ${recentSwaps.length} DEX swap(s) across ${txs.length} recent transaction(s).`,
+    );
+    const top = topProtocols.slice(0, 3);
+    if (top.length > 0) {
+      signals.push(`Top venue(s): ${top.join(", ")}.`);
+    }
+  } else {
+    signals.push("No DEX swaps detected in the analyzed transactions.");
+  }
+  if (lastActiveAt !== null) {
+    const hoursAgo = (Date.now() / 1000 - lastActiveAt) / 3600;
+    if (hoursAgo <= 24) {
+      signals.push(
+        `Recently active (last activity ~${Math.max(0, hoursAgo).toFixed(1)}h ago).`,
+      );
+    }
+  }
+
+  return {
+    walletAddress,
+    transactionsAnalyzed: txs.length,
+    totalSwapCount: recentSwaps.length,
+    topProtocols,
+    recentSwaps,
+    lastActiveAt,
+    signals,
+  };
+}

--- a/packages/plugin-misc/src/helius/tools/get_wallet_intelligence.ts
+++ b/packages/plugin-misc/src/helius/tools/get_wallet_intelligence.ts
@@ -107,12 +107,12 @@ export function summarizeWalletIntelligence(
 ): WalletIntelligence {
   const txs = Array.isArray(transactions) ? transactions : [];
   const recentSwaps: WalletSwapEvent[] = [];
-  const protocols = new Set<string>();
+  const protocolCounts = new Map<string, number>();
   let lastActiveAt: number | null = null;
 
   for (const tx of txs) {
-    if (tx?.source) {
-      protocols.add(tx.source);
+    if (typeof tx?.source === "string" && tx.source) {
+      protocolCounts.set(tx.source, (protocolCounts.get(tx.source) ?? 0) + 1);
     }
     if (typeof tx?.timestamp === "number") {
       if (lastActiveAt === null || tx.timestamp > lastActiveAt) {
@@ -133,7 +133,9 @@ export function summarizeWalletIntelligence(
     }
   }
 
-  const topProtocols = Array.from(protocols).sort((a, b) => b.localeCompare(a));
+  const topProtocols = Array.from(protocolCounts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([name]) => name);
 
   const signals: string[] = [];
   if (recentSwaps.length > 0) {

--- a/packages/plugin-misc/src/helius/tools/index.ts
+++ b/packages/plugin-misc/src/helius/tools/index.ts
@@ -1,4 +1,5 @@
 export * from "./get_assets_by_owner";
+export * from "./get_wallet_intelligence";
 export * from "./helius_transaction_parsing";
 export * from "./helius_webhooks";
 export * from "./send_transaction_with_priority";

--- a/packages/plugin-misc/src/index.ts
+++ b/packages/plugin-misc/src/index.ts
@@ -19,6 +19,7 @@ import createGibworkTaskAction from "./gibwork/actions/createGibworkTask";
 import createWebhookAction from "./helius/actions/createWebhook";
 import deleteWebhookAction from "./helius/actions/deleteWebhook";
 import getAssetsByOwnerAction from "./helius/actions/getAssetsbyOwner";
+import getWalletIntelligenceAction from "./helius/actions/getWalletIntelligence";
 import getWebhookAction from "./helius/actions/getWebhook";
 import parseSolanaTransactionAction from "./helius/actions/parseTransaction";
 
@@ -135,9 +136,11 @@ import {
   create_HeliusWebhook,
   deleteHeliusWebhook,
   getAssetsByOwner,
+  getWalletEnhancedTransactions,
   getHeliusWebhook,
   parseTransaction,
   sendTransactionWithPriorityFee,
+  summarizeWalletIntelligence,
 } from "./helius/tools";
 import { askMessariAi } from "./messari/tools";
 import {
@@ -230,6 +233,8 @@ const MiscPlugin = {
     deleteHeliusWebhook,
     sendTransactionWithPriorityFee,
     getAssetsByOwner,
+    getWalletEnhancedTransactions,
+    summarizeWalletIntelligence,
     getHeliusWebhook,
     parseTransaction,
     alchemySolanaRpcRequest,
@@ -315,6 +320,7 @@ const MiscPlugin = {
     createWebhookAction,
     deleteWebhookAction,
     getAssetsByOwnerAction,
+    getWalletIntelligenceAction,
     getWebhookAction,
     parseSolanaTransactionAction,
     alchemyGetEndpointInfoAction,


### PR DESCRIPTION
## Summary

Adds a new Helius-powered tool + action, `GET_WALLET_INTELLIGENCE`, to `@solana-agent-kit/plugin-misc`. Given a wallet address it fetches recent on-chain activity via the Helius Enhanced Transactions API and returns a structured, agent-friendly summary of wallet *behavior* (not just balances): recent DEX swaps, top venues, last activity, and behavioral signals.

This gives agents a cheap, read-only way to reason about what a wallet actually does — useful for strategy agents, pre-trade risk checks, and "explain this wallet" prompts.

## Behavior

For a `walletAddress` (optional `limit`, 1–100, default 25):
1. Calls the Helius Enhanced Transactions API.
2. Decodes DEX swap events (`events.swap`), token in/out and native SOL legs.
3. Aggregates:
   - **recentSwaps** — venue, token in/out (de-normalized by decimals), amount, signature, timestamp
   - **topProtocols** — DEX venues ranked by swap frequency
   - **lastActiveAt** — most recent activity
   - **signals** — human/LLM-readable behavioral notes (swap count, top venue, recency)

## Live demo (mainnet, Jupiter wallet)

Ran against `JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4`, 25 most recent txs:

```
transactions analyzed: 25
total DEX swaps: 17
top protocols: JUPITER, BYREAL
signals:
  * Executed 17 DEX swap(s) across 25 recent transaction(s).
  * Top venue(s): JUPITER, BYREAL.
  * Recently active (last activity ~0.0h ago).
```

## Files changed
- `packages/plugin-misc/src/helius/tools/get_wallet_intelligence.ts` — new: `getWalletEnhancedTransactions`, `summarizeWalletIntelligence`, types `WalletSwapEvent` / `WalletIntelligence`.
- `packages/plugin-misc/src/helius/actions/getWalletIntelligence.ts` — new: `GET_WALLET_INTELLIGENCE` action (zod: `walletAddress` required, `limit` optional 1–100).
- `packages/plugin-misc/src/helius/tools/index.ts` — export.
- `packages/plugin-misc/src/index.ts` — register action + method.
- `packages/plugin-misc/src/helius/tools/get_wallet_intelligence.test.ts` — unit tests (swap extraction, native legs, empty list, missing key).
- `.changeset/helius-wallet-intelligence.md` — changeset (`@solana-agent-kit/plugin-misc: minor`).

## Testing
- `pnpm run build:plugin-misc` — passes (cjs + esm + dts).
- `pnpm run lint` (Biome) — clean.
- Live `tsx` demo against mainnet — correct swap/venue extraction.
- Unit tests cover the pure summarization logic + missing-key path.

## Notes
- Requires `HELIUS_API_KEY` in agent config (same key the existing Helius tools use).
- Read-only — no transactions are sent. One API call per invocation.